### PR TITLE
Improve What's New Experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +295,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -410,6 +554,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -855,6 +1008,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1059,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1029,6 +1230,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1779,6 +1993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2010,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2329,10 +2562,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "pango"
@@ -2360,6 +2615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2642,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2588,6 +2855,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2923,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4051,6 +4343,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,6 +4833,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tokio",
  "tracepilot-core",
  "tracepilot-indexer",
@@ -4657,6 +4972,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5737,6 +6063,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,3 +6208,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-opener": "^2.0.0",
     "@tracepilot/client": "workspace:*",
     "@tracepilot/types": "workspace:*",
     "@tracepilot/ui": "workspace:*",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tauri-plugin-dialog = "2.6.0"
+tauri-plugin-opener = "2"
 
 [[bin]]
 name = "tracepilot-desktop"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "permissions": [
     "core:default",
     "tracepilot:default",
-    "dialog:default"
+    "dialog:default",
+    "opener:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
     tauri::Builder::default()
         .manage(shared_config)
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tracepilot_tauri_bindings::init())
         .run(tauri::generate_context!())
         .expect("error while running TracePilot");

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1,17 +1,16 @@
 <script setup lang="ts">
 import { checkConfigExists } from '@tracepilot/client';
-import type { ReleaseManifestEntry } from '@tracepilot/types';
 import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import IndexingLoadingScreen from '@/components/IndexingLoadingScreen.vue';
 import AppSidebar from '@/components/layout/AppSidebar.vue';
 import BreadcrumbNav from '@/components/layout/BreadcrumbNav.vue';
 import SetupWizard from '@/components/SetupWizard.vue';
-import UpdateBanner from '@/components/UpdateBanner.vue';
 import UpdateInstructionsModal from '@/components/UpdateInstructionsModal.vue';
 import WhatsNewModal from '@/components/WhatsNewModal.vue';
 import { initAppVersion, useAppVersion } from '@/composables/useAppVersion';
 import { runUpdateCheck } from '@/composables/useUpdateCheck';
+import { useWhatsNew } from '@/composables/useWhatsNew';
 import { usePreferencesStore } from '@/stores/preferences';
 import { useSessionsStore } from '@/stores/sessions';
 
@@ -25,9 +24,15 @@ const { appVersion } = useAppVersion();
 const phase = ref<AppPhase>('loading');
 const expectedSessionCount = ref(0);
 const showUpdateModal = ref(false);
-const showWhatsNew = ref(false);
-const whatsNewPreviousVersion = ref('');
-const whatsNewEntries = ref<ReleaseManifestEntry[]>([]);
+
+const {
+  showWhatsNew,
+  whatsNewPreviousVersion,
+  whatsNewCurrentVersion,
+  whatsNewEntries,
+  openWhatsNew,
+  closeWhatsNew,
+} = useWhatsNew();
 
 onMounted(async () => {
   // Initialize app version from Tauri runtime (or 'dev' in browser mode)
@@ -60,18 +65,7 @@ async function checkVersionChange() {
 
   const previous = prefsStore.lastSeenVersion;
   if (previous && previous !== current) {
-    // Load release manifest for "What's New" display
-    try {
-      const resp = await fetch('/release-manifest.json');
-      if (resp.ok) {
-        const manifest = await resp.json();
-        whatsNewEntries.value = manifest.versions ?? [];
-        whatsNewPreviousVersion.value = previous;
-        showWhatsNew.value = true;
-      }
-    } catch {
-      // Release manifest missing or invalid — skip "What's New"
-    }
+    await openWhatsNew(previous, current);
   }
   prefsStore.lastSeenVersion = current;
 }
@@ -134,19 +128,13 @@ const breadcrumbs = computed(() => {
     @complete="onIndexingComplete"
   />
   <div v-else-if="phase === 'app'" class="app-layout">
-    <!-- Update notification banner -->
-    <UpdateBanner
-      @view-details="showUpdateModal = true"
-      @dismiss="() => { /* banner handles its own dismiss state */ }"
-    />
-
     <!-- Ambient background (matches setup wizard aesthetic) -->
     <div class="app-bg" aria-hidden="true">
       <div class="app-dot-grid" />
       <div class="app-orb app-orb-1" />
       <div class="app-orb app-orb-2" />
     </div>
-    <AppSidebar />
+    <AppSidebar @view-update-details="showUpdateModal = true" />
     <div class="main-content">
       <div class="page-header-bar">
         <BreadcrumbNav :items="breadcrumbs" />
@@ -161,13 +149,13 @@ const breadcrumbs = computed(() => {
     @close="showUpdateModal = false"
   />
 
-  <!-- What's New modal (shown on version change) -->
+  <!-- What's New modal (shown on version change or reopened from settings) -->
   <WhatsNewModal
     v-if="showWhatsNew"
     :previous-version="whatsNewPreviousVersion"
-    :current-version="appVersion"
+    :current-version="whatsNewCurrentVersion"
     :entries="whatsNewEntries"
-    @close="showWhatsNew = false"
+    @close="closeWhatsNew"
   />
 </template>
 

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useUpdateCheck } from '@/composables/useUpdateCheck';
+import { openExternal } from '@/utils/openExternal';
 
 const emit = defineEmits<{
   close: [];
@@ -10,6 +11,12 @@ const { updateResult } = useUpdateCheck();
 
 const version = computed(() => updateResult.value?.latestVersion ?? '');
 const releaseUrl = computed(() => updateResult.value?.releaseUrl);
+
+function handleOpenRelease() {
+  if (releaseUrl.value) {
+    openExternal(releaseUrl.value);
+  }
+}
 </script>
 
 <template>
@@ -60,7 +67,7 @@ const releaseUrl = computed(() => updateResult.value?.releaseUrl);
           </div>
 
           <div v-if="releaseUrl" class="update-links">
-            <a :href="releaseUrl" target="_blank" rel="noopener">
+            <a href="#" @click.prevent="handleOpenRelease">
               View full release notes on GitHub →
             </a>
           </div>
@@ -101,7 +108,7 @@ const releaseUrl = computed(() => updateResult.value?.releaseUrl);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px 12px;
+  padding: 24px 24px 16px;
 }
 
 .modal-header h2 {
@@ -126,7 +133,7 @@ const releaseUrl = computed(() => updateResult.value?.releaseUrl);
 }
 
 .modal-body {
-  padding: 0 24px 16px;
+  padding: 4px 24px 20px;
 }
 
 .update-intro {

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -47,7 +47,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
         </div>
 
         <div class="modal-body">
-          <p v-if="previousVersion" class="version-jump">
+          <p v-if="previousVersion && previousVersion !== '0.0.0'" class="version-jump">
             Updated from v{{ previousVersion }}
           </p>
 
@@ -130,7 +130,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px 12px;
+  padding: 24px 24px 16px;
 }
 
 .modal-header h2 {
@@ -155,13 +155,15 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
 }
 
 .modal-body {
-  padding: 0 24px 16px;
+  padding: 4px 24px 20px;
 }
 
 .version-jump {
   font-size: 13px;
   color: var(--color-fg-muted, #94a3b8);
-  margin-bottom: 16px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--color-border-muted, rgba(255, 255, 255, 0.06));
 }
 
 .version-section {

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -3,10 +3,18 @@ import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import LogoIcon from '@/components/icons/LogoIcon.vue';
 import { useAppVersion } from '@/composables/useAppVersion';
+import { useUpdateCheck } from '@/composables/useUpdateCheck';
+import { useWhatsNew } from '@/composables/useWhatsNew';
 import { usePreferencesStore } from '@/stores/preferences';
 import { useSessionsStore } from '@/stores/sessions';
 
+const emit = defineEmits<{
+  'view-update-details': [];
+}>();
+
 const { appVersion } = useAppVersion();
+const { updateResult } = useUpdateCheck();
+const { openWhatsNew } = useWhatsNew();
 
 const route = useRoute();
 const sessionsStore = useSessionsStore();
@@ -18,6 +26,14 @@ const currentTheme = computed(() => prefsStore.theme);
 
 function toggleTheme() {
   prefsStore.theme = currentTheme.value === 'dark' ? 'light' : 'dark';
+}
+
+const hasUpdate = computed(() => {
+  return updateResult.value?.hasUpdate === true;
+});
+
+async function handleVersionClick() {
+  await openWhatsNew('0.0.0', appVersion.value);
 }
 
 interface NavItem {
@@ -151,23 +167,46 @@ const orchestrationNav: NavItem[] = [
     </nav>
 
     <!-- Footer -->
-    <div class="sidebar-footer">
-      <span class="sidebar-version">v{{ appVersion }}</span>
-      <button
-        class="theme-toggle"
-        :aria-label="`Current theme: ${currentTheme}. Click to switch.`"
-        @click="toggleTheme"
-      >
-        <!-- Sun (shown in dark mode) -->
-        <svg v-if="currentTheme === 'dark'" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-          <circle cx="8" cy="8" r="3" />
-          <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.5 3.5l1.5 1.5M11 11l1.5 1.5M12.5 3.5l-1.5 1.5M5 11l-1.5 1.5" />
-        </svg>
-        <!-- Moon (shown in light mode) -->
-        <svg v-else width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-          <path d="M13.5 8.5a5.5 5.5 0 01-6-6 5.5 5.5 0 106 6z" />
-        </svg>
-      </button>
+    <div class="sidebar-footer-area">
+      <!-- Update available notification -->
+      <Transition name="sidebar-update-slide">
+        <div v-if="hasUpdate" class="sidebar-update-notice">
+          <div class="sidebar-update-content">
+            <span class="sidebar-update-icon">🎉</span>
+            <span class="sidebar-update-text">
+              <strong>v{{ updateResult?.latestVersion }}</strong> available
+            </span>
+          </div>
+          <button class="sidebar-update-btn" @click="emit('view-update-details')">
+            Update
+          </button>
+        </div>
+      </Transition>
+
+      <div class="sidebar-footer">
+        <button
+          class="sidebar-version-btn"
+          title="View release notes"
+          @click="handleVersionClick"
+        >
+          v{{ appVersion }}
+        </button>
+        <button
+          class="theme-toggle"
+          :aria-label="`Current theme: ${currentTheme}. Click to switch.`"
+          @click="toggleTheme"
+        >
+          <!-- Sun (shown in dark mode) -->
+          <svg v-if="currentTheme === 'dark'" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+            <circle cx="8" cy="8" r="3" />
+            <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.5 3.5l1.5 1.5M11 11l1.5 1.5M12.5 3.5l-1.5 1.5M5 11l-1.5 1.5" />
+          </svg>
+          <!-- Moon (shown in light mode) -->
+          <svg v-else width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M13.5 8.5a5.5 5.5 0 01-6-6 5.5 5.5 0 106 6z" />
+          </svg>
+        </button>
+      </div>
     </div>
   </aside>
 </template>

--- a/apps/desktop/src/components/settings/SettingsAbout.vue
+++ b/apps/desktop/src/components/settings/SettingsAbout.vue
@@ -5,6 +5,7 @@ import { SectionPanel } from '@tracepilot/ui';
 import { onMounted, ref } from 'vue';
 import LogoIcon from '@/components/icons/LogoIcon.vue';
 import { useAppVersion } from '@/composables/useAppVersion';
+import { openExternal } from '@/utils/openExternal';
 
 defineProps<{
   sessionCount: number;
@@ -58,19 +59,19 @@ onMounted(async () => {
         </dl>
 
         <div class="about-links">
-          <a href="https://github.com/MattShelton04/TracePilot" target="_blank" rel="noopener">
+          <a href="#" @click.prevent="openExternal('https://github.com/MattShelton04/TracePilot')">
             GitHub Repository
           </a>
-          <a href="https://github.com/MattShelton04/TracePilot/wiki" target="_blank" rel="noopener">
+          <a href="#" @click.prevent="openExternal('https://github.com/MattShelton04/TracePilot/wiki')">
             Documentation
           </a>
-          <a href="https://github.com/MattShelton04/TracePilot/issues/new" target="_blank" rel="noopener">
+          <a href="#" @click.prevent="openExternal('https://github.com/MattShelton04/TracePilot/issues/new')">
             Report Issue
           </a>
         </div>
 
         <div class="about-footer">
-          Built with Tauri, Rust &amp; Vue
+          Built with Tauri, Rust &amp; Vue by Matt :)
         </div>
       </div>
     </SectionPanel>

--- a/apps/desktop/src/components/settings/SettingsUpdates.vue
+++ b/apps/desktop/src/components/settings/SettingsUpdates.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
 import { ActionButton, FormSwitch, SectionPanel } from '@tracepilot/ui';
+import { useAppVersion } from '@/composables/useAppVersion';
 import { useUpdateCheck } from '@/composables/useUpdateCheck';
+import { useWhatsNew } from '@/composables/useWhatsNew';
+import { openExternal } from '@/utils/openExternal';
 import { usePreferencesStore } from '@/stores/preferences';
 
 const preferences = usePreferencesStore();
+const { appVersion } = useAppVersion();
 const { updateResult, updateCheckLoading, updateCheckError, runUpdateCheck } = useUpdateCheck();
+const { openWhatsNew } = useWhatsNew();
 
 async function handleCheckForUpdates() {
   await runUpdateCheck(true);
+}
+
+async function handleViewWhatsNew() {
+  await openWhatsNew('0.0.0', appVersion.value);
+}
+
+function handleOpenRelease() {
+  if (updateResult.value?.releaseUrl) {
+    openExternal(updateResult.value.releaseUrl);
+  }
 }
 </script>
 
@@ -41,11 +56,28 @@ async function handleCheckForUpdates() {
           {{ updateCheckLoading ? 'Checking…' : 'Check Now' }}
         </ActionButton>
       </div>
+
+      <div class="setting-row">
+        <div>
+          <div class="setting-label">What's New</div>
+          <div class="setting-description">
+            View the release notes for your current version.
+          </div>
+        </div>
+        <ActionButton size="sm" @click="handleViewWhatsNew">
+          View Release Notes
+        </ActionButton>
+      </div>
       <div v-if="updateResult && !updateCheckLoading" class="setting-row">
         <div class="update-check-result">
           <template v-if="updateResult.hasUpdate">
             🎉 <strong>v{{ updateResult.latestVersion }}</strong> is available!
-            <a v-if="updateResult.releaseUrl" :href="updateResult.releaseUrl" target="_blank" rel="noopener">
+            <a
+              v-if="updateResult.releaseUrl"
+              href="#"
+              class="release-link"
+              @click.prevent="handleOpenRelease"
+            >
               View release →
             </a>
           </template>

--- a/apps/desktop/src/composables/useWhatsNew.ts
+++ b/apps/desktop/src/composables/useWhatsNew.ts
@@ -1,0 +1,42 @@
+import type { ReleaseManifestEntry } from '@tracepilot/types';
+import { ref } from 'vue';
+
+const showWhatsNew = ref(false);
+const whatsNewPreviousVersion = ref('');
+const whatsNewCurrentVersion = ref('');
+const whatsNewEntries = ref<ReleaseManifestEntry[]>([]);
+
+async function fetchManifest(): Promise<ReleaseManifestEntry[]> {
+  try {
+    const resp = await fetch('/release-manifest.json');
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return data.versions ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** Open the What's New modal for a specific version range. */
+export async function openWhatsNew(previous: string, current: string): Promise<void> {
+  const entries = await fetchManifest();
+  whatsNewEntries.value = entries;
+  whatsNewPreviousVersion.value = previous;
+  whatsNewCurrentVersion.value = current;
+  showWhatsNew.value = true;
+}
+
+export function closeWhatsNew(): void {
+  showWhatsNew.value = false;
+}
+
+export function useWhatsNew() {
+  return {
+    showWhatsNew,
+    whatsNewPreviousVersion,
+    whatsNewCurrentVersion,
+    whatsNewEntries,
+    openWhatsNew,
+    closeWhatsNew,
+  };
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -358,9 +358,78 @@ body {
   align-items: center;
   justify-content: space-between;
 }
+.sidebar-footer-area {
+  margin-top: auto;
+}
+.sidebar-update-notice {
+  padding: 10px 14px;
+  margin: 0 8px;
+  background: var(--accent-subtle, rgba(99, 102, 241, 0.08));
+  border: 1px solid var(--accent-muted, rgba(99, 102, 241, 0.2));
+  border-radius: var(--radius-md, 8px);
+  margin-bottom: 8px;
+}
+.sidebar-update-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.sidebar-update-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.sidebar-update-text {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  line-height: 1.3;
+}
+.sidebar-update-text strong {
+  color: var(--accent-fg, #818cf8);
+}
+.sidebar-update-btn {
+  width: 100%;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm, 6px);
+  background: var(--accent-emphasis, #6366f1);
+  color: #fff;
+  border: none;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+.sidebar-update-btn:hover {
+  background: var(--accent-emphasis-hover, #4f46e5);
+}
+.sidebar-update-slide-enter-active,
+.sidebar-update-slide-leave-active {
+  transition: all 0.3s ease;
+}
+.sidebar-update-slide-enter-from,
+.sidebar-update-slide-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
 .sidebar-version {
   font-size: 0.6875rem;
   color: var(--text-tertiary);
+}
+.sidebar-version-btn {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--accent-fg, #818cf8);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  margin: -2px -6px;
+  border-radius: var(--radius-sm, 4px);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.sidebar-version-btn:hover {
+  background: var(--accent-subtle, rgba(99, 102, 241, 0.08));
+  color: var(--accent-emphasis, #6366f1);
 }
 
 /* --- Main Content --- */
@@ -1673,7 +1742,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
 
   .sidebar-brand,
   .sidebar-section-title,
-  .sidebar-footer,
+  .sidebar-footer-area,
   .sidebar-nav-badge {
     display: none;
   }

--- a/apps/desktop/src/utils/openExternal.ts
+++ b/apps/desktop/src/utils/openExternal.ts
@@ -1,0 +1,17 @@
+/**
+ * Open a URL in the user's default system browser.
+ * Works in both Tauri (via the opener plugin) and plain browser contexts.
+ */
+export async function openExternal(url: string): Promise<void> {
+  try {
+    const { isTauri } = await import('@tauri-apps/api/core');
+    if (isTauri()) {
+      const { openUrl } = await import('@tauri-apps/plugin-opener');
+      await openUrl(url);
+      return;
+    }
+  } catch {
+    // Not in Tauri context — fall through to browser fallback
+  }
+  window.open(url, '_blank', 'noopener');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0
         version: 2.6.0
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.0.0
+        version: 2.5.3
       '@tracepilot/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -956,6 +959,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
@@ -2422,6 +2428,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-opener@2.5.3':
     dependencies:
       '@tauri-apps/api': 2.10.1
 


### PR DESCRIPTION
- Move update notification from top banner to sidebar footer (always visible)
- Add 'View Release Notes' button in Settings > Updates
- Make sidebar version clickable to reopen What's New modal
- Add useWhatsNew composable for shared modal state
- Fix external links with tauri-plugin-opener (About, release URLs)
- Add openExternal utility with Tauri/browser fallback
- Improve modal spacing in WhatsNewModal and UpdateInstructionsModal
- Hide 'Updated from v0.0.0' when manually opening release notes
- Update About footer text