### PR TITLE
Overhaul Launcher Template System

### DIFF
--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -69,6 +69,8 @@ fn main() {
                     "list_session_templates",
                     "save_session_template",
                     "delete_session_template",
+                    "restore_default_templates",
+                    "increment_template_usage",
                     // Logging commands
                     "get_log_path",
                     "export_logs",

--- a/apps/desktop/src/__tests__/stores/launcher.test.ts
+++ b/apps/desktop/src/__tests__/stores/launcher.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useLauncherStore } from "../../stores/launcher";
+import type { SessionTemplate, ModelInfo, SystemDependencies } from "@tracepilot/types";
+
+// Mock the client module
+const mockLaunchSession = vi.fn();
+const mockGetAvailableModels = vi.fn();
+const mockListSessionTemplates = vi.fn();
+const mockSaveSessionTemplate = vi.fn();
+const mockDeleteSessionTemplate = vi.fn();
+const mockRestoreDefaultTemplates = vi.fn();
+const mockIncrementTemplateUsage = vi.fn();
+const mockCheckSystemDeps = vi.fn();
+
+vi.mock("@tracepilot/client", () => ({
+  launchSession: (...args: unknown[]) => mockLaunchSession(...args),
+  getAvailableModels: (...args: unknown[]) => mockGetAvailableModels(...args),
+  listSessionTemplates: (...args: unknown[]) => mockListSessionTemplates(...args),
+  saveSessionTemplate: (...args: unknown[]) => mockSaveSessionTemplate(...args),
+  deleteSessionTemplate: (...args: unknown[]) => mockDeleteSessionTemplate(...args),
+  restoreDefaultTemplates: (...args: unknown[]) => mockRestoreDefaultTemplates(...args),
+  incrementTemplateUsage: (...args: unknown[]) => mockIncrementTemplateUsage(...args),
+  checkSystemDeps: (...args: unknown[]) => mockCheckSystemDeps(...args),
+}));
+
+const MOCK_TEMPLATE: SessionTemplate = {
+  id: "default-multi-agent-review",
+  name: "Multi Agent Code Review",
+  description: "Comprehensive code review using multiple AI models",
+  icon: "🔍",
+  category: "Quality",
+  config: {
+    repoPath: "",
+    headless: false,
+    envVars: {},
+    createWorktree: false,
+    autoApprove: false,
+    model: "claude-opus-4.6",
+    reasoningEffort: "high",
+    prompt:
+      "Spin up opus 4.6, GPT 5.4, Codex 5.3, and Gemini subagents to do a comprehensive code review of the changes on this branch (git diff). Consolidate and validate their feedback, and provide a summary.",
+  },
+  tags: ["review", "multi-agent", "premium"],
+  createdAt: "2025-01-01T00:00:00Z",
+  usageCount: 0,
+};
+
+const MOCK_TEMPLATE_WRITE_TESTS: SessionTemplate = {
+  id: "default-write-tests",
+  name: "Write Tests",
+  description: "Generate comprehensive test coverage for recent changes",
+  icon: "🧪",
+  category: "Quality",
+  config: {
+    repoPath: "",
+    headless: false,
+    envVars: {},
+    createWorktree: false,
+    autoApprove: false,
+    model: "claude-sonnet-4.6",
+    reasoningEffort: "high",
+  },
+  tags: ["testing", "coverage"],
+  createdAt: "2025-01-01T00:00:00Z",
+  usageCount: 0,
+};
+
+const MOCK_MODELS: ModelInfo[] = [
+  { id: "claude-opus-4.6", name: "Claude Opus 4.6", tier: "premium" },
+  { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", tier: "standard" },
+  { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", tier: "fast" },
+];
+
+const MOCK_DEPS: SystemDependencies = {
+  gitAvailable: true,
+  gitVersion: "2.45.0",
+  copilotAvailable: true,
+  copilotVersion: "1.0.9",
+  copilotHomeExists: true,
+};
+
+describe("useLauncherStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockLaunchSession.mockReset();
+    mockGetAvailableModels.mockReset();
+    mockListSessionTemplates.mockReset();
+    mockSaveSessionTemplate.mockReset();
+    mockDeleteSessionTemplate.mockReset();
+    mockRestoreDefaultTemplates.mockReset();
+    mockIncrementTemplateUsage.mockReset();
+    mockCheckSystemDeps.mockReset();
+  });
+
+  it("initializes with empty state", () => {
+    const store = useLauncherStore();
+    expect(store.models).toEqual([]);
+    expect(store.templates).toEqual([]);
+    expect(store.recentLaunches).toEqual([]);
+    expect(store.systemDeps).toBeNull();
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+  });
+
+  describe("initialize", () => {
+    it("loads models, templates, and system deps", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue(MOCK_MODELS);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE, MOCK_TEMPLATE_WRITE_TESTS]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      expect(store.systemDeps).toEqual(MOCK_DEPS);
+      expect(store.models).toEqual(MOCK_MODELS);
+      expect(store.templates).toHaveLength(2);
+      expect(store.templates[0].icon).toBe("🔍");
+      expect(store.templates[1].icon).toBe("🧪");
+      expect(store.loading).toBe(false);
+      expect(store.error).toBeNull();
+    });
+
+    it("sets error when some requests fail", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockRejectedValue(new Error("Network error"));
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      expect(store.systemDeps).toEqual(MOCK_DEPS);
+      expect(store.models).toEqual([]); // failed
+      expect(store.templates).toHaveLength(1); // succeeded
+      expect(store.error).toContain("Network error");
+    });
+  });
+
+  describe("isReady", () => {
+    it("returns false when system deps not loaded", () => {
+      const store = useLauncherStore();
+      expect(store.isReady).toBeFalsy();
+    });
+
+    it("returns true when git and copilot available", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      expect(store.isReady).toBe(true);
+    });
+
+    it("returns false when git not available", async () => {
+      mockCheckSystemDeps.mockResolvedValue({ ...MOCK_DEPS, gitAvailable: false });
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      expect(store.isReady).toBeFalsy();
+    });
+  });
+
+  describe("modelsByTier", () => {
+    it("groups models by tier", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue(MOCK_MODELS);
+      mockListSessionTemplates.mockResolvedValue([]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      expect(store.modelsByTier).toEqual({
+        premium: [{ id: "claude-opus-4.6", name: "Claude Opus 4.6", tier: "premium" }],
+        standard: [{ id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", tier: "standard" }],
+        fast: [{ id: "claude-haiku-4.5", name: "Claude Haiku 4.5", tier: "fast" }],
+      });
+    });
+  });
+
+  describe("templates", () => {
+    it("default templates have icon field", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE, MOCK_TEMPLATE_WRITE_TESTS]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      for (const tpl of store.templates) {
+        expect(tpl.icon).toBeDefined();
+        expect(typeof tpl.icon).toBe("string");
+      }
+    });
+
+    it("multi-agent review template has correct config", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      const tpl = store.templates.find((t) => t.id === "default-multi-agent-review");
+      expect(tpl).toBeDefined();
+      expect(tpl!.config.model).toBe("claude-opus-4.6");
+      expect(tpl!.config.reasoningEffort).toBe("high");
+      expect(tpl!.config.prompt).toContain("Spin up opus 4.6");
+      expect(tpl!.icon).toBe("🔍");
+    });
+
+    it("write tests template has correct config", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE_WRITE_TESTS]);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      const tpl = store.templates.find((t) => t.id === "default-write-tests");
+      expect(tpl).toBeDefined();
+      expect(tpl!.config.model).toBe("claude-sonnet-4.6");
+      expect(tpl!.config.reasoningEffort).toBe("high");
+      expect(tpl!.config.createWorktree).toBe(false);
+      expect(tpl!.config.autoApprove).toBe(false);
+      expect(tpl!.icon).toBe("🧪");
+    });
+  });
+
+  describe("saveTemplate", () => {
+    it("saves template and refreshes list", async () => {
+      const savedTemplate: SessionTemplate = {
+        ...MOCK_TEMPLATE,
+        id: "user-custom-1",
+        name: "Custom Template",
+        icon: "⭐",
+      };
+
+      mockSaveSessionTemplate.mockResolvedValue(undefined);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE, savedTemplate]);
+
+      const store = useLauncherStore();
+      const result = await store.saveTemplate(savedTemplate);
+
+      expect(result).toBe(true);
+      expect(mockSaveSessionTemplate).toHaveBeenCalledWith(savedTemplate);
+      expect(mockListSessionTemplates).toHaveBeenCalled();
+      expect(store.templates).toHaveLength(2);
+    });
+
+    it("returns false and sets error on failure", async () => {
+      mockSaveSessionTemplate.mockRejectedValue(new Error("Save failed"));
+
+      const store = useLauncherStore();
+      const result = await store.saveTemplate(MOCK_TEMPLATE);
+
+      expect(result).toBe(false);
+      expect(store.error).toContain("Save failed");
+    });
+  });
+
+  describe("deleteTemplate", () => {
+    it("removes template from store", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE, MOCK_TEMPLATE_WRITE_TESTS]);
+      mockDeleteSessionTemplate.mockResolvedValue(undefined);
+
+      const store = useLauncherStore();
+      await store.initialize();
+      expect(store.templates).toHaveLength(2);
+
+      const result = await store.deleteTemplate("default-write-tests");
+      expect(result).toBe(true);
+      expect(mockDeleteSessionTemplate).toHaveBeenCalledWith("default-write-tests");
+      expect(store.templates).toHaveLength(1);
+      expect(store.templates[0].id).toBe("default-multi-agent-review");
+    });
+
+    it("can delete default templates (dismiss)", async () => {
+      mockCheckSystemDeps.mockResolvedValue(MOCK_DEPS);
+      mockGetAvailableModels.mockResolvedValue([]);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE]);
+      mockDeleteSessionTemplate.mockResolvedValue(undefined);
+
+      const store = useLauncherStore();
+      await store.initialize();
+
+      const result = await store.deleteTemplate("default-multi-agent-review");
+      expect(result).toBe(true);
+      expect(store.templates).toHaveLength(0);
+    });
+
+    it("returns false and sets error on failure", async () => {
+      mockDeleteSessionTemplate.mockRejectedValue(new Error("Delete failed"));
+
+      const store = useLauncherStore();
+      store.templates = [MOCK_TEMPLATE];
+      const result = await store.deleteTemplate("default-multi-agent-review");
+
+      expect(result).toBe(false);
+      expect(store.error).toContain("Delete failed");
+    });
+  });
+
+  describe("launch", () => {
+    it("launches session and tracks in recent launches", async () => {
+      const mockSession = {
+        pid: 12345,
+        command: "copilot --model=claude-opus-4.6",
+        launchedAt: "2025-01-01T00:00:00Z",
+      };
+      mockLaunchSession.mockResolvedValue(mockSession);
+
+      const store = useLauncherStore();
+      const result = await store.launch({
+        repoPath: "C:\\git\\test",
+        headless: false,
+        envVars: {},
+        createWorktree: false,
+        autoApprove: false,
+      });
+
+      expect(result).toEqual(mockSession);
+      expect(store.recentLaunches).toHaveLength(1);
+      expect(store.recentLaunches[0].pid).toBe(12345);
+    });
+
+    it("caps recent launches at 10", async () => {
+      const store = useLauncherStore();
+      store.recentLaunches = Array.from({ length: 10 }, (_, i) => ({
+        pid: i,
+        command: `cmd-${i}`,
+        launchedAt: "2025-01-01T00:00:00Z",
+      }));
+
+      const mockSession = {
+        pid: 99,
+        command: "copilot",
+        launchedAt: "2025-01-01T00:00:00Z",
+      };
+      mockLaunchSession.mockResolvedValue(mockSession);
+
+      await store.launch({
+        repoPath: "C:\\git\\test",
+        headless: false,
+        envVars: {},
+        createWorktree: false,
+        autoApprove: false,
+      });
+
+      expect(store.recentLaunches).toHaveLength(10);
+      expect(store.recentLaunches[0].pid).toBe(99);
+    });
+
+    it("returns null and sets error on failure", async () => {
+      mockLaunchSession.mockRejectedValue(new Error("Launch failed"));
+
+      const store = useLauncherStore();
+      const result = await store.launch({
+        repoPath: "C:\\git\\test",
+        headless: false,
+        envVars: {},
+        createWorktree: false,
+        autoApprove: false,
+      });
+
+      expect(result).toBeNull();
+      expect(store.error).toContain("Launch failed");
+    });
+  });
+
+  describe("restoreDefaults", () => {
+    it("calls restore API and refreshes templates", async () => {
+      mockRestoreDefaultTemplates.mockResolvedValue(undefined);
+      mockListSessionTemplates.mockResolvedValue([MOCK_TEMPLATE, MOCK_TEMPLATE_WRITE_TESTS]);
+
+      const store = useLauncherStore();
+      store.templates = []; // all dismissed
+
+      const result = await store.restoreDefaults();
+
+      expect(result).toBe(true);
+      expect(mockRestoreDefaultTemplates).toHaveBeenCalled();
+      expect(mockListSessionTemplates).toHaveBeenCalled();
+      expect(store.templates).toHaveLength(2);
+    });
+
+    it("returns false and sets error on failure", async () => {
+      mockRestoreDefaultTemplates.mockRejectedValue(new Error("Restore failed"));
+
+      const store = useLauncherStore();
+      const result = await store.restoreDefaults();
+
+      expect(result).toBe(false);
+      expect(store.error).toContain("Restore failed");
+    });
+  });
+
+  describe("incrementUsage", () => {
+    it("increments usage count optimistically", async () => {
+      mockIncrementTemplateUsage.mockResolvedValue(undefined);
+
+      const store = useLauncherStore();
+      store.templates = [{ ...MOCK_TEMPLATE, usageCount: 3 }];
+
+      await store.incrementUsage("default-multi-agent-review");
+
+      expect(mockIncrementTemplateUsage).toHaveBeenCalledWith("default-multi-agent-review");
+      expect(store.templates[0].usageCount).toBe(4);
+    });
+
+    it("does not surface errors for usage tracking", async () => {
+      mockIncrementTemplateUsage.mockRejectedValue(new Error("Tracking failed"));
+
+      const store = useLauncherStore();
+      store.templates = [{ ...MOCK_TEMPLATE, usageCount: 0 }];
+
+      await store.incrementUsage("default-multi-agent-review");
+
+      // Error should NOT be set — usage tracking is non-critical
+      expect(store.error).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -68,7 +68,7 @@ const visibleAdvancedNav = computed(() =>
 );
 
 const orchestrationNav: NavItem[] = [
-  { id: 'orchestration', label: 'Command Center', to: '/orchestration', icon: 'orchestration' },
+  { id: 'orchestration', label: 'Command Centre', to: '/orchestration', icon: 'orchestration' },
   { id: 'worktrees', label: 'Worktrees', to: '/orchestration/worktrees', icon: 'worktrees' },
   { id: 'launcher', label: 'Launcher', to: '/orchestration/launcher', icon: 'launcher' },
   { id: 'config-injector', label: 'Config Injector', to: '/orchestration/config', icon: 'config' },

--- a/apps/desktop/src/stores/launcher.ts
+++ b/apps/desktop/src/stores/launcher.ts
@@ -13,6 +13,8 @@ import {
   listSessionTemplates,
   saveSessionTemplate as saveTemplateApi,
   deleteSessionTemplate as deleteTemplateApi,
+  restoreDefaultTemplates as restoreDefaultsApi,
+  incrementTemplateUsage as incrementUsageApi,
   checkSystemDeps,
 } from '@tracepilot/client';
 
@@ -93,6 +95,28 @@ export const useLauncherStore = defineStore('launcher', () => {
     }
   }
 
+  async function restoreDefaults(): Promise<boolean> {
+    try {
+      await restoreDefaultsApi();
+      templates.value = await listSessionTemplates();
+      return true;
+    } catch (e) {
+      error.value = String(e);
+      return false;
+    }
+  }
+
+  async function incrementUsage(id: string): Promise<void> {
+    try {
+      await incrementUsageApi(id);
+      // Update local count optimistically
+      const tpl = templates.value.find((t) => t.id === id);
+      if (tpl) tpl.usageCount += 1;
+    } catch {
+      // Non-critical — don't surface errors for usage tracking
+    }
+  }
+
   return {
     models,
     templates,
@@ -106,5 +130,7 @@ export const useLauncherStore = defineStore('launcher', () => {
     launch,
     saveTemplate,
     deleteTemplate,
+    restoreDefaults,
+    incrementUsage,
   };
 });

--- a/apps/desktop/src/stores/orchestrationHome.ts
+++ b/apps/desktop/src/stores/orchestrationHome.ts
@@ -28,8 +28,10 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
   const totalDiskUsage = ref(0);
   const registeredRepos = ref<RegisteredRepo[]>([]);
   const loading = ref(false);
+  const refreshing = ref(false);
   const error = ref<string | null>(null);
   const activityFeed = ref<ActivityEvent[]>([]);
+  const lastInitialized = ref(0);
 
   const isHealthy = computed(() => {
     if (!systemDeps.value) return false;
@@ -38,9 +40,37 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
 
   const copilotVersionStr = computed(() => activeVersion.value?.version ?? systemDeps.value?.copilotVersion ?? 'unknown');
 
+  // Show cached data immediately if initialized within the last 5 minutes
+  const hasCachedData = computed(() => lastInitialized.value > 0);
+  const CACHE_TTL_MS = 5 * 60 * 1000;
+
   async function initialize() {
+    const now = Date.now();
+    const isFresh = lastInitialized.value > 0 && (now - lastInitialized.value) < CACHE_TTL_MS;
+
+    if (isFresh) {
+      // Data is fresh — refresh silently in the background
+      refreshing.value = true;
+      await doFetch();
+      refreshing.value = false;
+      return;
+    }
+
+    if (hasCachedData.value) {
+      // Stale cache — show it immediately but refresh in background
+      refreshing.value = true;
+      doFetch().finally(() => { refreshing.value = false; });
+      return;
+    }
+
+    // First load — show loading spinner
     loading.value = true;
     error.value = null;
+    await doFetch();
+    loading.value = false;
+  }
+
+  async function doFetch() {
     try {
       // Fast path: system deps and version info load first (< 100ms)
       const [depsResult, activeResult] = await Promise.allSettled([
@@ -53,8 +83,8 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
       systemDeps.value = deps;
       activeVersion.value = active;
 
-      // Mark as loaded so the UI renders immediately with core info
-      loading.value = false;
+      // If this was the initial load, mark as loaded so the UI renders
+      if (loading.value) loading.value = false;
 
       // Background path: sessions + versions (can be slower)
       const [sessionsResult, versionsResult] = await Promise.allSettled([
@@ -71,6 +101,8 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
         .map((r) => String(r.reason));
       if (bgFailures.length) {
         error.value = bgFailures.join('; ');
+      } else {
+        error.value = null;
       }
 
       totalSessions.value = sessions.length;
@@ -89,6 +121,8 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
 
       // Load worktree stats from all registered repos
       await loadWorktreeStatsFromRegistry();
+
+      lastInitialized.value = Date.now();
     } catch (e) {
       error.value = String(e);
       loading.value = false;
@@ -148,6 +182,7 @@ export const useOrchestrationHomeStore = defineStore('orchestrationHome', () => 
     totalDiskUsage,
     registeredRepos,
     loading,
+    refreshing,
     error,
     activityFeed,
     isHealthy,

--- a/apps/desktop/src/views/orchestration/OrchestrationHomeView.vue
+++ b/apps/desktop/src/views/orchestration/OrchestrationHomeView.vue
@@ -119,7 +119,7 @@ onUnmounted(() => {
       <!-- Loading State -->
       <div v-if="store.loading" class="loading-state">
         <div class="loading-spinner" />
-        <p>Loading command center…</p>
+        <p>Loading command centre…</p>
       </div>
 
       <!-- Error State -->
@@ -137,7 +137,7 @@ onUnmounted(() => {
             <svg class="title-icon" width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
               <path d="M6.906.664a1.749 1.749 0 0 1 2.187 0l5.25 4.2c.415.332.657.835.657 1.367v7.019A1.75 1.75 0 0 1 13.25 15h-3.5a.75.75 0 0 1-.75-.75V9H7v5.25a.75.75 0 0 1-.75.75h-3.5A1.75 1.75 0 0 1 1 13.25V6.23c0-.531.242-1.034.657-1.366l5.25-4.2Z" />
             </svg>
-            Command Center
+            Command Centre
           </h1>
           <div class="live-indicator">
             <span class="live-dot" />
@@ -162,10 +162,10 @@ onUnmounted(() => {
             <svg class="hero-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
               <line x1="6" y1="3" x2="6" y2="15" /><circle cx="18" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><path d="M18 9a9 9 0 0 1-9 9" />
             </svg>
-            <div class="hero-value">{{ store.worktreeCount || '—' }}</div>
-            <div class="hero-label">Worktrees</div>
-            <div class="hero-sub" v-if="store.worktreeCount > 0">{{ store.registeredRepos.length }} repos · {{ store.staleWorktreeCount }} stale · {{ formatBytes(store.totalDiskUsage) }}</div>
-            <div class="hero-sub" v-else-if="store.registeredRepos.length > 0">{{ store.registeredRepos.length }} registered repos</div>
+            <div class="hero-value">{{ store.registeredRepos.length || '—' }}</div>
+            <div class="hero-label">Repositories</div>
+            <div class="hero-sub" v-if="store.worktreeCount > 0">{{ store.worktreeCount }} worktrees · {{ store.staleWorktreeCount }} stale · {{ formatBytes(store.totalDiskUsage) }}</div>
+            <div class="hero-sub" v-else-if="store.registeredRepos.length > 0">No worktrees yet</div>
             <div class="hero-sub" v-else>No repos registered yet</div>
           </div>
 
@@ -276,12 +276,6 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- §5 Keyboard Shortcuts Bar -->
-        <div class="shortcuts-bar fade-section" style="--stagger: 4">
-          <span class="shortcuts-label">⌨️ Shortcuts:</span>
-          <span class="shortcut"><kbd>Ctrl+N</kbd> New Session</span>
-          <span class="shortcut"><kbd>Ctrl+K</kbd> Quick Search</span>
-        </div>
       </template>
     </div>
   </div>
@@ -722,35 +716,4 @@ onUnmounted(() => {
 }
 
 /* ── §5 Keyboard Shortcuts Bar ───────────────────────────────── */
-.shortcuts-bar {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 10px 16px;
-  background: var(--canvas-subtle);
-  border: 1px solid var(--border-muted);
-  border-radius: var(--radius-lg);
-  font-size: 0.75rem;
-  color: var(--text-tertiary);
-}
-
-.shortcuts-label {
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.shortcut {
-  white-space: nowrap;
-}
-
-.shortcut kbd {
-  display: inline-block;
-  padding: 1px 5px;
-  font-family: inherit;
-  font-size: 0.6875rem;
-  background: var(--canvas-inset);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-  margin-right: 4px;
-}
 </style>

--- a/apps/desktop/src/views/orchestration/SessionLauncherView.vue
+++ b/apps/desktop/src/views/orchestration/SessionLauncherView.vue
@@ -29,7 +29,7 @@ const envVars = reactive<{ key: string; value: string }[]>([]);
 const selectedTemplateId = ref<string | null>(null);
 const showAdvanced = ref(false);
 const showTemplateForm = ref(false);
-const templateForm = reactive({ name: '', description: '', category: '' });
+const templateForm = reactive({ name: '', description: '', category: '', icon: '' });
 const launchSuccess = ref<{ pid: number; command: string; worktreePath?: string } | null>(null);
 const contextMenuTpl = ref<{ id: string; x: number; y: number } | null>(null);
 const confirmingDeleteId = ref<string | null>(null);
@@ -116,6 +116,11 @@ const canLaunch= computed(() => {
   return true;
 });
 
+const defaultTemplateIds = ['default-multi-agent-review', 'default-write-tests'];
+const hasDismissedDefaults = computed(() =>
+  defaultTemplateIds.some((id) => !store.templates.some((t) => t.id === id)),
+);
+
 function tierLabel(tier: string): string {
   return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
@@ -127,6 +132,10 @@ function truncate(s: string, max: number): string {
 function extractEmoji(name: string): string {
   const match = name.match(/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})/u);
   return match ? match[0] : '📄';
+}
+
+function templateIcon(tpl: SessionTemplate): string {
+  return tpl.icon || extractEmoji(tpl.name);
 }
 
 function templateDisplayName(name: string): string {
@@ -142,7 +151,10 @@ function applyTemplate(tplId: string) {
   const tpl = store.templates.find((t: SessionTemplate) => t.id === tplId);
   if (!tpl) return;
   selectedTemplateId.value = tplId;
-  repoPath.value = tpl.config.repoPath;
+  // Only override repoPath if the template specifies one
+  if (tpl.config.repoPath) {
+    repoPath.value = tpl.config.repoPath;
+  }
   branch.value = tpl.config.branch ?? '';
   selectedModel.value = tpl.config.model ?? '';
   createWorktree.value = tpl.config.createWorktree;
@@ -222,6 +234,10 @@ async function handleLaunch(asHeadless = false) {
     if (cfg.repoPath) prefsStore.addRecentRepoPath(cfg.repoPath);
     const session = await store.launch(cfg);
     if (session) {
+      // Track template usage if one was selected
+      if (selectedTemplateId.value) {
+        store.incrementUsage(selectedTemplateId.value);
+      }
       launchSuccess.value = {
         pid: session.pid,
         command: session.command,
@@ -252,6 +268,7 @@ async function handleSaveTemplate() {
     name: templateForm.name,
     description: templateForm.description,
     category: templateForm.category,
+    icon: templateForm.icon.trim() || undefined,
     tags: [],
     config: launchConfig.value,
     createdAt: existing?.createdAt ?? new Date().toISOString(),
@@ -261,6 +278,7 @@ async function handleSaveTemplate() {
   templateForm.name = '';
   templateForm.description = '';
   templateForm.category = '';
+  templateForm.icon = '';
 }
 
 function openContextMenu(e: MouseEvent, tplId: string) {
@@ -291,9 +309,12 @@ onMounted(async () => {
   store.initialize();
   document.addEventListener('click', closeContextMenu);
 
-  // Load registered repos for the dropdown
+  // Load registered repos for the dropdown, discovering from sessions if needed
   if (worktreeStore.registeredRepos.length === 0) {
     await worktreeStore.loadRegisteredRepos();
+    if (worktreeStore.registeredRepos.length === 0) {
+      await worktreeStore.discoverRepos();
+    }
   }
 
   // Pre-fill from query params (e.g., navigated from Worktree Manager)
@@ -382,8 +403,18 @@ onUnmounted(() => {
         </div>
 
         <!-- ── Templates ─────────────────────────────────────── -->
-        <section v-if="store.loading || store.templates.length" class="section-block">
-          <h2 class="section-label">Saved Templates</h2>
+        <section v-if="store.loading || store.templates.length || hasDismissedDefaults" class="section-block">
+          <div class="section-header-row">
+            <h2 class="section-label">Saved Templates</h2>
+            <button
+              v-if="hasDismissedDefaults"
+              class="tpl-restore-btn"
+              title="Restore dismissed default templates"
+              @click="store.restoreDefaults()"
+            >
+              ↻ Restore Defaults
+            </button>
+          </div>
           <div v-if="store.loading && !store.templates.length" class="tpl-grid">
             <div v-for="n in 3" :key="n" class="tpl-card tpl-skeleton">
               <span class="tpl-emoji">⏳</span>
@@ -419,14 +450,17 @@ onUnmounted(() => {
                   @click="deleteTemplateInline(tpl.id)"
                 >×</button>
               </div>
-              <template v-if="confirmingDeleteId === tpl.id">
-                <div class="tpl-confirm-delete" @click.stop>
-                  <span>Delete?</span>
-                  <button class="tpl-confirm-yes" @click="deleteTemplateInline(tpl.id)">Yes</button>
-                  <button class="tpl-confirm-cancel" @click="cancelDeleteInline">Cancel</button>
+              <!-- Delete confirmation overlay -->
+              <Transition name="fade">
+                <div v-if="confirmingDeleteId === tpl.id" class="tpl-delete-overlay" @click.stop>
+                  <span class="tpl-delete-overlay-text">Delete this template?</span>
+                  <div class="tpl-delete-overlay-actions">
+                    <button class="tpl-confirm-yes" @click="deleteTemplateInline(tpl.id)">Delete</button>
+                    <button class="tpl-confirm-cancel" @click="cancelDeleteInline">Cancel</button>
+                  </div>
                 </div>
-              </template>
-              <span class="tpl-emoji">{{ extractEmoji(tpl.name) }}</span>
+              </Transition>
+              <span class="tpl-emoji">{{ templateIcon(tpl) }}</span>
               <span class="tpl-name">{{ templateDisplayName(tpl.name) }}</span>
               <span v-if="tpl.description" class="tpl-desc">{{ tpl.description }}</span>
               <span class="tpl-stats">Used {{ tpl.usageCount }} times</span>
@@ -445,6 +479,7 @@ onUnmounted(() => {
                   <select
                     v-if="worktreeStore.registeredRepos.length || prefsStore.recentRepoPaths.length"
                     class="form-input form-select repo-recent"
+                    :value="repoPath"
                     @change="selectRecentRepo"
                   >
                     <option value="">Select a repository…</option>
@@ -570,9 +605,9 @@ onUnmounted(() => {
                       v-model="baseBranch"
                       type="text"
                       class="form-input"
-                      placeholder="main (defaults to current HEAD)"
+                      placeholder="Leave blank to use current HEAD"
                     />
-                    <span class="form-hint">The branch to base the new worktree on. A new branch matching the session branch will be created from this base.</span>
+                    <span class="form-hint">The branch to base the new worktree on. If left blank, the worktree is created from the current HEAD.</span>
                   </div>
                   <div v-if="!branch" class="worktree-warning">
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575ZM8 5a.75.75 0 0 0-.75.75v2.5a.75.75 0 0 0 1.5 0v-2.5A.75.75 0 0 0 8 5Zm1 6a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"/></svg>
@@ -637,16 +672,23 @@ onUnmounted(() => {
               <div class="form-grid-2col">
                 <div class="form-group">
                   <label class="form-label">Template Name <span class="required">*</span></label>
-                  <input v-model="templateForm.name" type="text" class="form-input" placeholder="🚀 My Template" />
+                  <input v-model="templateForm.name" type="text" class="form-input" placeholder="My Template" />
                 </div>
                 <div class="form-group">
                   <label class="form-label">Category</label>
                   <input v-model="templateForm.category" type="text" class="form-input" placeholder="e.g. frontend" />
                 </div>
               </div>
-              <div class="form-group">
-                <label class="form-label">Description</label>
-                <input v-model="templateForm.description" type="text" class="form-input" placeholder="Quick description of this template" />
+              <div class="form-grid-2col">
+                <div class="form-group">
+                  <label class="form-label">Description</label>
+                  <input v-model="templateForm.description" type="text" class="form-input" placeholder="Quick description of this template" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">Icon</label>
+                  <input v-model="templateForm.icon" type="text" class="form-input tpl-icon-input" placeholder="🚀" maxlength="14" />
+                  <span class="form-hint">Emoji shown on the template card</span>
+                </div>
               </div>
               <button
                 class="btn btn-primary"
@@ -902,6 +944,29 @@ onUnmounted(() => {
   color: var(--text-tertiary);
   letter-spacing: 0.04em;
   margin: 0 0 10px;
+}
+
+.section-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tpl-restore-btn {
+  background: none;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  margin-bottom: 10px;
+}
+.tpl-restore-btn:hover {
+  background: var(--canvas-subtle);
+  color: var(--text-primary);
+  border-color: var(--border-emphasis);
 }
 
 .section-panel {
@@ -1253,6 +1318,13 @@ onUnmounted(() => {
   margin-top: 0;
 }
 
+.tpl-icon-input {
+  width: 60px;
+  text-align: center;
+  font-size: 1.25rem;
+  padding: 4px 8px;
+}
+
 /* ── Buttons ─────────────────────────────────────────────────────── */
 .btn {
   padding: 8px 16px;
@@ -1515,24 +1587,42 @@ onUnmounted(() => {
   color: var(--danger-fg);
 }
 
-.tpl-confirm-delete {
+/* ── Template Delete Overlay ──────────────────────────────────────── */
+.tpl-delete-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 6px;
-  font-size: 0.6875rem;
-  margin-bottom: 4px;
+  justify-content: center;
+  gap: 8px;
+  background: color-mix(in srgb, var(--canvas-default) 92%, transparent);
+  backdrop-filter: blur(2px);
+  border-radius: var(--radius-lg);
+}
+
+.tpl-delete-overlay-text {
+  font-size: 0.75rem;
+  font-weight: 600;
   color: var(--danger-fg);
+}
+
+.tpl-delete-overlay-actions {
+  display: flex;
+  gap: 6px;
 }
 
 .tpl-confirm-yes,
 .tpl-confirm-cancel {
-  padding: 1px 6px;
-  font-size: 0.625rem;
+  padding: 3px 10px;
+  font-size: 0.6875rem;
   font-family: inherit;
   border: 1px solid var(--border-default);
-  border-radius: 3px;
+  border-radius: 4px;
   cursor: pointer;
   background: none;
+  font-weight: 500;
 }
 
 .tpl-confirm-yes {
@@ -1550,6 +1640,17 @@ onUnmounted(() => {
 
 .tpl-confirm-cancel:hover {
   background: var(--canvas-subtle);
+}
+
+/* ── Fade Transition ─────────────────────────────────────────────── */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 
 /* ── Skeleton Loading ────────────────────────────────────────────── */

--- a/crates/tracepilot-orchestrator/src/templates.rs
+++ b/crates/tracepilot-orchestrator/src/templates.rs
@@ -12,6 +12,69 @@ pub fn templates_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Path to the file tracking which default templates have been dismissed.
+fn dismissed_defaults_path() -> Result<PathBuf> {
+    Ok(templates_dir()?.join("dismissed_defaults.json"))
+}
+
+/// Read the set of dismissed default template IDs.
+fn read_dismissed_defaults() -> Result<Vec<String>> {
+    let path = dismissed_defaults_path()?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = std::fs::read_to_string(&path)?;
+    let ids: Vec<String> = serde_json::from_str(&content).unwrap_or_default();
+    Ok(ids)
+}
+
+/// Write the set of dismissed default template IDs.
+fn write_dismissed_defaults(ids: &[String]) -> Result<()> {
+    let path = dismissed_defaults_path()?;
+    let content = serde_json::to_string_pretty(ids)?;
+    std::fs::write(&path, content)?;
+    Ok(())
+}
+
+/// Dismiss a default template so it no longer appears.
+pub fn dismiss_default_template(id: &str) -> Result<()> {
+    let defaults = default_templates();
+    if !defaults.iter().any(|t| t.id == id) {
+        return Err(OrchestratorError::NotFound(format!(
+            "Not a default template: {id}"
+        )));
+    }
+    let mut dismissed = read_dismissed_defaults()?;
+    if !dismissed.contains(&id.to_string()) {
+        dismissed.push(id.to_string());
+        write_dismissed_defaults(&dismissed)?;
+    }
+    Ok(())
+}
+
+/// Restore a previously dismissed default template.
+pub fn restore_default_template(id: &str) -> Result<()> {
+    let mut dismissed = read_dismissed_defaults()?;
+    dismissed.retain(|d| d != id);
+    write_dismissed_defaults(&dismissed)?;
+    Ok(())
+}
+
+/// Restore all dismissed default templates at once.
+pub fn restore_all_default_templates() -> Result<()> {
+    let path = dismissed_defaults_path()?;
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+/// Check whether any default templates have been dismissed.
+pub fn has_dismissed_defaults() -> Result<bool> {
+    let dismissed = read_dismissed_defaults()?;
+    Ok(!dismissed.is_empty())
+}
+
 /// List all saved templates.
 pub fn list_templates() -> Result<Vec<SessionTemplate>> {
     let dir = templates_dir()?;
@@ -25,6 +88,10 @@ pub fn list_templates() -> Result<Vec<SessionTemplate>> {
         let entry = entry?;
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            // Skip the dismissed_defaults metadata file
+            if path.file_stem().and_then(|s| s.to_str()) == Some("dismissed_defaults") {
+                continue;
+            }
             let content = std::fs::read_to_string(&path)?;
             match serde_json::from_str::<SessionTemplate>(&content) {
                 Ok(template) => templates.push(template),
@@ -41,6 +108,13 @@ pub fn list_templates() -> Result<Vec<SessionTemplate>> {
 
 /// Save a new template.
 pub fn save_template(template: &SessionTemplate) -> Result<()> {
+    // Prevent collision with internal metadata file
+    if template.id == "dismissed_defaults" {
+        return Err(OrchestratorError::NotFound(
+            "Template ID 'dismissed_defaults' is reserved".into(),
+        ));
+    }
+
     let dir = templates_dir()?;
     let path = dir.join(format!("{}.json", template.id));
     let temp = dir.join(format!(".{}.json.tmp", template.id));
@@ -51,27 +125,61 @@ pub fn save_template(template: &SessionTemplate) -> Result<()> {
     Ok(())
 }
 
-/// Delete a template by ID.
+/// Delete a template by ID. For default templates, this dismisses them instead.
 pub fn delete_template(id: &str) -> Result<()> {
+    // Prevent accidental deletion of internal metadata file
+    if id == "dismissed_defaults" {
+        return Err(OrchestratorError::NotFound(
+            "Template ID 'dismissed_defaults' is reserved".into(),
+        ));
+    }
+
+    // Check if it's a default template — dismiss instead of file delete
+    let defaults = default_templates();
+    if defaults.iter().any(|t| t.id == id) {
+        // Dismiss first to avoid data loss if the file delete succeeds but dismiss fails
+        dismiss_default_template(id)?;
+        // Then remove any user override file if it exists
+        let dir = templates_dir()?;
+        let path = dir.join(format!("{id}.json"));
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        return Ok(());
+    }
+
     let dir = templates_dir()?;
     let path = dir.join(format!("{id}.json"));
     if !path.exists() {
-        return Err(OrchestratorError::NotFound(format!("Template not found: {id}")));
+        return Err(OrchestratorError::NotFound(format!(
+            "Template not found: {id}"
+        )));
     }
     std::fs::remove_file(&path)?;
     Ok(())
 }
 
 /// Increment usage count for a template.
+/// For default templates that haven't been saved yet, creates a user override.
 pub fn increment_usage(id: &str) -> Result<()> {
     let dir = templates_dir()?;
     let path = dir.join(format!("{id}.json"));
-    if !path.exists() {
-        return Err(OrchestratorError::NotFound(format!("Template not found: {id}")));
-    }
 
-    let content = std::fs::read_to_string(&path)?;
-    let mut template: SessionTemplate = serde_json::from_str(&content)?;
+    let mut template = if path.exists() {
+        let content = std::fs::read_to_string(&path)?;
+        serde_json::from_str(&content)?
+    } else {
+        // Check if it's a default template
+        match default_templates().into_iter().find(|t| t.id == id) {
+            Some(t) => t,
+            None => {
+                return Err(OrchestratorError::NotFound(format!(
+                    "Template not found: {id}"
+                )));
+            }
+        }
+    };
+
     template.usage_count += 1;
     save_template(&template)?;
     Ok(())
@@ -82,80 +190,73 @@ pub fn default_templates() -> Vec<SessionTemplate> {
     let now = chrono::Utc::now().to_rfc3339();
     vec![
         SessionTemplate {
-            id: "default-bugfix".into(),
-            name: "Bug Fix".into(),
-            description: "Quick bug fix session with auto-approve".into(),
-            category: "Development".into(),
-            config: crate::types::LaunchConfig {
-                repo_path: String::new(),
-                branch: Some("fix/".into()),
-                base_branch: None,
-                model: Some("claude-sonnet-4.6".into()),
-                prompt: None,
-                headless: false,
-                reasoning_effort: None,
-                custom_instructions: None,
-                env_vars: Default::default(),
-                create_worktree: true,
-                auto_approve: true,
-                cli_command: "copilot".into(),
-            },
-            tags: vec!["bugfix".into(), "quick".into()],
-            created_at: now.clone(),
-            usage_count: 0,
-        },
-        SessionTemplate {
-            id: "default-feature".into(),
-            name: "Feature Development".into(),
-            description: "Full feature development with premium model".into(),
-            category: "Development".into(),
-            config: crate::types::LaunchConfig {
-                repo_path: String::new(),
-                branch: Some("feature/".into()),
-                base_branch: None,
-                model: Some("claude-opus-4.6".into()),
-                prompt: None,
-                headless: false,
-                reasoning_effort: Some("high".into()),
-                custom_instructions: None,
-                env_vars: Default::default(),
-                create_worktree: true,
-                auto_approve: false,
-                cli_command: "copilot".into(),
-            },
-            tags: vec!["feature".into(), "premium".into()],
-            created_at: now.clone(),
-            usage_count: 0,
-        },
-        SessionTemplate {
-            id: "default-review".into(),
-            name: "Code Review".into(),
-            description: "Code review session with explore agent".into(),
-            category: "Review".into(),
+            id: "default-multi-agent-review".into(),
+            name: "Multi Agent Code Review".into(),
+            description: "Comprehensive code review using multiple AI models".into(),
+            icon: Some("🔍".into()),
+            category: "Quality".into(),
             config: crate::types::LaunchConfig {
                 repo_path: String::new(),
                 branch: None,
                 base_branch: None,
-                model: Some("claude-sonnet-4.6".into()),
-                prompt: Some("Review the recent changes and provide feedback".into()),
+                model: Some("claude-opus-4.6".into()),
+                prompt: Some(
+                    "Spin up opus 4.6, GPT 5.4, Codex 5.3, and Gemini subagents to do a \
+                     comprehensive code review of the changes on this branch (git diff). \
+                     Consolidate and validate their feedback, and provide a summary."
+                        .into(),
+                ),
                 headless: false,
-                reasoning_effort: None,
+                reasoning_effort: Some("high".into()),
                 custom_instructions: None,
                 env_vars: Default::default(),
                 create_worktree: false,
                 auto_approve: false,
                 cli_command: "copilot".into(),
             },
-            tags: vec!["review".into()],
+            tags: vec!["review".into(), "multi-agent".into(), "premium".into()],
+            created_at: now.clone(),
+            usage_count: 0,
+        },
+        SessionTemplate {
+            id: "default-write-tests".into(),
+            name: "Write Tests".into(),
+            description: "Generate comprehensive test coverage for recent changes".into(),
+            icon: Some("🧪".into()),
+            category: "Quality".into(),
+            config: crate::types::LaunchConfig {
+                repo_path: String::new(),
+                branch: None,
+                base_branch: None,
+                model: Some("claude-sonnet-4.6".into()),
+                prompt: Some(
+                    "Analyze the recent changes and generate comprehensive tests. \
+                     Cover edge cases, error paths, and integration scenarios."
+                        .into(),
+                ),
+                headless: false,
+                reasoning_effort: Some("high".into()),
+                custom_instructions: None,
+                env_vars: Default::default(),
+                create_worktree: false,
+                auto_approve: false,
+                cli_command: "copilot".into(),
+            },
+            tags: vec!["testing".into(), "coverage".into()],
             created_at: now,
             usage_count: 0,
         },
     ]
 }
 
-/// Return all templates (defaults + user-saved).
+/// Return all templates (non-dismissed defaults + user-saved).
 pub fn all_templates() -> Result<Vec<SessionTemplate>> {
-    let mut templates = default_templates();
+    let dismissed = read_dismissed_defaults().unwrap_or_default();
+    let mut templates: Vec<SessionTemplate> = default_templates()
+        .into_iter()
+        .filter(|t| !dismissed.contains(&t.id))
+        .collect();
+
     let user_templates = list_templates()?;
 
     // User templates override defaults with same ID
@@ -173,25 +274,63 @@ pub fn all_templates() -> Result<Vec<SessionTemplate>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // Thread-safety for tests that use env vars
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_home<F: FnOnce()>(f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().unwrap();
+        // Create .copilot so copilot_home() succeeds
+        std::fs::create_dir_all(tmp.path().join(".copilot")).unwrap();
+        let old = std::env::var("HOME").ok();
+        let old_userprofile = std::env::var("USERPROFILE").ok();
+        // SAFETY: Tests using this helper are serialized via ENV_LOCK mutex.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("USERPROFILE", tmp.path());
+        }
+        f();
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match old_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
 
     #[test]
     fn test_default_templates_not_empty() {
         let templates = default_templates();
-        assert_eq!(templates.len(), 3);
-        assert!(templates.iter().any(|t| t.id == "default-bugfix"));
-        assert!(templates.iter().any(|t| t.id == "default-feature"));
-        assert!(templates.iter().any(|t| t.id == "default-review"));
+        assert_eq!(templates.len(), 2);
+        assert!(templates.iter().any(|t| t.id == "default-multi-agent-review"));
+        assert!(templates.iter().any(|t| t.id == "default-write-tests"));
     }
 
     #[test]
-    fn test_save_and_list_templates() {
-        // This test would need a temp dir override for templates_dir()
-        // In integration tests we'd mock the path. For unit tests, we test serialization.
+    fn test_default_templates_have_icons() {
+        let templates = default_templates();
+        for t in &templates {
+            assert!(t.icon.is_some(), "Template {} should have an icon", t.id);
+        }
+        assert_eq!(templates[0].icon.as_deref(), Some("🔍"));
+        assert_eq!(templates[1].icon.as_deref(), Some("🧪"));
+    }
+
+    #[test]
+    fn test_template_serialization_roundtrip() {
         let template = SessionTemplate {
             id: "test-1".into(),
             name: "Test Template".into(),
             description: "A test".into(),
             category: "Test".into(),
+            icon: Some("🚀".into()),
             config: crate::types::LaunchConfig {
                 repo_path: "/tmp/test".into(),
                 branch: None,
@@ -215,5 +354,217 @@ mod tests {
         let parsed: SessionTemplate = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.id, "test-1");
         assert_eq!(parsed.usage_count, 5);
+        assert_eq!(parsed.icon.as_deref(), Some("🚀"));
+    }
+
+    #[test]
+    fn test_template_deserialization_without_icon() {
+        // Backward compat: old templates without icon field should parse fine
+        let json = r#"{
+            "id": "old-template",
+            "name": "Old Template",
+            "description": "No icon field",
+            "category": "Test",
+            "config": {
+                "repoPath": "",
+                "headless": false,
+                "envVars": {},
+                "createWorktree": false,
+                "autoApprove": false
+            },
+            "tags": [],
+            "createdAt": "2025-01-01T00:00:00Z",
+            "usageCount": 0
+        }"#;
+        let parsed: SessionTemplate = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.id, "old-template");
+        assert!(parsed.icon.is_none());
+    }
+
+    #[test]
+    fn test_dismiss_and_restore_default_template() {
+        with_temp_home(|| {
+            // All defaults should appear initially
+            let all = all_templates().unwrap();
+            assert_eq!(all.len(), 2);
+
+            // Dismiss one
+            dismiss_default_template("default-write-tests").unwrap();
+            let all = all_templates().unwrap();
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].id, "default-multi-agent-review");
+
+            // Restore it
+            restore_default_template("default-write-tests").unwrap();
+            let all = all_templates().unwrap();
+            assert_eq!(all.len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_dismiss_nondefault_fails() {
+        with_temp_home(|| {
+            let result = dismiss_default_template("nonexistent");
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_delete_default_template_dismisses_it() {
+        with_temp_home(|| {
+            let all_before = all_templates().unwrap();
+            assert_eq!(all_before.len(), 2);
+
+            // delete_template on a default should dismiss it, not error
+            delete_template("default-write-tests").unwrap();
+            let all_after = all_templates().unwrap();
+            assert_eq!(all_after.len(), 1);
+            assert!(!all_after.iter().any(|t| t.id == "default-write-tests"));
+        });
+    }
+
+    #[test]
+    fn test_save_and_list_user_template() {
+        with_temp_home(|| {
+            let template = SessionTemplate {
+                id: "user-custom-1".into(),
+                name: "Custom Template".into(),
+                description: "A user template".into(),
+                category: "Custom".into(),
+                icon: Some("⭐".into()),
+                config: crate::types::LaunchConfig {
+                    repo_path: "/tmp/test".into(),
+                    branch: None,
+                    base_branch: None,
+                    model: None,
+                    prompt: None,
+                    headless: false,
+                    reasoning_effort: None,
+                    custom_instructions: None,
+                    env_vars: Default::default(),
+                    create_worktree: false,
+                    auto_approve: false,
+                    cli_command: "copilot".into(),
+                },
+                tags: vec![],
+                created_at: "2025-01-01T00:00:00Z".into(),
+                usage_count: 0,
+            };
+
+            save_template(&template).unwrap();
+            let all = all_templates().unwrap();
+            // 2 defaults + 1 user
+            assert_eq!(all.len(), 3);
+            assert!(all.iter().any(|t| t.id == "user-custom-1"));
+        });
+    }
+
+    #[test]
+    fn test_restore_all_default_templates() {
+        with_temp_home(|| {
+            // Dismiss both defaults
+            dismiss_default_template("default-multi-agent-review").unwrap();
+            dismiss_default_template("default-write-tests").unwrap();
+            assert_eq!(all_templates().unwrap().len(), 0);
+            assert!(has_dismissed_defaults().unwrap());
+
+            // Restore all at once
+            restore_all_default_templates().unwrap();
+            assert_eq!(all_templates().unwrap().len(), 2);
+            assert!(!has_dismissed_defaults().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_has_dismissed_defaults() {
+        with_temp_home(|| {
+            assert!(!has_dismissed_defaults().unwrap());
+            dismiss_default_template("default-write-tests").unwrap();
+            assert!(has_dismissed_defaults().unwrap());
+            restore_default_template("default-write-tests").unwrap();
+            assert!(!has_dismissed_defaults().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_reserved_id_rejected_on_save() {
+        with_temp_home(|| {
+            let template = SessionTemplate {
+                id: "dismissed_defaults".into(),
+                name: "Sneaky".into(),
+                description: "Trying to overwrite metadata".into(),
+                category: "Test".into(),
+                icon: None,
+                config: crate::types::LaunchConfig {
+                    repo_path: String::new(),
+                    branch: None,
+                    base_branch: None,
+                    model: None,
+                    prompt: None,
+                    headless: false,
+                    reasoning_effort: None,
+                    custom_instructions: None,
+                    env_vars: Default::default(),
+                    create_worktree: false,
+                    auto_approve: false,
+                    cli_command: "copilot".into(),
+                },
+                tags: vec![],
+                created_at: "2025-01-01T00:00:00Z".into(),
+                usage_count: 0,
+            };
+            let result = save_template(&template);
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_reserved_id_rejected_on_delete() {
+        with_temp_home(|| {
+            let result = delete_template("dismissed_defaults");
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_default_templates_have_prompts() {
+        let templates = default_templates();
+        for t in &templates {
+            assert!(
+                t.config.prompt.is_some(),
+                "Default template {} should have a prompt",
+                t.id
+            );
+        }
+    }
+
+    #[test]
+    fn test_increment_usage_default_template() {
+        with_temp_home(|| {
+            // Default templates start with usage_count 0
+            let all = all_templates().unwrap();
+            let review = all.iter().find(|t| t.id == "default-multi-agent-review").unwrap();
+            assert_eq!(review.usage_count, 0);
+
+            // Increment creates a user override file
+            increment_usage("default-multi-agent-review").unwrap();
+            let all = all_templates().unwrap();
+            let review = all.iter().find(|t| t.id == "default-multi-agent-review").unwrap();
+            assert_eq!(review.usage_count, 1);
+
+            // Second increment reads from the file
+            increment_usage("default-multi-agent-review").unwrap();
+            let all = all_templates().unwrap();
+            let review = all.iter().find(|t| t.id == "default-multi-agent-review").unwrap();
+            assert_eq!(review.usage_count, 2);
+        });
+    }
+
+    #[test]
+    fn test_increment_usage_nonexistent_fails() {
+        with_temp_home(|| {
+            let result = increment_usage("nonexistent-template");
+            assert!(result.is_err());
+        });
     }
 }

--- a/crates/tracepilot-orchestrator/src/types.rs
+++ b/crates/tracepilot-orchestrator/src/types.rs
@@ -200,6 +200,9 @@ pub struct SessionTemplate {
     pub created_at: String,
     #[serde(default)]
     pub usage_count: u32,
+    /// Optional emoji/icon for display. Falls back to extracting from name if absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
 }
 
 // ─── Active Session Discovery Types ───────────────────────────────

--- a/crates/tracepilot-tauri-bindings/src/lib.rs
+++ b/crates/tracepilot-tauri-bindings/src/lib.rs
@@ -1745,6 +1745,26 @@ mod commands {
         .map_err(|e| e.to_string())?
     }
 
+    #[tauri::command]
+    pub async fn restore_default_templates() -> Result<(), String> {
+        tokio::task::spawn_blocking(|| {
+            tracepilot_orchestrator::templates::restore_all_default_templates()
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    #[tauri::command]
+    pub async fn increment_template_usage(id: String) -> Result<(), String> {
+        tokio::task::spawn_blocking(move || {
+            tracepilot_orchestrator::templates::increment_usage(&id)
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     // ── Logging commands ─────────────────────────────────────────
 
     #[tauri::command]
@@ -1954,6 +1974,8 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
             commands::list_session_templates,
             commands::save_session_template,
             commands::delete_session_template,
+            commands::restore_default_templates,
+            commands::increment_template_usage,
             // Logging commands
             commands::get_log_path,
             commands::export_logs,

--- a/docs/git-worktree-guide.md
+++ b/docs/git-worktree-guide.md
@@ -118,9 +118,9 @@ In the Worktree Manager, click **Launch Session Here** in any worktree's detail 
 
 ---
 
-## Command Center Integration
+## Command Centre Integration
 
-The **Orchestration Home** (Command Center) shows aggregate worktree statistics:
+The **Orchestration Home** (Command Centre) shows aggregate worktree statistics:
 
 - Total worktrees across all registered repositories
 - Count of stale worktrees

--- a/packages/client/src/orchestration.ts
+++ b/packages/client/src/orchestration.ts
@@ -210,6 +210,14 @@ export async function deleteSessionTemplate(id: string): Promise<void> {
   return invoke<void>('delete_session_template', { id });
 }
 
+export async function restoreDefaultTemplates(): Promise<void> {
+  return invoke<void>('restore_default_templates');
+}
+
+export async function incrementTemplateUsage(id: string): Promise<void> {
+  return invoke<void>('increment_template_usage', { id });
+}
+
 // ─── Mock Data ────────────────────────────────────────────────────
 
 function getMockData<T>(cmd: string): T {
@@ -437,147 +445,10 @@ function getMockData<T>(cmd: string): T {
 
     list_session_templates: [
       {
-        id: 'default-bugfix',
-        name: '🐛 Bug Fix',
-        description: 'Quick bug fix session with auto-approve',
-        category: 'Development',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: true,
-          autoApprove: true,
-          model: 'claude-sonnet-4.6',
-          branch: 'fix/',
-        },
-        tags: ['bugfix', 'quick'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 12,
-      },
-      {
-        id: 'default-feature',
-        name: '🚀 Feature Build',
-        description: 'Full feature development with premium model',
-        category: 'Development',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: true,
-          autoApprove: false,
-          model: 'claude-opus-4.6',
-          branch: 'feature/',
-        },
-        tags: ['feature', 'premium'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 8,
-      },
-      {
-        id: 'default-review',
-        name: '🔍 Code Review',
-        description: 'Thorough code review and analysis',
-        category: 'Quality',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: false,
-          autoApprove: false,
-          model: 'claude-sonnet-4.6',
-        },
-        tags: ['review', 'quality'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 15,
-      },
-      {
-        id: 'default-refactor',
-        name: '♻️ Refactor',
-        description: 'Code refactoring and cleanup',
-        category: 'Development',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: true,
-          autoApprove: false,
-          model: 'claude-sonnet-4.6',
-        },
-        tags: ['refactor', 'cleanup'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 6,
-      },
-      {
-        id: 'default-test',
-        name: '🧪 Test Writing',
-        description: 'Generate comprehensive test coverage',
-        category: 'Quality',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: true,
-          autoApprove: true,
-          model: 'claude-sonnet-4.6',
-        },
-        tags: ['testing', 'coverage'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 10,
-      },
-      {
-        id: 'default-docs',
-        name: '📝 Documentation',
-        description: 'Documentation generation and updates',
-        category: 'Documentation',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: false,
-          autoApprove: true,
-          model: 'claude-haiku-4.5',
-        },
-        tags: ['docs', 'fast'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 4,
-      },
-      {
-        id: 'default-quickfix',
-        name: '⚡ Quick Fix',
-        description: 'Rapid one-shot fix with fast model',
-        category: 'Development',
-        config: {
-          repoPath: '',
-          headless: true,
-          envVars: {},
-          createWorktree: false,
-          autoApprove: true,
-          model: 'claude-haiku-4.5',
-        },
-        tags: ['quick', 'fast'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 20,
-      },
-      {
-        id: 'default-deps',
-        name: '📦 Dependency Update',
-        description: 'Update and audit project dependencies',
-        category: 'Maintenance',
-        config: {
-          repoPath: '',
-          headless: false,
-          envVars: {},
-          createWorktree: true,
-          autoApprove: false,
-          model: 'claude-sonnet-4.6',
-        },
-        tags: ['deps', 'maintenance'],
-        createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 3,
-      },
-      {
-        id: 'default-comprehensive-review',
-        name: '🧠 Comprehensive Review (Multi-Agent)',
-        description: 'Review session with multi-agent insight.',
+        id: 'default-multi-agent-review',
+        name: 'Multi Agent Code Review',
+        description: 'Comprehensive code review using multiple AI models',
+        icon: '🔍',
         category: 'Quality',
         config: {
           repoPath: '',
@@ -586,15 +457,42 @@ function getMockData<T>(cmd: string): T {
           createWorktree: false,
           autoApprove: false,
           model: 'claude-opus-4.6',
-          prompt: 'Please spin up Opus 4.6, GPT 5.4, Codex 5.3, and Gemini Subagents to review the changes in this branch (git diff). Consolidate and validate their findings, and provide a summary.',
+          reasoningEffort: 'high',
+          prompt:
+            'Spin up opus 4.6, GPT 5.4, Codex 5.3, and Gemini subagents to do a comprehensive code review of the changes on this branch (git diff). Consolidate and validate their feedback, and provide a summary.',
         },
         tags: ['review', 'multi-agent', 'premium'],
         createdAt: '2025-01-01T00:00:00Z',
-        usageCount: 5,
+        usageCount: 0,
+      },
+      {
+        id: 'default-write-tests',
+        name: 'Write Tests',
+        description: 'Generate comprehensive test coverage for recent changes',
+        icon: '🧪',
+        category: 'Quality',
+        config: {
+          repoPath: '',
+          headless: false,
+          envVars: {},
+          createWorktree: false,
+          autoApprove: false,
+          model: 'claude-sonnet-4.6',
+          reasoningEffort: 'high',
+          prompt:
+            'Analyze the recent changes and generate comprehensive tests. Cover edge cases, error paths, and integration scenarios.',
+        },
+        tags: ['testing', 'coverage'],
+        createdAt: '2025-01-01T00:00:00Z',
+        usageCount: 0,
       },
     ] satisfies SessionTemplate[],
 
     // Write operations return void
+    save_session_template: undefined,
+    delete_session_template: undefined,
+    restore_default_templates: undefined,
+    increment_template_usage: undefined,
     remove_worktree: undefined,
     is_git_repo: true,
     lock_worktree: undefined,
@@ -645,8 +543,6 @@ function getMockData<T>(cmd: string): T {
     delete_config_backup: undefined,
     diff_config_files: { fileName: 'test.yaml', diffText: '', hasChanges: false } satisfies ConfigDiff,
     migrate_agent_definition: undefined,
-    save_session_template: undefined,
-    delete_session_template: undefined,
   };
 
   return (mocks[cmd] ?? null) as T;

--- a/packages/types/src/orchestration.ts
+++ b/packages/types/src/orchestration.ts
@@ -145,6 +145,8 @@ export interface SessionTemplate {
   tags: string[];
   createdAt: string;
   usageCount: number;
+  /** Optional emoji/icon for display. Falls back to extracting from name if absent. */
+  icon?: string;
 }
 
 // ─── Active Session Discovery Types ───────────────────────────────


### PR DESCRIPTION
- Replace default templates with Multi Agent Code Review + Write Tests
- Add icon/emoji field to SessionTemplate (Rust + TypeScript)
- Make default templates dismissable with restore capability
- Fix delete confirmation UX with absolute overlay instead of inline shift
- Fix base branch placeholder text
- Wire up template usage count tracking end-to-end
- Fix restore_default_templates Tauri ACL registration in build.rs
- Add increment_template_usage command for tracking template usage
- Template apply preserves current repo selection when template has no repo
- Launcher auto-discovers repos from sessions on mount
- Rename Command Center to Command Centre across all display text
- Add caching to command centre store (5-min TTL, background refresh)
- Remove keyboard shortcuts bar from command centre
- Show Repositories count in command centre hero card
- Bind repo selector value so it reflects current repoPath
- Protect dismissed_defaults.json from namespace collision
- Fix delete ordering: dismiss before file delete to prevent data loss
- Increase icon input maxlength for complex emojis
- Add 15 Rust tests and 22 frontend tests for template system