### PR TITLE
Conversation (Chat) UI/UX Overhaul

### DIFF
--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useSessionDetailStore } from "@/stores/sessionDetail";
 import { usePreferencesStore } from "@/stores/preferences";
@@ -57,7 +57,6 @@ const panel = useSubagentPanel(allSubagents);
 
 const expandedReasoning = useToggleSet<string>();
 const expandedGroups = useToggleSet<string>();
-const expandedUserMsgs = useToggleSet<number>();
 const expandedToolDetails = useToggleSet<string>();
 
 // ─── Tool result loader ───────────────────────────────────────────
@@ -73,6 +72,34 @@ const { findToolCallIndex, getArgsSummary } = useConversationSections(() => stor
 // ─── Scroll ───────────────────────────────────────────────────────
 
 const scrollEl = ref<HTMLElement | null>(null);
+const cvRootEl = ref<HTMLElement | null>(null);
+
+// ─── Panel top offset (fixed position below page header) ──────────
+
+const panelTopPx = ref(0);
+
+function updatePanelTop() {
+  if (cvRootEl.value) {
+    panelTopPx.value = cvRootEl.value.getBoundingClientRect().top;
+  }
+}
+
+let panelTopRO: ResizeObserver | null = null;
+
+onMounted(() => {
+  updatePanelTop();
+  window.addEventListener("resize", updatePanelTop);
+  // Use a ResizeObserver on the parent to catch layout shifts (stat cards loading, etc.)
+  if (cvRootEl.value?.parentElement) {
+    panelTopRO = new ResizeObserver(updatePanelTop);
+    panelTopRO.observe(cvRootEl.value.parentElement);
+  }
+});
+
+onUnmounted(() => {
+  window.removeEventListener("resize", updatePanelTop);
+  panelTopRO?.disconnect();
+});
 
 // ─── Computed helpers ─────────────────────────────────────────────
 
@@ -141,21 +168,6 @@ function isItemVisible(
 
 function hiddenToolCount(items: ToolGroupItem[]): number {
   return countRegularTools(items) - MAX_VISIBLE_TOOLS;
-}
-
-// ─── User message truncation ──────────────────────────────────────
-
-const USER_MSG_MAX = 600;
-
-function isUserMsgLong(msg: string | undefined): boolean {
-  return (msg?.length ?? 0) > USER_MSG_MAX;
-}
-
-function displayUserMsg(msg: string, turnIndex: number): string {
-  if (expandedUserMsgs.has(turnIndex) || msg.length <= USER_MSG_MAX) {
-    return msg;
-  }
-  return msg.slice(0, USER_MSG_MAX);
 }
 
 // ─── Intent/memory pill helpers ───────────────────────────────────
@@ -280,7 +292,7 @@ defineExpose({ revealEvent });
 </script>
 
 <template>
-  <div class="cv-root">
+  <div class="cv-root" ref="cvRootEl">
     <!-- Main column (shrinks when panel is open) -->
     <div :class="['cv-main', { 'panel-open': panel.isPanelOpen.value }]">
       <div class="cv-scroll" ref="scrollEl">
@@ -323,22 +335,7 @@ defineExpose({ revealEvent });
                   </span>
                 </div>
                 <div class="cv-user-body">
-                  <div
-                    :class="['cv-user-text', {
-                      'cv-user-text--clamped': isUserMsgLong(turn.userMessage) && !expandedUserMsgs.has(turn.turnIndex)
-                    }]"
-                  >
-                    <MarkdownContent :content="displayUserMsg(turn.userMessage, turn.turnIndex)" :render="renderMd" />
-                  </div>
-                  <button
-                    v-if="isUserMsgLong(turn.userMessage)"
-                    class="cv-user-expand"
-                    :aria-expanded="expandedUserMsgs.has(turn.turnIndex)"
-                    aria-label="Toggle full message"
-                    @click="expandedUserMsgs.toggle(turn.turnIndex)"
-                  >
-                    {{ expandedUserMsgs.has(turn.turnIndex) ? 'Show less ↑' : 'Show more ↓' }}
-                  </button>
+                  <MarkdownContent :content="turn.userMessage" :render="renderMd" />
                 </div>
               </div>
 
@@ -493,7 +490,7 @@ defineExpose({ revealEvent });
       </div>
     </div>
 
-    <!-- Subagent panel (includes its own overlay) -->
+    <!-- Subagent panel (fixed viewport-sticky, below header) -->
     <SubagentPanel
       :subagent="panel.selectedSubagent.value"
       :is-open="panel.isPanelOpen.value"
@@ -501,6 +498,7 @@ defineExpose({ revealEvent });
       :total-count="allSubagents.length"
       :has-prev="panel.hasPrev.value"
       :has-next="panel.hasNext.value"
+      :top-offset="panelTopPx"
       @close="panel.closePanel"
       @prev="panel.navigatePrev"
       @next="panel.navigateNext"
@@ -543,7 +541,7 @@ defineExpose({ revealEvent });
 }
 
 .cv-content {
-  max-width: 1400px;
+  max-width: var(--content-max-width, 1600px);
   margin: 0 auto;
   padding: 24px 32px 80px;
 }
@@ -669,35 +667,14 @@ defineExpose({ revealEvent });
 
 .cv-user-body {
   position: relative;
-}
-
-.cv-user-text {
+  background: var(--accent-subtle, rgba(56, 139, 253, 0.08));
+  border: 1px solid var(--accent-muted, rgba(56, 139, 253, 0.15));
+  border-radius: var(--radius-md, 8px);
+  padding: 12px 16px;
   font-size: 13px;
   line-height: 1.55;
   color: var(--text-primary, #c9d1d9);
   overflow-wrap: break-word;
-}
-
-.cv-user-text--clamped {
-  mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
-  -webkit-mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
-}
-
-.cv-user-expand {
-  display: inline-block;
-  margin-top: 4px;
-  padding: 2px 8px;
-  font-size: 12px;
-  color: var(--accent-fg, #58a6ff);
-  background: none;
-  border: 1px solid var(--border-muted, #484f58);
-  border-radius: var(--radius-full, 100px);
-  cursor: pointer;
-  transition: background var(--transition-fast, 0.1s) ease;
-}
-
-.cv-user-expand:hover {
-  background: var(--accent-subtle, rgba(56, 139, 253, 0.1));
 }
 
 /* ─── Turn block + timeline ────────────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -206,6 +206,39 @@ function memoryLabel(tc: TurnToolCall): string {
   return (args?.fact as string) ?? (args?.subject as string) ?? "…";
 }
 
+// ─── Subagent completion pill helpers ─────────────────────────────
+
+function parseReadAgentId(tc: TurnToolCall): string | null {
+  try {
+    const args = typeof tc.arguments === "string"
+      ? JSON.parse(tc.arguments)
+      : tc.arguments;
+    return (args?.agent_id as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function subagentCompleteLabel(tc: TurnToolCall): string {
+  const agentId = parseReadAgentId(tc);
+  if (agentId) {
+    const sa = subagentMap.value.get(agentId);
+    if (sa) {
+      const agentType = inferAgentTypeFromToolCall(sa.toolCall);
+      const label = agentType.charAt(0).toUpperCase() + agentType.slice(1);
+      return `${label} agent ${tc.success === false ? "failed" : "completed"}`;
+    }
+  }
+  return tc.success === false ? "Agent failed" : "Agent completed";
+}
+
+function openSubagentFromReadAgent(tc: TurnToolCall) {
+  const agentId = parseReadAgentId(tc);
+  if (agentId) {
+    panel.selectSubagent(agentId);
+  }
+}
+
 // ─── ToolCallItem helpers ─────────────────────────────────────────
 
 function tcProps(turn: ConversationTurn, tc: TurnToolCall) {
@@ -424,19 +457,29 @@ defineExpose({ revealEvent });
                           <span class="cv-pill-label">{{ truncateText(memoryLabel(item.toolCall), 80) }}</span>
                         </div>
 
-                        <!-- Ask-user card -->
-                        <div
+                        <!-- Ask-user (rich renderer) -->
+                        <ToolCallItem
                           v-else-if="item.type === 'ask-user'"
-                          class="cv-ask-user-card"
                           :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                          v-bind="tcProps(turn, item.toolCall)"
+                          @toggle="toggleToolDetail(turn, item.toolCall)"
+                          @load-full-result="handleLoadFullResult"
+                          @retry-full-result="handleRetryResult"
+                        />
+
+                        <!-- Subagent completion pill -->
+                        <div
+                          v-else-if="item.type === 'subagent-complete'"
+                          :class="['cv-subagent-complete-pill', item.toolCall.success === false ? 'failed' : 'completed']"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                          role="button"
+                          tabindex="0"
+                          @click="openSubagentFromReadAgent(item.toolCall)"
+                          @keydown.enter="openSubagentFromReadAgent(item.toolCall)"
                         >
-                          <div class="cv-ask-user-header">
-                            <span aria-hidden="true">💬</span>
-                            <span>Asked User</span>
-                          </div>
-                          <div v-if="item.toolCall.resultContent" class="cv-ask-user-body">
-                            {{ truncateText(item.toolCall.resultContent, 300) }}
-                          </div>
+                          <span class="cv-pill-icon" aria-hidden="true">{{ item.toolCall.success === false ? '✗' : '✓' }}</span>
+                          <span class="cv-pill-label">{{ subagentCompleteLabel(item.toolCall) }}</span>
+                          <span v-if="item.toolCall.durationMs" class="cv-pill-duration">{{ formatDuration(item.toolCall.durationMs) }}</span>
                         </div>
 
                         <!-- Regular tool row (with progressive disclosure) -->
@@ -847,32 +890,37 @@ defineExpose({ revealEvent });
   white-space: nowrap;
 }
 
-/* ─── Ask-user card ────────────────────────────────────────────── */
+/* ─── Subagent completion pill ─────────────────────────────────── */
 
-.cv-ask-user-card {
-  background: var(--warning-subtle, rgba(210, 153, 34, 0.1));
-  border: 1px solid var(--warning-muted, rgba(210, 153, 34, 0.2));
-  border-radius: var(--radius-md, 8px);
-  padding: 10px 14px;
-  margin: 4px 0;
-}
-
-.cv-ask-user-header {
-  display: flex;
+.cv-subagent-complete-pill {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
   font-size: 12px;
-  font-weight: 600;
-  color: var(--warning-fg, #d29922);
-  margin-bottom: 4px;
+  cursor: pointer;
+  margin: 4px 0;
+  transition: filter 0.15s ease;
 }
 
-.cv-ask-user-body {
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--text-primary, #c9d1d9);
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
+.cv-subagent-complete-pill:hover {
+  filter: brightness(1.15);
+}
+
+.cv-subagent-complete-pill.completed {
+  background: var(--success-subtle, rgba(63, 185, 80, 0.1));
+  color: var(--success-fg, #3fb950);
+}
+
+.cv-subagent-complete-pill.failed {
+  background: var(--danger-subtle, rgba(248, 81, 73, 0.1));
+  color: var(--danger-fg, #f85149);
+}
+
+.cv-subagent-complete-pill .cv-pill-duration {
+  opacity: 0.7;
+  font-size: 11px;
 }
 
 /* ─── Parallel subagent layout ─────────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -485,20 +485,6 @@ defineExpose({ revealEvent });
                       </div>
                     </div>
                   </template>
-
-                  <!-- Read agent check -->
-                  <template v-if="segment.type === 'read-agent-pill'">
-                    <div
-                      :class="['cv-read-agent-check', {
-                        complete: segment.toolCall.isComplete && segment.toolCall.success !== false,
-                        failed: segment.toolCall.success === false
-                      }]"
-                      :id="segment.toolCall.eventIndex != null ? `event-${segment.toolCall.eventIndex}` : undefined"
-                    >
-                      <span class="cv-check-icon">{{ !segment.toolCall.isComplete ? '⏳' : segment.toolCall.success === false ? '✗' : '✓' }}</span>
-                      <span class="cv-check-text">{{ (segment.toolCall.arguments as any)?.agent_id ?? 'agent' }}</span>
-                    </div>
-                  </template>
                 </template>
               </div>
             </template>
@@ -880,31 +866,6 @@ defineExpose({ revealEvent });
   color: var(--text-primary, #c9d1d9);
   white-space: pre-wrap;
   overflow-wrap: break-word;
-}
-
-/* ─── Read agent check (subtle inline) ─────────────────────────── */
-
-.cv-read-agent-check {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  color: var(--text-tertiary, #484f58);
-  padding: 1px 0;
-}
-
-.cv-read-agent-check.complete .cv-check-icon {
-  color: var(--success-fg, #3fb950);
-}
-
-.cv-read-agent-check.failed .cv-check-icon {
-  color: var(--danger-fg, #f85149);
-}
-
-.cv-check-text {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  opacity: 0.6;
 }
 
 /* ─── Parallel subagent layout ─────────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -206,9 +206,11 @@ function memoryLabel(tc: TurnToolCall): string {
   return (args?.fact as string) ?? (args?.subject as string) ?? "…";
 }
 
-// ─── Subagent completion pill helpers ─────────────────────────────
+// ─── Subagent completion tracking ─────────────────────────────────
+// Maps turnIndex → agent IDs whose LAST read_agent appears in that turn.
+// Only one pill per subagent, positioned at the final read.
 
-function parseReadAgentId(tc: TurnToolCall): string | null {
+function parseAgentIdFromArgs(tc: TurnToolCall): string | null {
   try {
     const args = typeof tc.arguments === "string"
       ? JSON.parse(tc.arguments)
@@ -219,24 +221,40 @@ function parseReadAgentId(tc: TurnToolCall): string | null {
   }
 }
 
-function subagentCompleteLabel(tc: TurnToolCall): string {
-  const agentId = parseReadAgentId(tc);
-  if (agentId) {
-    const sa = subagentMap.value.get(agentId);
-    if (sa) {
-      const agentType = inferAgentTypeFromToolCall(sa.toolCall);
-      const label = agentType.charAt(0).toUpperCase() + agentType.slice(1);
-      return `${label} agent ${tc.success === false ? "failed" : "completed"}`;
+const completionsByTurn = computed(() => {
+  const lastReadByAgent = new Map<string, number>();
+
+  for (const turn of turns.value) {
+    for (const tc of turn.toolCalls) {
+      if (tc.toolName === "read_agent" && !tc.parentToolCallId) {
+        const agentId = parseAgentIdFromArgs(tc);
+        if (agentId && subagentMap.value.has(agentId)) {
+          lastReadByAgent.set(agentId, turn.turnIndex);
+        }
+      }
     }
   }
-  return tc.success === false ? "Agent failed" : "Agent completed";
-}
 
-function openSubagentFromReadAgent(tc: TurnToolCall) {
-  const agentId = parseReadAgentId(tc);
-  if (agentId) {
-    panel.selectSubagent(agentId);
+  const byTurn = new Map<number, string[]>();
+  for (const [agentId, turnIdx] of lastReadByAgent) {
+    const sa = subagentMap.value.get(agentId);
+    if (sa?.toolCall.isComplete) {
+      const list = byTurn.get(turnIdx) ?? [];
+      list.push(agentId);
+      byTurn.set(turnIdx, list);
+    }
   }
+  return byTurn;
+});
+
+function completionLabel(agentId: string): string {
+  const sa = subagentMap.value.get(agentId);
+  if (sa) {
+    const agentType = inferAgentTypeFromToolCall(sa.toolCall);
+    const label = agentType.charAt(0).toUpperCase() + agentType.slice(1);
+    return `${label} agent ${sa.toolCall.success === false ? "failed" : "completed"}`;
+  }
+  return "Agent completed";
 }
 
 // ─── ToolCallItem helpers ─────────────────────────────────────────
@@ -467,21 +485,6 @@ defineExpose({ revealEvent });
                           @retry-full-result="handleRetryResult"
                         />
 
-                        <!-- Subagent completion pill -->
-                        <div
-                          v-else-if="item.type === 'subagent-complete'"
-                          :class="['cv-subagent-complete-pill', item.toolCall.success === false ? 'failed' : 'completed']"
-                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
-                          role="button"
-                          tabindex="0"
-                          @click="openSubagentFromReadAgent(item.toolCall)"
-                          @keydown.enter="openSubagentFromReadAgent(item.toolCall)"
-                        >
-                          <span class="cv-pill-icon" aria-hidden="true">{{ item.toolCall.success === false ? '✗' : '✓' }}</span>
-                          <span class="cv-pill-label">{{ subagentCompleteLabel(item.toolCall) }}</span>
-                          <span v-if="item.toolCall.durationMs" class="cv-pill-duration">{{ formatDuration(item.toolCall.durationMs) }}</span>
-                        </div>
-
                         <!-- Regular tool row (with progressive disclosure) -->
                         <ToolCallItem
                           v-else-if="item.type === 'tool'"
@@ -550,6 +553,23 @@ defineExpose({ revealEvent });
                     </div>
                   </template>
                 </template>
+
+                <!-- Subagent completion pills (at the turn of their final read_agent) -->
+                <div
+                  v-for="agentId in (completionsByTurn.get(turn.turnIndex) ?? [])"
+                  :key="`complete-${agentId}`"
+                  :class="['cv-subagent-complete-pill', subagentMap.get(agentId)?.toolCall.success === false ? 'failed' : 'completed']"
+                  role="button"
+                  tabindex="0"
+                  @click="panel.selectSubagent(agentId)"
+                  @keydown.enter="panel.selectSubagent(agentId)"
+                >
+                  <span class="cv-pill-icon" aria-hidden="true">{{ subagentMap.get(agentId)?.toolCall.success === false ? '✗' : '✓' }}</span>
+                  <span class="cv-pill-label">{{ completionLabel(agentId) }}</span>
+                  <span v-if="subagentMap.get(agentId)?.toolCall.durationMs" class="cv-pill-duration">
+                    {{ formatDuration(subagentMap.get(agentId)!.toolCall.durationMs!) }}
+                  </span>
+                </div>
               </div>
             </template>
           </div>

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,0 +1,993 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
+import { useRoute } from "vue-router";
+import { useSessionDetailStore } from "@/stores/sessionDetail";
+import { usePreferencesStore } from "@/stores/preferences";
+import type { ConversationTurn, TurnToolCall, SessionEventSeverity } from "@tracepilot/types";
+import {
+  formatDuration,
+  formatTime,
+  formatNumber,
+  truncateText,
+  toolIcon,
+  formatArgsSummary,
+  ReasoningBlock,
+  MarkdownContent,
+  ToolCallItem,
+  useConversationSections,
+  useToggleSet,
+  getAgentColor,
+  getAgentIcon,
+  inferAgentTypeFromToolCall,
+} from "@tracepilot/ui";
+import { useCrossTurnSubagents } from "@/composables/useCrossTurnSubagents";
+import { useSubagentPanel } from "@/composables/useSubagentPanel";
+import { useToolResultLoader } from "@/composables/useToolResultLoader";
+import SubagentCard from "./SubagentCard.vue";
+import SubagentPanel from "./SubagentPanel.vue";
+import {
+  segmentToolCalls,
+  getMainReasoning,
+  getMainMessages,
+  MAX_VISIBLE_TOOLS,
+  COLLAPSE_THRESHOLD,
+  countRegularTools,
+  getCollapsedToolNames,
+  type ToolSegment,
+  type ToolGroupItem,
+} from "./chatViewUtils";
+
+// ─── Store & Route ────────────────────────────────────────────────
+
+const store = useSessionDetailStore();
+const preferences = usePreferencesStore();
+const route = useRoute();
+const turns = computed(() => store.turns);
+const renderMd = computed(() => preferences.isFeatureEnabled("renderMarkdown"));
+
+// ─── Cross-turn subagent data ─────────────────────────────────────
+
+const { subagentMap, allSubagents } = useCrossTurnSubagents(turns);
+
+// ─── Panel state ──────────────────────────────────────────────────
+
+const panel = useSubagentPanel(allSubagents);
+
+// ─── Disclosure state ─────────────────────────────────────────────
+
+const expandedReasoning = useToggleSet<string>();
+const expandedGroups = useToggleSet<string>();
+const expandedUserMsgs = useToggleSet<number>();
+const expandedToolDetails = useToggleSet<string>();
+
+// ─── Tool result loader ───────────────────────────────────────────
+
+const { fullResults, loadingResults, failedResults, loadFullResult: handleLoadFullResult, retryFullResult: handleRetryResult } = useToolResultLoader(
+  () => store.sessionId
+);
+
+// ─── Conversation sections (for tool call index) ─────────────────
+
+const { findToolCallIndex, getArgsSummary } = useConversationSections(() => store.turns);
+
+// ─── Scroll ───────────────────────────────────────────────────────
+
+const scrollEl = ref<HTMLElement | null>(null);
+
+// ─── Computed helpers ─────────────────────────────────────────────
+
+function showGap(turn: ConversationTurn, ti: number): boolean {
+  if (ti === 0) return false;
+  return turn.turnIndex - turns.value[ti - 1].turnIndex > 1;
+}
+
+function gapCount(turn: ConversationTurn, ti: number): number {
+  return turn.turnIndex - turns.value[ti - 1].turnIndex - 1;
+}
+
+function userEventId(turn: ConversationTurn): string | undefined {
+  return turn.eventIndex != null ? `event-${turn.eventIndex}` : undefined;
+}
+
+function mainReasoningForTurn(turn: ConversationTurn): string[] {
+  return getMainReasoning(turn);
+}
+
+function mainMessagesForTurn(turn: ConversationTurn) {
+  return getMainMessages(turn);
+}
+
+function toolSegmentsForTurn(turn: ConversationTurn): ToolSegment[] {
+  return segmentToolCalls(turn.toolCalls);
+}
+
+function severityClass(severity: SessionEventSeverity): string {
+  if (severity === "error") return "error";
+  if (severity === "warning") return "warning";
+  return "info";
+}
+
+function severityIcon(severity: SessionEventSeverity): string {
+  if (severity === "error") return "⚠️";
+  if (severity === "warning") return "⚠️";
+  return "ℹ️";
+}
+
+// ─── Progressive disclosure ───────────────────────────────────────
+
+function shouldCollapse(items: ToolGroupItem[]): boolean {
+  return countRegularTools(items) > MAX_VISIBLE_TOOLS + COLLAPSE_THRESHOLD;
+}
+
+function isItemVisible(
+  item: ToolGroupItem,
+  items: ToolGroupItem[],
+  itemIndex: number,
+  groupKey: string,
+): boolean {
+  // Pills (intent, memory, ask-user) are always visible
+  if (item.type !== "tool") return true;
+  // If group is expanded, everything visible
+  if (expandedGroups.has(groupKey)) return true;
+  // If no collapse needed, everything visible
+  if (!shouldCollapse(items)) return true;
+  // Count regular tools up to this index
+  let toolIdx = 0;
+  for (let i = 0; i <= itemIndex; i++) {
+    if (items[i].type === "tool") toolIdx++;
+  }
+  return toolIdx <= MAX_VISIBLE_TOOLS;
+}
+
+function hiddenToolCount(items: ToolGroupItem[]): number {
+  return countRegularTools(items) - MAX_VISIBLE_TOOLS;
+}
+
+// ─── User message truncation ──────────────────────────────────────
+
+const USER_MSG_MAX = 600;
+
+function isUserMsgLong(msg: string | undefined): boolean {
+  return (msg?.length ?? 0) > USER_MSG_MAX;
+}
+
+function displayUserMsg(msg: string, turnIndex: number): string {
+  if (expandedUserMsgs.has(turnIndex) || msg.length <= USER_MSG_MAX) {
+    return msg;
+  }
+  return msg.slice(0, USER_MSG_MAX);
+}
+
+// ─── Intent/memory pill helpers ───────────────────────────────────
+
+function intentLabel(tc: TurnToolCall): string {
+  const args = tc.arguments as Record<string, unknown> | undefined;
+  return (args?.intent as string) ?? "…";
+}
+
+function memoryLabel(tc: TurnToolCall): string {
+  const args = tc.arguments as Record<string, unknown> | undefined;
+  return (args?.fact as string) ?? (args?.subject as string) ?? "…";
+}
+
+// ─── ToolCallItem helpers ─────────────────────────────────────────
+
+function tcProps(turn: ConversationTurn, tc: TurnToolCall) {
+  const idx = findToolCallIndex(turn, tc);
+  const key = `${turn.turnIndex}-${idx}`;
+  return {
+    tc,
+    variant: "compact" as const,
+    argsSummary: getArgsSummary(turn.turnIndex, idx),
+    expanded: expandedToolDetails.has(key),
+    fullResult: tc.toolCallId ? fullResults.get(tc.toolCallId) : undefined,
+    loadingFullResult: tc.toolCallId ? loadingResults.has(tc.toolCallId) : false,
+    failedFullResult: tc.toolCallId ? failedResults.has(tc.toolCallId) : false,
+    richEnabled: preferences.isRichRenderingEnabled(tc.toolName),
+  };
+}
+
+function toggleToolDetail(turn: ConversationTurn, tc: TurnToolCall) {
+  const idx = findToolCallIndex(turn, tc);
+  expandedToolDetails.toggle(`${turn.turnIndex}-${idx}`);
+}
+
+// ─── Subagent turn colors ─────────────────────────────────────────
+
+/** Map turnIndex → agent color for turns that have subagent-owned content */
+const subagentTurnColors = computed(() => {
+  const map = new Map<number, string>();
+  for (const sa of allSubagents.value) {
+    const color = getAgentColor(inferAgentTypeFromToolCall(sa.toolCall));
+    // The launch turn
+    map.set(sa.turnIndex, color);
+    // Any turns where child tools appear
+    for (const ct of sa.childTools) {
+      const turn = turns.value.find(t => t.toolCalls.some(tc => tc.toolCallId === ct.toolCallId));
+      if (turn) map.set(turn.turnIndex, color);
+    }
+  }
+  return map;
+});
+
+// ─── Deep-link: revealEvent ───────────────────────────────────────
+
+/**
+ * Resolve an eventIndex to its owning subagent (if it's a child tool call).
+ * Returns the subagent's toolCallId, or null if the event is not a child.
+ */
+function findOwningSubagent(turnIndex: number, eventIndex: number): string | null {
+  const turn = turns.value.find(t => t.turnIndex === turnIndex);
+  if (!turn) return null;
+  const tc = turn.toolCalls.find(t => t.eventIndex === eventIndex);
+  if (!tc) return null;
+  // If this IS a subagent launch, return its own toolCallId
+  if (tc.isSubagent && tc.toolCallId) return tc.toolCallId;
+  // If this is a child tool call, return its parent
+  if (tc.parentToolCallId && subagentMap.value.has(tc.parentToolCallId)) {
+    return tc.parentToolCallId;
+  }
+  return null;
+}
+
+function revealEvent(turnIndex: number, eventIndex?: number) {
+  const elId = eventIndex != null ? `event-${eventIndex}` : `turn-${turnIndex}`;
+  let el = document.getElementById(elId);
+
+  // If event not in DOM, check if it belongs to a subagent and open the panel
+  if (!el && eventIndex != null) {
+    const agentId = findOwningSubagent(turnIndex, eventIndex);
+    if (agentId) {
+      panel.selectSubagent(agentId);
+      // Scroll to the subagent card wrapper instead
+      const cardEl = document.querySelector(`[data-agent-id="${agentId}"]`) as HTMLElement | null;
+      if (cardEl) el = cardEl;
+    }
+  }
+
+  if (!el) {
+    // Final fallback: scroll to the turn block
+    el = document.getElementById(`turn-${turnIndex}`);
+    if (!el) return;
+  }
+
+  // If the element is inside a collapsed group, expand it
+  const collapsedParent = el.closest("[data-collapse-key]") as HTMLElement | null;
+  if (collapsedParent) {
+    const key = collapsedParent.dataset.collapseKey;
+    if (key && !expandedGroups.has(key)) {
+      expandedGroups.toggle(key);
+    }
+  }
+
+  // If tool call belongs to a subagent, open the panel
+  const agentEl = el.closest("[data-agent-id]") as HTMLElement | null;
+  if (agentEl) {
+    const agentId = agentEl.dataset.agentId;
+    if (agentId) {
+      panel.selectSubagent(agentId);
+    }
+  }
+
+  nextTick(() => {
+    el!.scrollIntoView({ behavior: "smooth", block: "center" });
+    el!.classList.add("cv-highlight");
+    setTimeout(() => el!.classList.remove("cv-highlight"), 4000);
+  });
+}
+
+defineExpose({ revealEvent });
+</script>
+
+<template>
+  <div class="cv-root">
+    <!-- Main column (shrinks when panel is open) -->
+    <div :class="['cv-main', { 'panel-open': panel.isPanelOpen.value }]">
+      <div class="cv-scroll" ref="scrollEl">
+        <div class="cv-content">
+          <div class="cv-stream">
+            <template v-for="(turn, ti) in turns" :key="turn.turnIndex">
+              <!-- Gap indicator -->
+              <div v-if="showGap(turn, ti)" class="cv-gap">
+                <div class="cv-gap-line" />
+                <div class="cv-gap-label">⋯ {{ gapCount(turn, ti) }} turns not shown</div>
+                <div class="cv-gap-line" />
+              </div>
+
+              <!-- Session events -->
+              <div
+                v-for="evt in (turn.sessionEvents ?? [])"
+                :key="evt.timestamp"
+                :class="['cv-session-event', severityClass(evt.severity)]"
+              >
+                <span class="cv-session-event-icon">{{ severityIcon(evt.severity) }}</span>
+                <span class="cv-session-event-type">{{ evt.eventType }}</span>
+                <span class="cv-session-event-summary">{{ evt.summary }}</span>
+                <span v-if="evt.timestamp" class="cv-session-event-time">
+                  {{ formatTime(evt.timestamp) }}
+                </span>
+              </div>
+
+              <!-- User message anchor -->
+              <div
+                v-if="turn.userMessage"
+                class="cv-user-anchor"
+                :id="userEventId(turn)"
+              >
+                <div class="cv-user-header">
+                  <span class="cv-user-avatar" aria-hidden="true">👤</span>
+                  <span class="cv-user-name">User</span>
+                  <span class="cv-user-turn">T{{ turn.turnIndex }}</span>
+                  <span v-if="turn.timestamp" class="cv-user-time">
+                    {{ formatTime(turn.timestamp) }}
+                  </span>
+                </div>
+                <div class="cv-user-body">
+                  <div
+                    :class="['cv-user-text', {
+                      'cv-user-text--clamped': isUserMsgLong(turn.userMessage) && !expandedUserMsgs.has(turn.turnIndex)
+                    }]"
+                  >
+                    <MarkdownContent :content="displayUserMsg(turn.userMessage, turn.turnIndex)" :render="renderMd" />
+                  </div>
+                  <button
+                    v-if="isUserMsgLong(turn.userMessage)"
+                    class="cv-user-expand"
+                    :aria-expanded="expandedUserMsgs.has(turn.turnIndex)"
+                    aria-label="Toggle full message"
+                    @click="expandedUserMsgs.toggle(turn.turnIndex)"
+                  >
+                    {{ expandedUserMsgs.has(turn.turnIndex) ? 'Show less ↑' : 'Show more ↓' }}
+                  </button>
+                </div>
+              </div>
+
+              <!-- Turn block with timeline line -->
+              <div
+                class="cv-turn-block"
+                :data-turn="`T${turn.turnIndex}`"
+                :id="`turn-${turn.turnIndex}`"
+                :style="subagentTurnColors.get(turn.turnIndex) ? { borderLeft: `3px solid ${subagentTurnColors.get(turn.turnIndex)}`, paddingLeft: '12px' } : {}"
+              >
+                <!-- Main reasoning -->
+                <ReasoningBlock
+                  v-for="(reasoning, rIdx) in mainReasoningForTurn(turn)"
+                  :key="`r-${turn.turnIndex}-${rIdx}`"
+                  :reasoning="[reasoning]"
+                  :expanded="expandedReasoning.has(`${turn.turnIndex}-main-${rIdx}`)"
+                  @toggle="expandedReasoning.toggle(`${turn.turnIndex}-main-${rIdx}`)"
+                />
+
+                <!-- Main messages -->
+                <div
+                  v-for="(msg, mIdx) in mainMessagesForTurn(turn)"
+                  :key="`m-${turn.turnIndex}-${mIdx}`"
+                  class="cv-agent-bubble"
+                >
+                  <div class="cv-agent-bubble-header">
+                    <span class="cv-agent-avatar" aria-hidden="true">🤖</span>
+                    <span class="cv-agent-name">Copilot</span>
+                  </div>
+                  <MarkdownContent :content="msg.content" :render="renderMd" />
+                </div>
+
+                <!-- Tool segments -->
+                <template
+                  v-for="(segment, sIdx) in toolSegmentsForTurn(turn)"
+                  :key="`seg-${turn.turnIndex}-${sIdx}`"
+                >
+                  <!-- Tool group -->
+                  <template v-if="segment.type === 'tool-group'">
+                    <div
+                      class="cv-tool-group"
+                      :data-collapse-key="`${turn.turnIndex}-group-${sIdx}`"
+                    >
+                      <template v-for="(item, iIdx) in segment.items" :key="iIdx">
+                        <!-- Intent pill -->
+                        <div
+                          v-if="item.type === 'intent'"
+                          class="cv-intent-pill"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                        >
+                          <span class="cv-pill-icon" aria-hidden="true">🎯</span>
+                          <span class="cv-pill-label">{{ intentLabel(item.toolCall) }}</span>
+                        </div>
+
+                        <!-- Memory pill -->
+                        <div
+                          v-else-if="item.type === 'memory'"
+                          class="cv-memory-pill"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                        >
+                          <span class="cv-pill-icon" aria-hidden="true">🧠</span>
+                          <span class="cv-pill-label">{{ truncateText(memoryLabel(item.toolCall), 80) }}</span>
+                        </div>
+
+                        <!-- Ask-user card -->
+                        <div
+                          v-else-if="item.type === 'ask-user'"
+                          class="cv-ask-user-card"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                        >
+                          <div class="cv-ask-user-header">
+                            <span aria-hidden="true">💬</span>
+                            <span>Asked User</span>
+                          </div>
+                          <div v-if="item.toolCall.resultContent" class="cv-ask-user-body">
+                            {{ truncateText(item.toolCall.resultContent, 300) }}
+                          </div>
+                        </div>
+
+                        <!-- Regular tool row (with progressive disclosure) -->
+                        <ToolCallItem
+                          v-else-if="item.type === 'tool'"
+                          v-show="isItemVisible(item, segment.items, iIdx, `${turn.turnIndex}-group-${sIdx}`)"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                          v-bind="tcProps(turn, item.toolCall)"
+                          @toggle="toggleToolDetail(turn, item.toolCall)"
+                          @load-full-result="handleLoadFullResult"
+                          @retry-full-result="handleRetryResult"
+                        />
+                      </template>
+
+                      <!-- Collapse toggle -->
+                      <button
+                        v-if="shouldCollapse(segment.items) && !expandedGroups.has(`${turn.turnIndex}-group-${sIdx}`)"
+                        class="cv-collapsed-toggle"
+                        :aria-expanded="false"
+                        @click="expandedGroups.toggle(`${turn.turnIndex}-group-${sIdx}`)"
+                      >
+                        <span class="cv-collapsed-toggle-label">
+                          Show {{ hiddenToolCount(segment.items) }} more tools
+                        </span>
+                        <span class="cv-collapsed-toggle-tags">
+                          <span
+                            v-for="name in getCollapsedToolNames(segment.items, MAX_VISIBLE_TOOLS)"
+                            :key="name"
+                            class="cv-collapsed-tag"
+                          >{{ name }}</span>
+                        </span>
+                      </button>
+
+                      <button
+                        v-if="shouldCollapse(segment.items) && expandedGroups.has(`${turn.turnIndex}-group-${sIdx}`)"
+                        class="cv-collapsed-toggle"
+                        :aria-expanded="true"
+                        @click="expandedGroups.toggle(`${turn.turnIndex}-group-${sIdx}`)"
+                      >
+                        <span class="cv-collapsed-toggle-label">Show fewer tools</span>
+                      </button>
+                    </div>
+                  </template>
+
+                  <!-- Subagent group -->
+                  <template v-if="segment.type === 'subagent-group'">
+                    <div
+                      v-if="segment.subagents.length > 1"
+                      class="cv-parallel-header"
+                      aria-hidden="true"
+                    >
+                      ⚡ {{ segment.subagents.length }} agents launched in parallel
+                    </div>
+                    <div :class="{ 'cv-parallel-stack': segment.subagents.length > 1 }">
+                      <div
+                        v-for="sa in segment.subagents"
+                        :key="sa.toolCallId"
+                        :id="sa.eventIndex != null ? `event-${sa.eventIndex}` : undefined"
+                        :data-agent-id="sa.toolCallId"
+                      >
+                        <SubagentCard
+                          :tool-call="sa"
+                          :child-tool-count="subagentMap.get(sa.toolCallId!)?.childTools.length ?? 0"
+                          :selected="panel.selectedAgentId.value === sa.toolCallId"
+                          @select="panel.selectSubagent"
+                        />
+                      </div>
+                    </div>
+                  </template>
+
+                  <!-- Read agent check -->
+                  <template v-if="segment.type === 'read-agent-pill'">
+                    <div
+                      :class="['cv-read-agent-check', {
+                        complete: segment.toolCall.isComplete && segment.toolCall.success !== false,
+                        failed: segment.toolCall.success === false
+                      }]"
+                      :id="segment.toolCall.eventIndex != null ? `event-${segment.toolCall.eventIndex}` : undefined"
+                    >
+                      <span class="cv-check-icon">{{ !segment.toolCall.isComplete ? '⏳' : segment.toolCall.success === false ? '✗' : '✓' }}</span>
+                      <span class="cv-check-text">{{ (segment.toolCall.arguments as any)?.agent_id ?? 'agent' }}</span>
+                    </div>
+                  </template>
+                </template>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Subagent panel (includes its own overlay) -->
+    <SubagentPanel
+      :subagent="panel.selectedSubagent.value"
+      :is-open="panel.isPanelOpen.value"
+      :current-index="panel.selectedIndex.value"
+      :total-count="allSubagents.length"
+      :has-prev="panel.hasPrev.value"
+      :has-next="panel.hasNext.value"
+      @close="panel.closePanel"
+      @prev="panel.navigatePrev"
+      @next="panel.navigateNext"
+    />
+  </div>
+</template>
+
+<style scoped>
+/* ─── Root layout ──────────────────────────────────────────────── */
+
+.cv-root {
+  display: flex;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.cv-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: margin-right var(--transition-normal, 0.2s) ease;
+}
+
+.cv-main.panel-open {
+  margin-right: 38%;
+}
+
+@media (max-width: 959px) {
+  .cv-main.panel-open {
+    margin-right: 0;
+  }
+}
+
+.cv-scroll {
+  flex: 1;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}
+
+.cv-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px 32px 80px;
+}
+
+.cv-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ─── Gap indicator ────────────────────────────────────────────── */
+
+.cv-gap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.cv-gap-line {
+  flex: 1;
+  height: 0;
+  border-top: 1px dashed var(--border-muted, #484f58);
+}
+
+.cv-gap-label {
+  font-size: 12px;
+  color: var(--text-placeholder, #6e7681);
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* ─── Session events ───────────────────────────────────────────── */
+
+.cv-session-event {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--radius-md, 8px);
+  font-size: 12px;
+  margin: 4px 0;
+}
+
+.cv-session-event.info {
+  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
+  color: var(--text-secondary, #8b949e);
+}
+
+.cv-session-event.warning {
+  background: var(--warning-subtle, rgba(210, 153, 34, 0.1));
+  color: var(--warning-fg, #d29922);
+}
+
+.cv-session-event.error {
+  background: var(--danger-subtle, rgba(248, 81, 73, 0.1));
+  color: var(--danger-fg, #f85149);
+}
+
+.cv-session-event-icon {
+  flex-shrink: 0;
+}
+
+.cv-session-event-type {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.cv-session-event-summary {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-session-event-time {
+  flex-shrink: 0;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+/* ─── User message anchor ──────────────────────────────────────── */
+
+.cv-user-anchor {
+  border-left: 3px solid var(--accent-emphasis, #1f6feb);
+  background: var(--canvas-subtle, #161b22);
+  border-radius: 0 var(--radius-md, 8px) var(--radius-md, 8px) 0;
+  padding: 12px 16px;
+  margin: 12px 0 4px;
+}
+
+.cv-user-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.cv-user-avatar {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.cv-user-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--accent-fg, #58a6ff);
+}
+
+.cv-user-turn {
+  font-size: 11px;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--text-placeholder, #6e7681);
+}
+
+.cv-user-time {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-placeholder, #6e7681);
+}
+
+.cv-user-body {
+  position: relative;
+}
+
+.cv-user-text {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-primary, #c9d1d9);
+  overflow-wrap: break-word;
+}
+
+.cv-user-text--clamped {
+  mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
+}
+
+.cv-user-expand {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  color: var(--accent-fg, #58a6ff);
+  background: none;
+  border: 1px solid var(--border-muted, #484f58);
+  border-radius: var(--radius-full, 100px);
+  cursor: pointer;
+  transition: background var(--transition-fast, 0.1s) ease;
+}
+
+.cv-user-expand:hover {
+  background: var(--accent-subtle, rgba(56, 139, 253, 0.1));
+}
+
+/* ─── Turn block + timeline ────────────────────────────────────── */
+
+.cv-turn-block {
+  position: relative;
+  padding-left: 20px;
+  padding-top: 4px;
+  padding-bottom: 8px;
+}
+
+.cv-turn-block::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 7px;
+  width: 1px;
+  background: var(--border-muted, #484f58);
+  pointer-events: none;
+}
+
+.cv-turn-block::before {
+  content: attr(data-turn);
+  position: absolute;
+  left: -2px;
+  top: 8px;
+  font-size: 10px;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--text-placeholder, #6e7681);
+  background: var(--canvas-default, #0d1117);
+  padding: 0 3px;
+  border-radius: var(--radius-sm, 4px);
+  opacity: 0;
+  transition: opacity var(--transition-fast, 0.1s) ease;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.cv-turn-block:hover::before {
+  opacity: 1;
+}
+
+/* ─── Agent bubble ─────────────────────────────────────────────── */
+
+.cv-agent-bubble {
+  background: var(--canvas-subtle, #161b22);
+  border-radius: var(--radius-md, 8px);
+  padding: 12px 16px;
+  margin: 6px 0;
+}
+
+.cv-agent-bubble-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #8b949e);
+  margin-bottom: 6px;
+}
+
+.cv-agent-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  border-radius: var(--radius-full, 100px);
+  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
+  font-size: 13px;
+  line-height: 1;
+}
+
+.cv-agent-name {
+  font-weight: 600;
+}
+
+/* ─── Tool group ───────────────────────────────────────────────── */
+
+.cv-tool-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 4px 0;
+}
+
+/* ─── Intent pill ──────────────────────────────────────────────── */
+
+.cv-intent-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--accent-subtle, rgba(56, 139, 253, 0.1));
+  border: 1px solid var(--accent-muted, rgba(56, 139, 253, 0.2));
+  border-radius: var(--radius-full, 100px);
+  font-size: 12px;
+  color: var(--accent-fg, #58a6ff);
+  max-width: 100%;
+  margin: 2px 0;
+}
+
+.cv-intent-pill .cv-pill-icon {
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.cv-intent-pill .cv-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Memory pill ──────────────────────────────────────────────── */
+
+.cv-memory-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--done-subtle, rgba(163, 113, 247, 0.1));
+  border: 1px solid color-mix(in srgb, var(--done-fg, #a371f7) 30%, transparent);
+  border-radius: var(--radius-full, 100px);
+  font-size: 12px;
+  color: var(--done-fg, #a371f7);
+  max-width: 100%;
+  margin: 2px 0;
+}
+
+.cv-memory-pill .cv-pill-icon {
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.cv-memory-pill .cv-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Ask-user card ────────────────────────────────────────────── */
+
+.cv-ask-user-card {
+  background: var(--warning-subtle, rgba(210, 153, 34, 0.1));
+  border: 1px solid var(--warning-muted, rgba(210, 153, 34, 0.2));
+  border-radius: var(--radius-md, 8px);
+  padding: 10px 14px;
+  margin: 4px 0;
+}
+
+.cv-ask-user-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--warning-fg, #d29922);
+  margin-bottom: 4px;
+}
+
+.cv-ask-user-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary, #c9d1d9);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+/* ─── Read agent check (subtle inline) ─────────────────────────── */
+
+.cv-read-agent-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-tertiary, #484f58);
+  padding: 1px 0;
+}
+
+.cv-read-agent-check.complete .cv-check-icon {
+  color: var(--success-fg, #3fb950);
+}
+
+.cv-read-agent-check.failed .cv-check-icon {
+  color: var(--danger-fg, #f85149);
+}
+
+.cv-check-text {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+/* ─── Parallel subagent layout ─────────────────────────────────── */
+
+.cv-parallel-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--warning-fg, #d29922);
+  padding: 6px 0 2px;
+  user-select: none;
+}
+
+.cv-parallel-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-left: 2px solid var(--warning-emphasis, #d29922);
+  padding-left: 12px;
+  margin-left: 4px;
+}
+
+/* ─── Collapse toggle ──────────────────────────────────────────── */
+
+.cv-collapsed-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--canvas-inset, #010409);
+  border: 1px dashed var(--border-muted, #484f58);
+  border-radius: var(--radius-sm, 4px);
+  color: var(--accent-fg, #58a6ff);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background var(--transition-fast, 0.1s) ease;
+}
+
+.cv-collapsed-toggle:hover {
+  background: var(--accent-subtle, rgba(56, 139, 253, 0.1));
+}
+
+.cv-collapsed-toggle-label {
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.cv-collapsed-toggle-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.cv-collapsed-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
+  border-radius: var(--radius-sm, 4px);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--text-tertiary, #484f58);
+  white-space: nowrap;
+}
+
+/* ─── Deep-link highlight animation ────────────────────────────── */
+
+@keyframes cv-flash {
+  0% {
+    box-shadow: 0 0 0 2px var(--accent-emphasis, #1f6feb);
+  }
+  50% {
+    box-shadow: 0 0 0 4px var(--accent-muted, rgba(56, 139, 253, 0.2));
+  }
+  100% {
+    box-shadow: none;
+  }
+}
+
+.cv-highlight {
+  animation: cv-flash 2s ease-out 2;
+  border-radius: var(--radius-sm, 4px);
+}
+</style>

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -529,9 +529,12 @@ defineExpose({ revealEvent });
   transition: margin-right var(--transition-normal, 0.2s) ease;
 }
 
+.cv-main.panel-open {
+  margin-right: min(38%, 650px);
+}
+
 .cv-main.panel-open .cv-content {
   max-width: none;
-  margin-right: 0;
 }
 
 @media (max-width: 959px) {

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -207,48 +207,67 @@ function memoryLabel(tc: TurnToolCall): string {
 }
 
 // ─── Subagent completion tracking ─────────────────────────────────
-// Maps turnIndex → agent IDs whose LAST read_agent appears in that turn.
+// Maps turnIndex → subagent toolCallIds whose LAST read_agent appears in that turn.
 // Only one pill per subagent, positioned at the final read.
+// Bridge: read_agent uses agent_name (e.g. "explore-rust-backend") while
+// subagentMap is keyed by toolCallId (e.g. "tooluse_QVH..."). The launch
+// tool call's arguments.name provides the bridge.
 
-function parseAgentIdFromArgs(tc: TurnToolCall): string | null {
+function parseAgentNameFromReadAgent(tc: TurnToolCall): string | null {
   try {
     const args = typeof tc.arguments === "string"
       ? JSON.parse(tc.arguments)
-      : tc.arguments;
+      : (tc.arguments as Record<string, unknown> | null);
     return (args?.agent_id as string) ?? null;
   } catch {
     return null;
   }
 }
 
+/** Reverse map: agent launch name → subagentMap toolCallId */
+const agentNameToToolCallId = computed(() => {
+  const map = new Map<string, string>();
+  for (const [toolCallId, sa] of subagentMap.value) {
+    const args = sa.toolCall.arguments as Record<string, unknown> | undefined;
+    const name = (args?.name as string) ?? undefined;
+    if (name) {
+      map.set(name, toolCallId);
+    }
+  }
+  return map;
+});
+
 const completionsByTurn = computed(() => {
-  const lastReadByAgent = new Map<string, number>();
+  const lastReadByAgent = new Map<string, number>(); // toolCallId → turnIndex
 
   for (const turn of turns.value) {
     for (const tc of turn.toolCalls) {
       if (tc.toolName === "read_agent" && !tc.parentToolCallId) {
-        const agentId = parseAgentIdFromArgs(tc);
-        if (agentId && subagentMap.value.has(agentId)) {
-          lastReadByAgent.set(agentId, turn.turnIndex);
+        const agentName = parseAgentNameFromReadAgent(tc);
+        if (agentName) {
+          const toolCallId = agentNameToToolCallId.value.get(agentName);
+          if (toolCallId) {
+            lastReadByAgent.set(toolCallId, turn.turnIndex);
+          }
         }
       }
     }
   }
 
   const byTurn = new Map<number, string[]>();
-  for (const [agentId, turnIdx] of lastReadByAgent) {
-    const sa = subagentMap.value.get(agentId);
+  for (const [toolCallId, turnIdx] of lastReadByAgent) {
+    const sa = subagentMap.value.get(toolCallId);
     if (sa?.toolCall.isComplete) {
       const list = byTurn.get(turnIdx) ?? [];
-      list.push(agentId);
+      list.push(toolCallId);
       byTurn.set(turnIdx, list);
     }
   }
   return byTurn;
 });
 
-function completionLabel(agentId: string): string {
-  const sa = subagentMap.value.get(agentId);
+function completionLabel(toolCallId: string): string {
+  const sa = subagentMap.value.get(toolCallId);
   if (sa) {
     const agentType = inferAgentTypeFromToolCall(sa.toolCall);
     const label = agentType.charAt(0).toUpperCase() + agentType.slice(1);

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -106,7 +106,21 @@ onUnmounted(() => {
   if (pageScrollEl) {
     pageScrollEl.removeEventListener("scroll", updatePanelTop);
   }
+  // Clean up ancestor class on unmount
+  cvRootEl.value?.closest('.page-content-inner')?.classList.remove('panel-open-layout');
 });
+
+// ─── Shift page-content-inner layout when panel opens ─────────────
+
+watch(
+  () => panel.isPanelOpen.value,
+  (open) => {
+    const inner = cvRootEl.value?.closest('.page-content-inner');
+    if (inner) {
+      inner.classList.toggle('panel-open-layout', open);
+    }
+  },
+);
 
 // ─── Computed helpers ─────────────────────────────────────────────
 

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -3,7 +3,7 @@ import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useSessionDetailStore } from "@/stores/sessionDetail";
 import { usePreferencesStore } from "@/stores/preferences";
-import type { ConversationTurn, TurnToolCall, SessionEventSeverity } from "@tracepilot/types";
+import type { ConversationTurn, TurnToolCall, SessionEventSeverity, AttributedMessage } from "@tracepilot/types";
 import {
   formatDuration,
   formatTime,
@@ -140,17 +140,44 @@ function userEventId(turn: ConversationTurn): string | undefined {
   return turn.eventIndex != null ? `event-${turn.eventIndex}` : undefined;
 }
 
-function mainReasoningForTurn(turn: ConversationTurn): string[] {
-  return getMainReasoning(turn);
+// ─── Memoized per-turn render data ────────────────────────────────
+// Computed once when turns change, avoids re-segmenting on every render.
+
+interface TurnRenderData {
+  reasoning: string[];
+  messages: AttributedMessage[];
+  segments: ToolSegment[];
 }
 
-function mainMessagesForTurn(turn: ConversationTurn) {
-  return getMainMessages(turn);
+const turnRenderData = computed(() => {
+  const map = new Map<number, TurnRenderData>();
+  for (const turn of turns.value) {
+    map.set(turn.turnIndex, {
+      reasoning: getMainReasoning(turn),
+      messages: getMainMessages(turn),
+      segments: segmentToolCalls(turn.toolCalls),
+    });
+  }
+  return map;
+});
+
+function renderDataFor(turn: ConversationTurn): TurnRenderData {
+  return turnRenderData.value.get(turn.turnIndex) ?? { reasoning: [], messages: [], segments: [] };
 }
 
-function toolSegmentsForTurn(turn: ConversationTurn): ToolSegment[] {
-  return segmentToolCalls(turn.toolCalls);
-}
+// ─── toolCallId → turnIndex index (O(1) lookups) ─────────────────
+
+const toolCallTurnIndex = computed(() => {
+  const map = new Map<string, number>();
+  for (const turn of turns.value) {
+    for (const tc of turn.toolCalls) {
+      if (tc.toolCallId) {
+        map.set(tc.toolCallId, turn.turnIndex);
+      }
+    }
+  }
+  return map;
+});
 
 function severityClass(severity: SessionEventSeverity): string {
   if (severity === "error") return "error";
@@ -305,12 +332,12 @@ const subagentTurnColors = computed(() => {
   const map = new Map<number, string>();
   for (const sa of allSubagents.value) {
     const color = getAgentColor(inferAgentTypeFromToolCall(sa.toolCall));
-    // The launch turn
     map.set(sa.turnIndex, color);
-    // Any turns where child tools appear
     for (const ct of sa.childTools) {
-      const turn = turns.value.find(t => t.toolCalls.some(tc => tc.toolCallId === ct.toolCallId));
-      if (turn) map.set(turn.turnIndex, color);
+      if (ct.toolCallId) {
+        const turnIdx = toolCallTurnIndex.value.get(ct.toolCallId);
+        if (turnIdx != null) map.set(turnIdx, color);
+      }
     }
   }
   return map;
@@ -442,7 +469,7 @@ defineExpose({ revealEvent });
               >
                 <!-- Main reasoning -->
                 <ReasoningBlock
-                  v-for="(reasoning, rIdx) in mainReasoningForTurn(turn)"
+                  v-for="(reasoning, rIdx) in renderDataFor(turn).reasoning"
                   :key="`r-${turn.turnIndex}-${rIdx}`"
                   :reasoning="[reasoning]"
                   :expanded="expandedReasoning.has(`${turn.turnIndex}-main-${rIdx}`)"
@@ -451,20 +478,23 @@ defineExpose({ revealEvent });
 
                 <!-- Main messages -->
                 <div
-                  v-for="(msg, mIdx) in mainMessagesForTurn(turn)"
+                  v-for="(msg, mIdx) in renderDataFor(turn).messages"
                   :key="`m-${turn.turnIndex}-${mIdx}`"
                   class="cv-agent-bubble"
                 >
                   <div class="cv-agent-bubble-header">
                     <span class="cv-agent-avatar" aria-hidden="true">🤖</span>
                     <span class="cv-agent-name">Copilot</span>
+                    <span v-if="turn.timestamp" class="cv-agent-time">
+                      {{ formatTime(turn.timestamp) }}
+                    </span>
                   </div>
                   <MarkdownContent :content="msg.content" :render="renderMd" />
                 </div>
 
                 <!-- Tool segments -->
                 <template
-                  v-for="(segment, sIdx) in toolSegmentsForTurn(turn)"
+                  v-for="(segment, sIdx) in renderDataFor(turn).segments"
                   :key="`seg-${turn.turnIndex}-${sIdx}`"
                 >
                   <!-- Tool group -->
@@ -864,6 +894,13 @@ defineExpose({ revealEvent });
 
 .cv-agent-name {
   font-weight: 600;
+}
+
+.cv-agent-time {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-placeholder, #6e7681);
+  font-weight: 400;
 }
 
 /* ─── Tool group ───────────────────────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
+import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useSessionDetailStore } from "@/stores/sessionDetail";
 import { usePreferencesStore } from "@/stores/preferences";
@@ -80,8 +80,9 @@ const panelTopPx = ref(0);
 let pageScrollEl: HTMLElement | null = null;
 
 function updatePanelTop() {
-  const cvRect = cvRootEl.value?.getBoundingClientRect();
-  if (!cvRect) return;
+  const cvRoot = cvRootEl.value;
+  if (!cvRoot) return;
+  const cvRect = cvRoot.getBoundingClientRect();
 
   // Find the sticky action bar (.detail-actions) — it sticks at top of scroll area
   const actionsEl = document.querySelector('.detail-actions') as HTMLElement | null;
@@ -89,6 +90,22 @@ function updatePanelTop() {
 
   // Panel top = whichever is lower: cv-root top or sticky bar bottom
   panelTopPx.value = Math.max(cvRect.top, actionsBottom);
+
+  // Compute breakout offsets so .cv-root can extend beyond .page-content-inner
+  // when the panel is open, without affecting sibling elements (toolbar, badges, etc.)
+  const pc = cvRoot.closest('.page-content') as HTMLElement | null;
+  const pci = cvRoot.closest('.page-content-inner') as HTMLElement | null;
+  if (pc && pci) {
+    const pcStyle = getComputedStyle(pc);
+    const padL = parseFloat(pcStyle.paddingLeft) || 0;
+    const padR = parseFloat(pcStyle.paddingRight) || 0;
+    const pcContentWidth = pc.clientWidth - padL - padR;
+    const pciWidth = pci.offsetWidth;
+    const sideGap = Math.max(0, (pcContentWidth - pciWidth) / 2);
+    cvRoot.style.setProperty('--breakout-left', `${sideGap}px`);
+    // Extend right through page-content padding so content meets the panel edge
+    cvRoot.style.setProperty('--breakout-right', `${sideGap + padR}px`);
+  }
 }
 
 onMounted(() => {
@@ -106,21 +123,7 @@ onUnmounted(() => {
   if (pageScrollEl) {
     pageScrollEl.removeEventListener("scroll", updatePanelTop);
   }
-  // Clean up ancestor class on unmount
-  cvRootEl.value?.closest('.page-content-inner')?.classList.remove('panel-open-layout');
 });
-
-// ─── Shift page-content-inner layout when panel opens ─────────────
-
-watch(
-  () => panel.isPanelOpen.value,
-  (open) => {
-    const inner = cvRootEl.value?.closest('.page-content-inner');
-    if (inner) {
-      inner.classList.toggle('panel-open-layout', open);
-    }
-  },
-);
 
 // ─── Computed helpers ─────────────────────────────────────────────
 
@@ -313,7 +316,7 @@ defineExpose({ revealEvent });
 </script>
 
 <template>
-  <div class="cv-root" ref="cvRootEl">
+  <div :class="['cv-root', { 'panel-active': panel.isPanelOpen.value }]" ref="cvRootEl">
     <!-- Main column (shrinks when panel is open) -->
     <div :class="['cv-main', { 'panel-open': panel.isPanelOpen.value }]">
       <div class="cv-scroll" ref="scrollEl">
@@ -533,6 +536,12 @@ defineExpose({ revealEvent });
 .cv-root {
   display: flex;
   position: relative;
+  transition: margin var(--transition-normal, 0.2s) ease;
+}
+
+.cv-root.panel-active {
+  margin-left: calc(-1 * var(--breakout-left, 0px));
+  margin-right: calc(-1 * var(--breakout-right, 0px));
 }
 
 .cv-main {
@@ -544,7 +553,7 @@ defineExpose({ revealEvent });
 }
 
 .cv-main.panel-open {
-  margin-right: min(38%, 650px);
+  margin-right: min(38vw, 650px);
 }
 
 .cv-main.panel-open .cv-content {

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, onUnmounted } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useSessionDetailStore } from "@/stores/sessionDetail";
 import { usePreferencesStore } from "@/stores/preferences";
@@ -74,31 +74,38 @@ const { findToolCallIndex, getArgsSummary } = useConversationSections(() => stor
 const scrollEl = ref<HTMLElement | null>(null);
 const cvRootEl = ref<HTMLElement | null>(null);
 
-// ─── Panel top offset (fixed position below page header) ──────────
+// ─── Panel top offset (fixed position below sticky action bar) ────
 
 const panelTopPx = ref(0);
+let pageScrollEl: HTMLElement | null = null;
 
 function updatePanelTop() {
-  if (cvRootEl.value) {
-    panelTopPx.value = cvRootEl.value.getBoundingClientRect().top;
-  }
-}
+  const cvRect = cvRootEl.value?.getBoundingClientRect();
+  if (!cvRect) return;
 
-let panelTopRO: ResizeObserver | null = null;
+  // Find the sticky action bar (.detail-actions) — it sticks at top of scroll area
+  const actionsEl = document.querySelector('.detail-actions') as HTMLElement | null;
+  const actionsBottom = actionsEl ? actionsEl.getBoundingClientRect().bottom : 0;
+
+  // Panel top = whichever is lower: cv-root top or sticky bar bottom
+  panelTopPx.value = Math.max(cvRect.top, actionsBottom);
+}
 
 onMounted(() => {
   updatePanelTop();
   window.addEventListener("resize", updatePanelTop);
-  // Use a ResizeObserver on the parent to catch layout shifts (stat cards loading, etc.)
-  if (cvRootEl.value?.parentElement) {
-    panelTopRO = new ResizeObserver(updatePanelTop);
-    panelTopRO.observe(cvRootEl.value.parentElement);
+  // Listen to scroll on the page-content container (the page scroller)
+  pageScrollEl = cvRootEl.value?.closest('.page-content') as HTMLElement | null;
+  if (pageScrollEl) {
+    pageScrollEl.addEventListener("scroll", updatePanelTop, { passive: true });
   }
 });
 
 onUnmounted(() => {
   window.removeEventListener("resize", updatePanelTop);
-  panelTopRO?.disconnect();
+  if (pageScrollEl) {
+    pageScrollEl.removeEventListener("scroll", updatePanelTop);
+  }
 });
 
 // ─── Computed helpers ─────────────────────────────────────────────
@@ -511,21 +518,20 @@ defineExpose({ revealEvent });
 
 .cv-root {
   display: flex;
-  height: 100%;
   position: relative;
-  overflow: hidden;
 }
 
 .cv-main {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  min-width: 0;
   transition: margin-right var(--transition-normal, 0.2s) ease;
 }
 
-.cv-main.panel-open {
-  margin-right: 38%;
+.cv-main.panel-open .cv-content {
+  max-width: none;
+  margin-right: 0;
 }
 
 @media (max-width: 959px) {
@@ -536,8 +542,6 @@ defineExpose({ revealEvent });
 
 .cv-scroll {
   flex: 1;
-  overflow-y: auto;
-  scroll-behavior: smooth;
 }
 
 .cv-content {

--- a/apps/desktop/src/components/conversation/SubagentCard.vue
+++ b/apps/desktop/src/components/conversation/SubagentCard.vue
@@ -43,8 +43,7 @@ const description = computed(() => {
 
 const model = computed(() => {
   const args = props.toolCall.arguments as Record<string, unknown> | undefined;
-  const m = (args?.model as string) || props.toolCall.model || "";
-  return m.replace("claude-", "").replace("gpt-", "");
+  return (args?.model as string) || props.toolCall.model || "";
 });
 
 const duration = computed(() =>

--- a/apps/desktop/src/components/conversation/SubagentCard.vue
+++ b/apps/desktop/src/components/conversation/SubagentCard.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { TurnToolCall } from "@tracepilot/types";
+import {
+  formatDuration,
+  inferAgentTypeFromToolCall,
+  getAgentColor,
+  getAgentIcon,
+  agentStatusFromToolCall,
+} from "@tracepilot/ui";
+
+const props = defineProps<{
+  toolCall: TurnToolCall;
+  childToolCount?: number;
+  selected?: boolean;
+}>();
+
+const emit = defineEmits<{
+  select: [agentId: string];
+}>();
+
+const agentType = computed(() => inferAgentTypeFromToolCall(props.toolCall));
+const agentColor = computed(() => getAgentColor(agentType.value));
+const agentIcon = computed(() => getAgentIcon(agentType.value));
+const status = computed(() => agentStatusFromToolCall(props.toolCall));
+
+const displayName = computed(() => {
+  return (
+    props.toolCall.agentDisplayName || props.toolCall.toolName || "Subagent"
+  );
+});
+
+const description = computed(() => {
+  const tc = props.toolCall;
+  const args = tc.arguments as Record<string, unknown> | undefined;
+  return (
+    tc.intentionSummary ||
+    (args?.description as string) ||
+    (args?.name as string) ||
+    ""
+  );
+});
+
+const model = computed(() => {
+  const args = props.toolCall.arguments as Record<string, unknown> | undefined;
+  const m = (args?.model as string) || props.toolCall.model || "";
+  return m.replace("claude-", "").replace("gpt-", "");
+});
+
+const duration = computed(() =>
+  formatDuration(props.toolCall.durationMs ?? 0),
+);
+
+function handleClick() {
+  if (props.toolCall.toolCallId) {
+    emit("select", props.toolCall.toolCallId);
+  }
+}
+</script>
+
+<template>
+  <div
+    :class="['cv-subagent-card', { selected }]"
+    :style="{ '--agent-color': agentColor }"
+    role="button"
+    tabindex="0"
+    @click="handleClick"
+    @keydown.enter="handleClick"
+    @keydown.space.prevent="handleClick"
+  >
+    <div class="cv-subagent-inner">
+      <span class="cv-subagent-badge">
+        {{ agentIcon }} {{ displayName }}
+      </span>
+      <div class="cv-subagent-meta">
+        <span class="cv-subagent-desc">{{ description }}</span>
+      </div>
+      <span v-if="model" class="cv-subagent-model">{{ model }}</span>
+      <span class="cv-subagent-dur">{{ duration }}</span>
+      <span
+        :class="[
+          'cv-subagent-status',
+          status === 'failed' ? 'fail' : status === 'in-progress' ? 'pending' : 'success',
+        ]"
+      />
+      <span class="cv-subagent-arrow">▶</span>
+    </div>
+    <div v-if="childToolCount" class="cv-subagent-hint">
+      {{ childToolCount }} tool call{{ childToolCount !== 1 ? "s" : "" }} inside
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cv-subagent-card {
+  margin: 6px 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--canvas-subtle);
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  user-select: none;
+}
+.cv-subagent-card:hover {
+  border-color: var(--border-accent);
+  background: var(--canvas-overlay);
+}
+.cv-subagent-card.selected {
+  border-color: var(--accent-emphasis);
+  box-shadow:
+    0 0 0 1px var(--accent-emphasis),
+    0 0 12px rgba(99, 102, 241, 0.15);
+}
+.cv-subagent-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 2px solid var(--agent-color, var(--accent-emphasis));
+}
+.cv-subagent-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  border-radius: var(--radius-full);
+  font-size: 0.625rem;
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--agent-color) 15%, transparent);
+  color: var(--agent-color);
+}
+.cv-subagent-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.cv-subagent-desc {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cv-subagent-model {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.5625rem;
+  color: var(--text-placeholder);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.cv-subagent-dur {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.cv-subagent-status {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.cv-subagent-status.success {
+  background: var(--success-fg);
+}
+.cv-subagent-status.fail {
+  background: var(--danger-fg);
+}
+.cv-subagent-status.pending {
+  background: var(--warning-fg);
+}
+.cv-subagent-arrow {
+  font-size: 9px;
+  color: var(--text-placeholder);
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+}
+.cv-subagent-card:hover .cv-subagent-arrow {
+  transform: translateX(2px);
+  color: var(--accent-fg);
+}
+.cv-subagent-hint {
+  font-size: 0.625rem;
+  color: var(--text-placeholder);
+  padding: 0 12px 6px;
+}
+</style>

--- a/apps/desktop/src/components/conversation/SubagentPanel.vue
+++ b/apps/desktop/src/components/conversation/SubagentPanel.vue
@@ -35,6 +35,7 @@ const props = defineProps<{
   totalCount: number;
   hasPrev: boolean;
   hasNext: boolean;
+  topOffset: number;
 }>();
 
 const emit = defineEmits<{
@@ -179,7 +180,7 @@ const activities = computed<ActivityItem[]>(() => {
 watch(
   () => props.subagent?.agentId,
   () => {
-    promptExpanded.value = false;
+    promptExpanded.value = true;
     resultExpanded.value = false;
     expandedReasoning.value = new Set();
     expandedToolDetails.clear();
@@ -219,21 +220,12 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
 </script>
 
 <template>
-  <!-- Backdrop overlay (visible on narrow screens or always as dimming layer) -->
-  <Transition name="cv-panel-overlay">
-    <div
-      v-if="isOpen && subagent"
-      class="cv-panel-overlay"
-      aria-hidden="true"
-      @click="emit('close')"
-    />
-  </Transition>
-
   <!-- Slide-out panel -->
   <Transition name="cv-panel">
     <div
       v-if="isOpen && subagent"
       class="cv-panel"
+      :style="{ top: `${topOffset}px` }"
       role="dialog"
       aria-label="Subagent detail panel"
       @keydown.esc="emit('close')"
@@ -439,40 +431,16 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
   transform: translateX(100%);
 }
 
-.cv-panel-overlay-enter-active,
-.cv-panel-overlay-leave-active {
-  transition: opacity 320ms cubic-bezier(0.4, 0, 0.2, 1);
-}
-.cv-panel-overlay-enter-from,
-.cv-panel-overlay-leave-to {
-  opacity: 0;
-}
-
-/* ── Overlay ──────────────────────────────────────────────────── */
-
-.cv-panel-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 49;
-  background: rgba(0, 0, 0, 0.35);
-}
-
-@media (min-width: 960px) {
-  .cv-panel-overlay {
-    background: rgba(0, 0, 0, 0.1);
-  }
-}
-
 /* ── Panel container ──────────────────────────────────────────── */
 
 .cv-panel {
-  position: absolute;
-  top: 0;
+  position: fixed;
+  /* top is set dynamically via :style binding */
   right: 0;
   bottom: 0;
   width: 38%;
   min-width: 380px;
-  max-width: 600px;
+  max-width: 650px;
   z-index: 50;
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/components/conversation/SubagentPanel.vue
+++ b/apps/desktop/src/components/conversation/SubagentPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
 }>();
 
 const scrollContainer = ref<HTMLElement | null>(null);
-const promptExpanded = ref(false);
+const promptExpanded = ref(true);
 const resultExpanded = ref(false);
 const expandedReasoning = ref<Set<number>>(new Set());
 
@@ -79,8 +79,7 @@ const statusText = computed(() => {
 const model = computed(() => {
   if (!props.subagent) return "";
   const args = props.subagent.toolCall.arguments as Record<string, unknown> | undefined;
-  const m = (args?.model as string) || props.subagent.toolCall.model || "";
-  return m.replace("claude-", "").replace("gpt-", "");
+  return (args?.model as string) || props.subagent.toolCall.model || "";
 });
 
 const description = computed(() => {
@@ -273,7 +272,7 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
           <p class="cv-panel-description">{{ description }}</p>
         </div>
 
-        <!-- Prompt (collapsible when long) -->
+        <!-- Prompt (expanded by default, collapsible when long) -->
         <div v-if="prompt" class="cv-panel-section">
           <div class="cv-panel-section-header">
             <div class="cv-panel-section-label">Prompt</div>
@@ -289,7 +288,33 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
             </button>
           </div>
           <div :class="['cv-panel-prompt', { collapsed: isPromptLong && !promptExpanded }]">
-            {{ isPromptLong && !promptExpanded ? truncateText(prompt, 300) : prompt }}
+            <MarkdownContent
+              :content="isPromptLong && !promptExpanded ? truncateText(prompt, 300) : prompt"
+              :render="renderMd"
+            />
+          </div>
+        </div>
+
+        <!-- Result / Output (shown before activity stream) -->
+        <div v-if="resultContent" class="cv-panel-section">
+          <div class="cv-panel-section-header">
+            <div class="cv-panel-section-label">Output</div>
+            <button
+              v-if="isResultLong"
+              class="cv-panel-toggle"
+              :aria-expanded="resultExpanded"
+              aria-label="Toggle result visibility"
+              @click="resultExpanded = !resultExpanded"
+            >
+              {{ resultExpanded ? "Collapse" : "Expand" }}
+              <span :class="['cv-panel-chevron', { open: resultExpanded }]">▸</span>
+            </button>
+          </div>
+          <div :class="['cv-panel-result', { collapsed: isResultLong && !resultExpanded }]">
+            <MarkdownContent
+              :content="isResultLong && !resultExpanded ? truncateText(resultContent, 400) : resultContent"
+              :render="renderMd"
+            />
           </div>
         </div>
 
@@ -376,26 +401,6 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
             </template>
           </div>
         </div>
-
-        <!-- Final result (collapsible) -->
-        <div v-if="resultContent" class="cv-panel-section">
-          <div class="cv-panel-section-header">
-            <div class="cv-panel-section-label">Result</div>
-            <button
-              v-if="isResultLong"
-              class="cv-panel-toggle"
-              :aria-expanded="resultExpanded"
-              aria-label="Toggle result visibility"
-              @click="resultExpanded = !resultExpanded"
-            >
-              {{ resultExpanded ? "Collapse" : "Expand" }}
-              <span :class="['cv-panel-chevron', { open: resultExpanded }]">▸</span>
-            </button>
-          </div>
-          <div :class="['cv-panel-result', { collapsed: isResultLong && !resultExpanded }]">
-            {{ isResultLong && !resultExpanded ? truncateText(resultContent, 400) : resultContent }}
-          </div>
-        </div>
       </div>
 
       <!-- Navigation footer -->
@@ -446,7 +451,7 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
 /* ── Overlay ──────────────────────────────────────────────────── */
 
 .cv-panel-overlay {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 49;
   background: rgba(0, 0, 0, 0.35);
@@ -461,7 +466,7 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
 /* ── Panel container ──────────────────────────────────────────── */
 
 .cv-panel {
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;

--- a/apps/desktop/src/components/conversation/SubagentPanel.vue
+++ b/apps/desktop/src/components/conversation/SubagentPanel.vue
@@ -1,0 +1,961 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from "vue";
+import type { TurnToolCall } from "@tracepilot/types";
+import type { SubagentFullData } from "@/composables/useCrossTurnSubagents";
+import { usePreferencesStore } from "@/stores/preferences";
+import {
+  formatDuration,
+  toolIcon,
+  truncateText,
+  formatArgsSummary,
+  inferAgentTypeFromToolCall,
+  getAgentColor,
+  getAgentIcon,
+  agentStatusFromToolCall,
+  MarkdownContent,
+  ToolCallItem,
+  useToggleSet,
+} from "@tracepilot/ui";
+import { useToolResultLoader } from "@/composables/useToolResultLoader";
+import { useSessionDetailStore } from "@/stores/sessionDetail";
+
+const preferences = usePreferencesStore();
+const renderMd = computed(() => preferences.isFeatureEnabled("renderMarkdown"));
+
+const store = useSessionDetailStore();
+const expandedToolDetails = useToggleSet<string>();
+const { fullResults, loadingResults, failedResults, loadFullResult: handleLoadFullResult, retryFullResult: handleRetryResult } = useToolResultLoader(
+  () => store.sessionId
+);
+
+const props = defineProps<{
+  subagent: SubagentFullData | null;
+  isOpen: boolean;
+  currentIndex: number;
+  totalCount: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  prev: [];
+  next: [];
+}>();
+
+const scrollContainer = ref<HTMLElement | null>(null);
+const promptExpanded = ref(false);
+const resultExpanded = ref(false);
+const expandedReasoning = ref<Set<number>>(new Set());
+
+// ── Derived agent metadata ───────────────────────────────────────
+
+const agentType = computed(() =>
+  props.subagent ? inferAgentTypeFromToolCall(props.subagent.toolCall) : "task",
+);
+
+const agentColor = computed(() => getAgentColor(agentType.value));
+const agentIcon = computed(() => getAgentIcon(agentType.value));
+
+const agentLabel = computed(() => {
+  if (!props.subagent) return "Subagent";
+  return (
+    props.subagent.toolCall.agentDisplayName ||
+    props.subagent.toolCall.toolName ||
+    "Subagent"
+  );
+});
+
+const status = computed(() =>
+  props.subagent ? agentStatusFromToolCall(props.subagent.toolCall) : "completed",
+);
+
+const statusText = computed(() => {
+  if (status.value === "completed") return "Completed";
+  if (status.value === "failed") return "Failed";
+  return "Running";
+});
+
+const model = computed(() => {
+  if (!props.subagent) return "";
+  const args = props.subagent.toolCall.arguments as Record<string, unknown> | undefined;
+  const m = (args?.model as string) || props.subagent.toolCall.model || "";
+  return m.replace("claude-", "").replace("gpt-", "");
+});
+
+const description = computed(() => {
+  if (!props.subagent) return "";
+  const tc = props.subagent.toolCall;
+  const args = tc.arguments as Record<string, unknown> | undefined;
+  return (
+    tc.intentionSummary ||
+    (args?.description as string) ||
+    (args?.name as string) ||
+    ""
+  );
+});
+
+const prompt = computed(() => {
+  if (!props.subagent) return "";
+  const args = props.subagent.toolCall.arguments as Record<string, unknown> | undefined;
+  return (args?.prompt as string) || "";
+});
+
+const isPromptLong = computed(() => prompt.value.length > 300);
+
+const resultContent = computed(() => {
+  if (!props.subagent) return "";
+  return props.subagent.toolCall.resultContent || "";
+});
+
+const isResultLong = computed(() => resultContent.value.length > 400);
+
+// ── Activity stream ──────────────────────────────────────────────
+
+type ActivityItem =
+  | { kind: "reasoning"; index: number; sortKey: number; content: string; agentName?: string }
+  | { kind: "tool"; index: number; sortKey: number; toolCall: TurnToolCall }
+  | { kind: "pill"; index: number; sortKey: number; type: "intent" | "memory" | "read_agent"; label: string; toolCall: TurnToolCall }
+  | { kind: "message"; index: number; sortKey: number; content: string; agentName?: string }
+  | { kind: "nested-subagent"; index: number; sortKey: number; toolCall: TurnToolCall };
+
+const PILL_TOOLS = new Set(["report_intent", "store_memory", "read_agent"]);
+
+const activities = computed<ActivityItem[]>(() => {
+  if (!props.subagent) return [];
+  const items: ActivityItem[] = [];
+  let idx = 0;
+
+  // Reasoning items use a sortKey based on insertion order (no eventIndex available)
+  // but placed before tools to approximate chronological order
+  for (const r of props.subagent.childReasoning) {
+    items.push({
+      kind: "reasoning",
+      index: idx++,
+      sortKey: -1000 + idx, // reasoning comes first within a turn
+      content: r.content,
+      agentName: r.agentDisplayName,
+    });
+  }
+
+  for (const tc of props.subagent.childTools) {
+    const sortKey = tc.eventIndex ?? idx;
+    if (tc.isSubagent) {
+      items.push({ kind: "nested-subagent", index: idx++, sortKey, toolCall: tc });
+    } else if (PILL_TOOLS.has(tc.toolName)) {
+      const pillType = tc.toolName === "report_intent"
+        ? "intent" as const
+        : tc.toolName === "store_memory"
+          ? "memory" as const
+          : "read_agent" as const;
+      const label = tc.toolName === "report_intent"
+        ? formatArgsSummary(tc.arguments, tc.toolName) || "Intent update"
+        : tc.toolName === "store_memory"
+          ? formatArgsSummary(tc.arguments, tc.toolName) || "Stored memory"
+          : formatArgsSummary(tc.arguments, tc.toolName) || "Read agent";
+      items.push({ kind: "pill", index: idx++, sortKey, type: pillType, label, toolCall: tc });
+    } else {
+      items.push({ kind: "tool", index: idx++, sortKey, toolCall: tc });
+    }
+  }
+
+  for (const m of props.subagent.childMessages) {
+    items.push({
+      kind: "message",
+      index: idx++,
+      sortKey: Infinity, // messages come after tools (final responses)
+      content: m.content,
+      agentName: m.agentDisplayName,
+    });
+  }
+
+  // Sort by eventIndex-based key for chronological ordering
+  items.sort((a, b) => a.sortKey - b.sortKey);
+
+  return items;
+});
+
+// ── State reset on subagent change ───────────────────────────────
+
+watch(
+  () => props.subagent?.agentId,
+  () => {
+    promptExpanded.value = false;
+    resultExpanded.value = false;
+    expandedReasoning.value = new Set();
+    expandedToolDetails.clear();
+    nextTick(() => {
+      scrollContainer.value?.scrollTo({ top: 0 });
+    });
+  },
+);
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function toggleReasoning(index: number) {
+  const next = new Set(expandedReasoning.value);
+  if (next.has(index)) next.delete(index);
+  else next.add(index);
+  expandedReasoning.value = next;
+}
+
+function reasoningPreview(content: string): string {
+  const first = content.split("\n")[0] ?? "";
+  return first.length > 80 ? first.slice(0, 80) + "…" : first;
+}
+
+function toggleToolDetail(tc: TurnToolCall, index: number) {
+  expandedToolDetails.toggle(`panel-${props.subagent?.agentId}-${index}`);
+}
+
+function isToolExpanded(tc: TurnToolCall, index: number): boolean {
+  return expandedToolDetails.has(`panel-${props.subagent?.agentId}-${index}`);
+}
+
+function pillIcon(type: "intent" | "memory" | "read_agent"): string {
+  if (type === "intent") return "📋";
+  if (type === "memory") return "💾";
+  return "⏳";
+}
+</script>
+
+<template>
+  <!-- Backdrop overlay (visible on narrow screens or always as dimming layer) -->
+  <Transition name="cv-panel-overlay">
+    <div
+      v-if="isOpen && subagent"
+      class="cv-panel-overlay"
+      aria-hidden="true"
+      @click="emit('close')"
+    />
+  </Transition>
+
+  <!-- Slide-out panel -->
+  <Transition name="cv-panel">
+    <div
+      v-if="isOpen && subagent"
+      class="cv-panel"
+      role="dialog"
+      aria-label="Subagent detail panel"
+      @keydown.esc="emit('close')"
+    >
+      <!-- Header -->
+      <div class="cv-panel-header" :style="{ '--agent-color': agentColor }">
+        <button
+          class="cv-panel-close"
+          aria-label="Close panel"
+          title="Close (Esc)"
+          @click="emit('close')"
+        >
+          ✕
+        </button>
+        <div class="cv-panel-info">
+          <div class="cv-panel-name" :style="{ color: agentColor }">
+            <span class="cv-panel-name-icon">{{ agentIcon }}</span>
+            <span>{{ agentLabel }}</span>
+          </div>
+          <div class="cv-panel-meta">
+            <span v-if="model" class="cv-panel-model">{{ model }}</span>
+            <span v-if="model" class="sep">·</span>
+            <span>{{ formatDuration(subagent.toolCall.durationMs ?? 0) }}</span>
+            <span class="sep">·</span>
+            <span>Turn {{ subagent.turnIndex }}</span>
+          </div>
+        </div>
+        <span :class="['cv-panel-status', status]">{{ statusText }}</span>
+      </div>
+
+      <!-- Scrollable body -->
+      <div ref="scrollContainer" class="cv-panel-scroll">
+        <!-- Description -->
+        <div v-if="description" class="cv-panel-section">
+          <div class="cv-panel-section-label">Description</div>
+          <p class="cv-panel-description">{{ description }}</p>
+        </div>
+
+        <!-- Prompt (collapsible when long) -->
+        <div v-if="prompt" class="cv-panel-section">
+          <div class="cv-panel-section-header">
+            <div class="cv-panel-section-label">Prompt</div>
+            <button
+              v-if="isPromptLong"
+              class="cv-panel-toggle"
+              :aria-expanded="promptExpanded"
+              aria-label="Toggle prompt visibility"
+              @click="promptExpanded = !promptExpanded"
+            >
+              {{ promptExpanded ? "Collapse" : "Expand" }}
+              <span :class="['cv-panel-chevron', { open: promptExpanded }]">▸</span>
+            </button>
+          </div>
+          <div :class="['cv-panel-prompt', { collapsed: isPromptLong && !promptExpanded }]">
+            {{ isPromptLong && !promptExpanded ? truncateText(prompt, 300) : prompt }}
+          </div>
+        </div>
+
+        <!-- Activity stream -->
+        <div v-if="activities.length > 0" class="cv-panel-section">
+          <div class="cv-panel-divider">
+            <span class="cv-panel-divider-label">Activity ({{ activities.length }})</span>
+          </div>
+
+          <div class="cv-panel-activities">
+            <template v-for="item in activities" :key="item.index">
+              <!-- Reasoning block -->
+              <div v-if="item.kind === 'reasoning'" class="cv-panel-reasoning">
+                <button
+                  class="cv-panel-reasoning-toggle"
+                  :aria-expanded="expandedReasoning.has(item.index)"
+                  aria-label="Toggle reasoning block"
+                  @click="toggleReasoning(item.index)"
+                >
+                  <span :class="['cv-panel-chevron', { open: expandedReasoning.has(item.index) }]">▸</span>
+                  <span class="cv-panel-reasoning-icon">💭</span>
+                  <span class="cv-panel-reasoning-label">Thinking…</span>
+                  <span
+                    v-if="!expandedReasoning.has(item.index)"
+                    class="cv-panel-reasoning-preview"
+                  >{{ reasoningPreview(item.content) }}</span>
+                </button>
+                <div
+                  v-if="expandedReasoning.has(item.index)"
+                  class="cv-panel-reasoning-content"
+                >{{ item.content }}</div>
+              </div>
+
+              <!-- Special tool pills -->
+              <div
+                v-else-if="item.kind === 'pill'"
+                :class="['cv-panel-pill', `cv-panel-pill--${item.type}`]"
+              >
+                <span class="cv-panel-pill-icon">{{ pillIcon(item.type) }}</span>
+                <span class="cv-panel-pill-label">{{ item.label }}</span>
+                <span
+                  v-if="item.toolCall.isComplete"
+                  class="cv-panel-pill-check"
+                >✓</span>
+              </div>
+
+              <!-- Regular tool call -->
+              <ToolCallItem
+                v-else-if="item.kind === 'tool'"
+                :tc="item.toolCall"
+                variant="compact"
+                :expanded="isToolExpanded(item.toolCall, item.index)"
+                :full-result="item.toolCall.toolCallId ? fullResults.get(item.toolCall.toolCallId) : undefined"
+                :loading-full-result="item.toolCall.toolCallId ? loadingResults.has(item.toolCall.toolCallId) : false"
+                :failed-full-result="item.toolCall.toolCallId ? failedResults.has(item.toolCall.toolCallId) : false"
+                :rich-enabled="preferences.isRichRenderingEnabled(item.toolCall.toolName)"
+                @toggle="toggleToolDetail(item.toolCall, item.index)"
+                @load-full-result="handleLoadFullResult"
+                @retry-full-result="handleRetryResult"
+              />
+
+              <!-- Nested subagent -->
+              <div
+                v-else-if="item.kind === 'nested-subagent'"
+                class="cv-panel-nested-subagent"
+              >
+                <div class="cv-panel-nested-header" :style="{ borderLeftColor: getAgentColor(inferAgentTypeFromToolCall(item.toolCall)) }">
+                  <span class="cv-panel-nested-icon">{{ getAgentIcon(inferAgentTypeFromToolCall(item.toolCall)) }}</span>
+                  <span class="cv-panel-nested-name">{{ item.toolCall.agentDisplayName || item.toolCall.toolName }}</span>
+                  <span v-if="item.toolCall.durationMs" class="cv-panel-nested-meta">{{ formatDuration(item.toolCall.durationMs) }}</span>
+                  <span :class="['cv-panel-nested-status', item.toolCall.success === false ? 'failed' : item.toolCall.isComplete ? 'completed' : 'running']">
+                    {{ item.toolCall.success === false ? '✗' : item.toolCall.isComplete ? '✓' : '…' }}
+                  </span>
+                </div>
+                <div v-if="item.toolCall.intentionSummary || (item.toolCall.arguments as any)?.description" class="cv-panel-nested-desc">
+                  {{ item.toolCall.intentionSummary || (item.toolCall.arguments as any)?.description }}
+                </div>
+              </div>
+
+              <!-- Agent message (rendered markdown) -->
+              <div v-else-if="item.kind === 'message'" class="cv-panel-message">
+                <MarkdownContent :content="item.content" :render="renderMd" />
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <!-- Final result (collapsible) -->
+        <div v-if="resultContent" class="cv-panel-section">
+          <div class="cv-panel-section-header">
+            <div class="cv-panel-section-label">Result</div>
+            <button
+              v-if="isResultLong"
+              class="cv-panel-toggle"
+              :aria-expanded="resultExpanded"
+              aria-label="Toggle result visibility"
+              @click="resultExpanded = !resultExpanded"
+            >
+              {{ resultExpanded ? "Collapse" : "Expand" }}
+              <span :class="['cv-panel-chevron', { open: resultExpanded }]">▸</span>
+            </button>
+          </div>
+          <div :class="['cv-panel-result', { collapsed: isResultLong && !resultExpanded }]">
+            {{ isResultLong && !resultExpanded ? truncateText(resultContent, 400) : resultContent }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Navigation footer -->
+      <div class="cv-panel-nav">
+        <button
+          class="cv-panel-nav-btn"
+          :disabled="!hasPrev"
+          aria-label="Previous subagent"
+          @click="emit('prev')"
+        >
+          ◀ Prev
+        </button>
+        <span class="cv-panel-nav-pos">{{ currentIndex + 1 }} / {{ totalCount }}</span>
+        <button
+          class="cv-panel-nav-btn"
+          :disabled="!hasNext"
+          aria-label="Next subagent"
+          @click="emit('next')"
+        >
+          Next ▶
+        </button>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+/* ── Panel slide transition ───────────────────────────────────── */
+
+.cv-panel-enter-active,
+.cv-panel-leave-active {
+  transition: transform 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.cv-panel-enter-from,
+.cv-panel-leave-to {
+  transform: translateX(100%);
+}
+
+.cv-panel-overlay-enter-active,
+.cv-panel-overlay-leave-active {
+  transition: opacity 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.cv-panel-overlay-enter-from,
+.cv-panel-overlay-leave-to {
+  opacity: 0;
+}
+
+/* ── Overlay ──────────────────────────────────────────────────── */
+
+.cv-panel-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+@media (min-width: 960px) {
+  .cv-panel-overlay {
+    background: rgba(0, 0, 0, 0.1);
+  }
+}
+
+/* ── Panel container ──────────────────────────────────────────── */
+
+.cv-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 38%;
+  min-width: 380px;
+  max-width: 600px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  background: var(--canvas-subtle);
+  border-left: 1px solid var(--border-default);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.15);
+  outline: none;
+}
+
+@media (max-width: 959px) {
+  .cv-panel {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+}
+
+/* ── Header ───────────────────────────────────────────────────── */
+
+.cv-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--canvas-inset);
+  flex-shrink: 0;
+}
+
+.cv-panel-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.cv-panel-close:hover {
+  background: var(--neutral-subtle);
+  color: var(--text-primary);
+}
+
+.cv-panel-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cv-panel-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.cv-panel-name-icon {
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.cv-panel-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}
+
+.cv-panel-meta .sep {
+  color: var(--text-placeholder);
+  user-select: none;
+}
+
+.cv-panel-model {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.625rem;
+  padding: 1px 5px;
+  background: var(--neutral-subtle);
+  border-radius: var(--radius-full);
+  color: var(--text-secondary);
+}
+
+.cv-panel-status {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+}
+
+.cv-panel-status.completed {
+  color: var(--success-fg);
+  background: var(--success-subtle);
+}
+
+.cv-panel-status.failed {
+  color: var(--danger-fg);
+  background: var(--danger-subtle);
+}
+
+.cv-panel-status.in-progress {
+  color: var(--warning-fg);
+  background: var(--warning-subtle);
+}
+
+/* ── Scrollable body ──────────────────────────────────────────── */
+
+.cv-panel-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px;
+}
+
+/* ── Sections ─────────────────────────────────────────────────── */
+
+.cv-panel-section {
+  margin-bottom: 16px;
+}
+
+.cv-panel-section-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.cv-panel-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.cv-panel-description {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Toggle button (expand/collapse) ──────────────────────────── */
+
+.cv-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  color: var(--accent-fg);
+  font-size: 0.6875rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
+}
+
+.cv-panel-toggle:hover {
+  background: var(--accent-subtle);
+}
+
+/* ── Chevron (shared) ─────────────────────────────────────────── */
+
+.cv-panel-chevron {
+  display: inline-block;
+  font-size: 10px;
+  transition: transform var(--transition-fast);
+}
+
+.cv-panel-chevron.open {
+  transform: rotate(90deg);
+}
+
+/* ── Prompt block ─────────────────────────────────────────────── */
+
+.cv-panel-prompt {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 10px 12px;
+  background: var(--canvas-inset);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-muted);
+}
+
+.cv-panel-prompt.collapsed {
+  max-height: 120px;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+}
+
+/* ── Activity divider ─────────────────────────────────────────── */
+
+.cv-panel-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.cv-panel-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-muted);
+}
+
+.cv-panel-divider-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+/* ── Activity stream ──────────────────────────────────────────── */
+
+.cv-panel-activities {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ── Reasoning block ──────────────────────────────────────────── */
+
+.cv-panel-reasoning {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-muted);
+  background: var(--canvas-inset);
+  overflow: hidden;
+}
+
+.cv-panel-reasoning-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  transition: background var(--transition-fast);
+}
+
+.cv-panel-reasoning-toggle:hover {
+  background: var(--neutral-subtle);
+}
+
+.cv-panel-reasoning-icon {
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.cv-panel-reasoning-label {
+  font-weight: 500;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.cv-panel-reasoning-preview {
+  flex: 1;
+  color: var(--text-placeholder);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+}
+
+.cv-panel-reasoning-content {
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 300px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border-muted);
+}
+
+/* ── Special pills (intent / memory / read_agent) ─────────────── */
+
+.cv-panel-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  max-width: 100%;
+}
+
+.cv-panel-pill-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.cv-panel-pill-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.cv-panel-pill-check {
+  font-size: 10px;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.cv-panel-pill--intent {
+  color: var(--accent-fg);
+  background: var(--accent-subtle);
+}
+
+.cv-panel-pill--memory {
+  color: var(--done-fg);
+  background: var(--done-subtle);
+}
+
+.cv-panel-pill--read_agent {
+  color: var(--success-fg);
+  background: var(--success-subtle);
+}
+
+/* ── Agent message bubble ─────────────────────────────────────── */
+
+.cv-panel-message {
+  padding: 10px 12px;
+  background: var(--canvas-inset);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-muted);
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+
+.cv-panel-message :deep(.markdown-content) {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+/* ── Result block ─────────────────────────────────────────────── */
+
+.cv-panel-result {
+  font-size: 0.75rem;
+  font-family: "JetBrains Mono", monospace;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 10px 12px;
+  background: var(--canvas-inset);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-muted);
+}
+
+.cv-panel-result.collapsed {
+  max-height: 160px;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+}
+
+/* ── Navigation footer ────────────────────────────────────────── */
+
+.cv-panel-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-top: 1px solid var(--border-default);
+  background: var(--canvas-inset);
+  flex-shrink: 0;
+}
+
+.cv-panel-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.cv-panel-nav-btn:hover:not(:disabled) {
+  background: var(--neutral-subtle);
+  color: var(--text-primary);
+  border-color: var(--border-default);
+}
+
+.cv-panel-nav-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.cv-panel-nav-pos {
+  font-size: 0.6875rem;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Nested subagent ─────────────────────────────────────────── */
+
+.cv-panel-nested-subagent {
+  border-radius: var(--radius-md, 8px);
+  background: var(--canvas-inset, #010409);
+  overflow: hidden;
+  margin: 2px 0;
+}
+
+.cv-panel-nested-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent-fg);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cv-panel-nested-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.cv-panel-nested-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cv-panel-nested-meta {
+  color: var(--text-tertiary);
+  font-weight: 400;
+  font-size: 0.6875rem;
+  flex-shrink: 0;
+}
+
+.cv-panel-nested-status {
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 0.6875rem;
+}
+.cv-panel-nested-status.completed {
+  color: var(--success-fg, #3fb950);
+}
+.cv-panel-nested-status.failed {
+  color: var(--danger-fg, #f85149);
+}
+.cv-panel-nested-status.running {
+  color: var(--warning-fg, #d29922);
+}
+
+.cv-panel-nested-desc {
+  padding: 4px 12px 8px 15px;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+</style>

--- a/apps/desktop/src/components/conversation/chatViewUtils.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.ts
@@ -1,0 +1,144 @@
+/**
+ * Utility functions for the Chat View rendering pipeline.
+ *
+ * Segments a turn's tool calls into renderable groups (regular tools,
+ * subagent groups, pills) and provides helpers for extracting main-agent
+ * content from a turn.
+ */
+import type {
+  ConversationTurn,
+  TurnToolCall,
+  AttributedMessage,
+} from "@tracepilot/types";
+
+// ─── Segment Types ────────────────────────────────────────────────
+
+export type ToolSegment =
+  | { type: "tool-group"; items: ToolGroupItem[] }
+  | { type: "subagent-group"; subagents: TurnToolCall[] }
+  | { type: "read-agent-pill"; toolCall: TurnToolCall };
+
+export type ToolGroupItem =
+  | { type: "intent"; toolCall: TurnToolCall }
+  | { type: "memory"; toolCall: TurnToolCall }
+  | { type: "ask-user"; toolCall: TurnToolCall }
+  | { type: "tool"; toolCall: TurnToolCall };
+
+/** Maximum tool rows shown before progressive disclosure collapse. */
+export const MAX_VISIBLE_TOOLS = 7;
+
+/** Threshold below which we show all tools without collapsing. */
+export const COLLAPSE_THRESHOLD = 3;
+
+// ─── Segmentation ─────────────────────────────────────────────────
+
+/**
+ * Segments a turn's tool calls into renderable groups.
+ *
+ * - Regular tools are grouped together
+ * - Consecutive subagent launches are grouped
+ * - Child tools (parentToolCallId set) are skipped (belong to panel)
+ * - read_agent calls become standalone pills
+ */
+export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
+  const segments: ToolSegment[] = [];
+  let currentRegular: TurnToolCall[] = [];
+  let currentSubagents: TurnToolCall[] = [];
+
+  function flushRegular() {
+    if (currentRegular.length > 0) {
+      segments.push({
+        type: "tool-group",
+        items: currentRegular.map(classifyTool),
+      });
+      currentRegular = [];
+    }
+  }
+
+  function flushSubagents() {
+    if (currentSubagents.length > 0) {
+      segments.push({
+        type: "subagent-group",
+        subagents: [...currentSubagents],
+      });
+      currentSubagents = [];
+    }
+  }
+
+  for (const tc of toolCalls) {
+    if (tc.isSubagent) {
+      flushRegular();
+      currentSubagents.push(tc);
+    } else if (tc.parentToolCallId) {
+      // Skip — child data belongs to subagent panel
+    } else if (tc.toolName === "read_agent") {
+      flushRegular();
+      flushSubagents();
+      segments.push({ type: "read-agent-pill", toolCall: tc });
+    } else {
+      flushSubagents();
+      currentRegular.push(tc);
+    }
+  }
+
+  flushRegular();
+  flushSubagents();
+
+  return segments;
+}
+
+function classifyTool(tc: TurnToolCall): ToolGroupItem {
+  switch (tc.toolName) {
+    case "report_intent":
+      return { type: "intent", toolCall: tc };
+    case "store_memory":
+      return { type: "memory", toolCall: tc };
+    case "ask_user":
+      return { type: "ask-user", toolCall: tc };
+    default:
+      return { type: "tool", toolCall: tc };
+  }
+}
+
+// ─── Turn Content Helpers ─────────────────────────────────────────
+
+/** Extract main-agent reasoning (not from subagents). */
+export function getMainReasoning(turn: ConversationTurn): string[] {
+  return (turn.reasoningTexts ?? [])
+    .filter((r) => !r.parentToolCallId && r.content?.trim())
+    .map((r) => r.content);
+}
+
+/** Extract main-agent messages (not from subagents). */
+export function getMainMessages(turn: ConversationTurn): AttributedMessage[] {
+  return turn.assistantMessages.filter(
+    (m) => !m.parentToolCallId && m.content?.trim(),
+  );
+}
+
+/**
+ * Count the number of regular (non-pill) tools in a ToolGroupItem array.
+ */
+export function countRegularTools(items: ToolGroupItem[]): number {
+  return items.filter((i) => i.type === "tool").length;
+}
+
+/**
+ * Get unique tool names from items beyond the visible threshold.
+ */
+export function getCollapsedToolNames(
+  items: ToolGroupItem[],
+  maxVisible: number,
+): string[] {
+  const names = new Set<string>();
+  let toolIdx = 0;
+  for (const item of items) {
+    if (item.type === "tool") {
+      toolIdx++;
+      if (toolIdx > maxVisible) {
+        names.add(item.toolCall.toolName);
+      }
+    }
+  }
+  return Array.from(names).slice(0, 6);
+}

--- a/apps/desktop/src/components/conversation/chatViewUtils.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.ts
@@ -21,6 +21,7 @@ export type ToolGroupItem =
   | { type: "intent"; toolCall: TurnToolCall }
   | { type: "memory"; toolCall: TurnToolCall }
   | { type: "ask-user"; toolCall: TurnToolCall }
+  | { type: "subagent-complete"; toolCall: TurnToolCall }
   | { type: "tool"; toolCall: TurnToolCall };
 
 /** Maximum tool rows shown before progressive disclosure collapse. */
@@ -37,7 +38,7 @@ export const COLLAPSE_THRESHOLD = 3;
  * - Regular tools are grouped together
  * - Consecutive subagent launches are grouped
  * - Child tools (parentToolCallId set) are skipped (belong to panel)
- * - read_agent calls become standalone pills
+ * - read_agent calls become subagent-complete pills
  */
 export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
   const segments: ToolSegment[] = [];
@@ -71,7 +72,8 @@ export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
     } else if (tc.parentToolCallId) {
       // Skip — child data belongs to subagent panel
     } else if (tc.toolName === "read_agent") {
-      // Skip — subagent status is shown on SubagentCard, these add noise
+      flushSubagents();
+      currentRegular.push(tc);
     } else {
       flushSubagents();
       currentRegular.push(tc);
@@ -92,6 +94,8 @@ function classifyTool(tc: TurnToolCall): ToolGroupItem {
       return { type: "memory", toolCall: tc };
     case "ask_user":
       return { type: "ask-user", toolCall: tc };
+    case "read_agent":
+      return { type: "subagent-complete", toolCall: tc };
     default:
       return { type: "tool", toolCall: tc };
   }

--- a/apps/desktop/src/components/conversation/chatViewUtils.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.ts
@@ -15,8 +15,7 @@ import type {
 
 export type ToolSegment =
   | { type: "tool-group"; items: ToolGroupItem[] }
-  | { type: "subagent-group"; subagents: TurnToolCall[] }
-  | { type: "read-agent-pill"; toolCall: TurnToolCall };
+  | { type: "subagent-group"; subagents: TurnToolCall[] };
 
 export type ToolGroupItem =
   | { type: "intent"; toolCall: TurnToolCall }
@@ -72,9 +71,7 @@ export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
     } else if (tc.parentToolCallId) {
       // Skip — child data belongs to subagent panel
     } else if (tc.toolName === "read_agent") {
-      flushRegular();
-      flushSubagents();
-      segments.push({ type: "read-agent-pill", toolCall: tc });
+      // Skip — subagent status is shown on SubagentCard, these add noise
     } else {
       flushSubagents();
       currentRegular.push(tc);

--- a/apps/desktop/src/components/conversation/chatViewUtils.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.ts
@@ -21,7 +21,6 @@ export type ToolGroupItem =
   | { type: "intent"; toolCall: TurnToolCall }
   | { type: "memory"; toolCall: TurnToolCall }
   | { type: "ask-user"; toolCall: TurnToolCall }
-  | { type: "subagent-complete"; toolCall: TurnToolCall }
   | { type: "tool"; toolCall: TurnToolCall };
 
 /** Maximum tool rows shown before progressive disclosure collapse. */
@@ -72,8 +71,7 @@ export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
     } else if (tc.parentToolCallId) {
       // Skip — child data belongs to subagent panel
     } else if (tc.toolName === "read_agent") {
-      flushSubagents();
-      currentRegular.push(tc);
+      // Skip — completion pills are rendered separately via completionsByTurn
     } else {
       flushSubagents();
       currentRegular.push(tc);
@@ -94,8 +92,6 @@ function classifyTool(tc: TurnToolCall): ToolGroupItem {
       return { type: "memory", toolCall: tc };
     case "ask_user":
       return { type: "ask-user", toolCall: tc };
-    case "read_agent":
-      return { type: "subagent-complete", toolCall: tc };
     default:
       return { type: "tool", toolCall: tc };
   }

--- a/apps/desktop/src/composables/useCrossTurnSubagents.ts
+++ b/apps/desktop/src/composables/useCrossTurnSubagents.ts
@@ -1,0 +1,82 @@
+import { computed, type ComputedRef, type Ref } from "vue";
+import type {
+  ConversationTurn,
+  TurnToolCall,
+  AttributedMessage,
+} from "@tracepilot/types";
+
+/** Full activity data for a subagent, aggregated across turns. */
+export interface SubagentFullData {
+  agentId: string;
+  turnIndex: number;
+  toolCall: TurnToolCall;
+  childTools: TurnToolCall[];
+  childMessages: AttributedMessage[];
+  childReasoning: AttributedMessage[];
+}
+
+/**
+ * Collects subagent data across all turns, linking child tools/messages/reasoning
+ * back to their parent subagent via parentToolCallId.
+ *
+ * Subagent output often spans multiple turns — a subagent launched in turn N
+ * may have its child tool calls appear in turns N+1, N+2, etc.
+ */
+export function useCrossTurnSubagents(
+  turns: Ref<ConversationTurn[]> | ComputedRef<ConversationTurn[]>,
+) {
+  const subagentMap = computed<Map<string, SubagentFullData>>(() => {
+    const map = new Map<string, SubagentFullData>();
+    const childToolsMap = new Map<string, TurnToolCall[]>();
+    const childMsgsMap = new Map<string, AttributedMessage[]>();
+    const childReasoningMap = new Map<string, AttributedMessage[]>();
+
+    for (const turn of turns.value) {
+      for (const tc of turn.toolCalls) {
+        if (tc.parentToolCallId) {
+          const arr = childToolsMap.get(tc.parentToolCallId);
+          if (arr) arr.push(tc);
+          else childToolsMap.set(tc.parentToolCallId, [tc]);
+        }
+      }
+
+      for (const m of turn.assistantMessages) {
+        if (m.parentToolCallId) {
+          const arr = childMsgsMap.get(m.parentToolCallId);
+          if (arr) arr.push(m);
+          else childMsgsMap.set(m.parentToolCallId, [m]);
+        }
+      }
+
+      for (const r of turn.reasoningTexts ?? []) {
+        if (r.parentToolCallId) {
+          const arr = childReasoningMap.get(r.parentToolCallId);
+          if (arr) arr.push(r);
+          else childReasoningMap.set(r.parentToolCallId, [r]);
+        }
+      }
+    }
+
+    for (const turn of turns.value) {
+      for (const tc of turn.toolCalls) {
+        if (tc.isSubagent && tc.toolCallId) {
+          map.set(tc.toolCallId, {
+            agentId: tc.toolCallId,
+            turnIndex: turn.turnIndex,
+            toolCall: tc,
+            childTools: childToolsMap.get(tc.toolCallId) ?? [],
+            childMessages: childMsgsMap.get(tc.toolCallId) ?? [],
+            childReasoning: childReasoningMap.get(tc.toolCallId) ?? [],
+          });
+        }
+      }
+    }
+
+    return map;
+  });
+
+  /** Flat ordered list of all subagents across all turns. */
+  const allSubagents = computed(() => Array.from(subagentMap.value.values()));
+
+  return { subagentMap, allSubagents };
+}

--- a/apps/desktop/src/composables/useSubagentPanel.ts
+++ b/apps/desktop/src/composables/useSubagentPanel.ts
@@ -8,6 +8,7 @@ import {
   type ComputedRef,
 } from "vue";
 import type { SubagentFullData } from "./useCrossTurnSubagents";
+import { shouldIgnoreGlobalShortcut } from "@/utils/keyboardShortcuts";
 
 /**
  * Manages the slide-out subagent detail panel state.
@@ -41,6 +42,10 @@ export function useSubagentPanel(
   );
 
   function selectSubagent(agentId: string) {
+    if (selectedAgentId.value === agentId && isPanelOpen.value) {
+      closePanel();
+      return;
+    }
     selectedAgentId.value = agentId;
     isPanelOpen.value = true;
   }
@@ -66,9 +71,7 @@ export function useSubagentPanel(
 
   function handleKeydown(e: KeyboardEvent) {
     if (!isPanelOpen.value) return;
-    // Don't intercept if focus is in an input/textarea
-    const tag = (e.target as HTMLElement)?.tagName;
-    if (tag === "INPUT" || tag === "TEXTAREA") return;
+    if (shouldIgnoreGlobalShortcut(e)) return;
 
     if (e.key === "Escape") {
       closePanel();

--- a/apps/desktop/src/composables/useSubagentPanel.ts
+++ b/apps/desktop/src/composables/useSubagentPanel.ts
@@ -1,0 +1,107 @@
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  type Ref,
+  type ComputedRef,
+} from "vue";
+import type { SubagentFullData } from "./useCrossTurnSubagents";
+
+/**
+ * Manages the slide-out subagent detail panel state.
+ *
+ * Provides selection, prev/next navigation, and keyboard shortcuts
+ * (Escape to close, arrow keys to navigate).
+ */
+export function useSubagentPanel(
+  allSubagents: Ref<SubagentFullData[]> | ComputedRef<SubagentFullData[]>,
+) {
+  const selectedAgentId = ref<string | null>(null);
+  const isPanelOpen = ref(false);
+
+  const selectedIndex = computed(() => {
+    if (!selectedAgentId.value) return -1;
+    return allSubagents.value.findIndex(
+      (s) => s.agentId === selectedAgentId.value,
+    );
+  });
+
+  const selectedSubagent = computed<SubagentFullData | null>(() => {
+    if (selectedIndex.value < 0) return null;
+    return allSubagents.value[selectedIndex.value] ?? null;
+  });
+
+  const hasPrev = computed(() => selectedIndex.value > 0);
+  const hasNext = computed(
+    () =>
+      selectedIndex.value >= 0 &&
+      selectedIndex.value < allSubagents.value.length - 1,
+  );
+
+  function selectSubagent(agentId: string) {
+    selectedAgentId.value = agentId;
+    isPanelOpen.value = true;
+  }
+
+  function closePanel() {
+    selectedAgentId.value = null;
+    isPanelOpen.value = false;
+  }
+
+  function navigatePrev() {
+    if (hasPrev.value) {
+      const prev = allSubagents.value[selectedIndex.value - 1];
+      if (prev) selectSubagent(prev.agentId);
+    }
+  }
+
+  function navigateNext() {
+    if (hasNext.value) {
+      const next = allSubagents.value[selectedIndex.value + 1];
+      if (next) selectSubagent(next.agentId);
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!isPanelOpen.value) return;
+    // Don't intercept if focus is in an input/textarea
+    const tag = (e.target as HTMLElement)?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+    if (e.key === "Escape") {
+      closePanel();
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft") {
+      navigatePrev();
+      e.preventDefault();
+    } else if (e.key === "ArrowRight") {
+      navigateNext();
+      e.preventDefault();
+    }
+  }
+
+  onMounted(() => document.addEventListener("keydown", handleKeydown));
+  onBeforeUnmount(() => document.removeEventListener("keydown", handleKeydown));
+
+  // Auto-close panel when selected subagent disappears (e.g. session switch)
+  watch(selectedIndex, (idx) => {
+    if (isPanelOpen.value && selectedAgentId.value && idx === -1) {
+      closePanel();
+    }
+  });
+
+  return {
+    selectedAgentId,
+    isPanelOpen,
+    selectedIndex,
+    selectedSubagent,
+    hasPrev,
+    hasNext,
+    selectSubagent,
+    closePanel,
+    navigatePrev,
+    navigateNext,
+  };
+}

--- a/apps/desktop/src/stores/sessionDetail.ts
+++ b/apps/desktop/src/stores/sessionDetail.ts
@@ -52,6 +52,36 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
   // Track file size for freshness detection (avoids redundant turn re-fetches)
   let lastEventsFileSize = 0;
 
+  /**
+   * Smart-merge incoming turns into the reactive array.
+   *
+   * During auto-refresh of active sessions, only the last turn changes
+   * (receives new tool calls) and new turns are appended. By mutating
+   * the existing reactive array in-place instead of wholesale replacement,
+   * Vue's reactivity system only triggers updates for the changed indices,
+   * dramatically reducing re-render work for long sessions (900+ turns).
+   *
+   * Falls back to full replacement on first load or when lengths shrink.
+   */
+  function mergeTurns(incoming: ConversationTurn[]) {
+    const existing = turns.value;
+
+    // Full replacement: first load, reset, or truncation (shouldn't happen)
+    if (existing.length === 0 || incoming.length < existing.length) {
+      turns.value = incoming;
+      return;
+    }
+
+    // Update the last existing turn (may have gained new tool calls / messages)
+    const lastIdx = existing.length - 1;
+    existing[lastIdx] = incoming[lastIdx];
+
+    // Append any new turns
+    for (let i = existing.length; i < incoming.length; i++) {
+      existing.push(incoming[i]);
+    }
+  }
+
   // ── Frontend session cache (last 5 sessions) ────────────────────────
   // Caches all loaded section data so switching between recently viewed
   // sessions restores the UI instantly without any IPC roundtrip.
@@ -296,7 +326,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
         if (freshness.eventsFileSize === lastEventsFileSize) return;
         const result = await getSessionTurns(id);
         if (!sessionGuard.isValid(token)) return;
-        turns.value = result.turns;
+        mergeTurns(result.turns);
         lastEventsFileSize = result.eventsFileSize;
       }).catch((e) => {
         if (!sessionGuard.isValid(token)) return;
@@ -416,7 +446,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
 
           const result = await getSessionTurns(id);
           if (!sessionGuard.isValid(token)) return;
-          turns.value = result.turns;
+          mergeTurns(result.turns);
           turnsError.value = null;
           lastEventsFileSize = result.eventsFileSize;
         })().catch((e) => {

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -276,6 +276,12 @@
   margin: 0 auto;
 }
 
+/* When the subagent panel is open, left-align content and let it fill to the panel edge */
+.page-content-inner.panel-open-layout {
+  max-width: none;
+  margin: 0;
+}
+
 /* --- Breadcrumb --- */
 .breadcrumb {
   display: flex;

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -276,11 +276,6 @@
   margin: 0 auto;
 }
 
-/* When the subagent panel is open, left-align content and let it fill to the panel edge */
-.page-content-inner.panel-open-layout {
-  max-width: none;
-  margin: 0;
-}
 
 /* --- Breadcrumb --- */
 .breadcrumb {

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -15,15 +15,17 @@ import {
   useSessionTabLoader, useToggleSet, useConversationSections,
   getAgentColor,
 } from "@tracepilot/ui";
+import ChatViewMode from "@/components/conversation/ChatViewMode.vue";
 
 const route = useRoute();
 const store = useSessionDetailStore();
 const preferences = usePreferencesStore();
-const expandedTools = useToggleSet<number>();
 const expandedToolDetails = useToggleSet<string>();
 const expandedReasoning = useToggleSet<string>();
-const collapsedSubagents = useToggleSet<string>();
 const activeView = ref("chat");
+
+// Chat view ref for deep-link delegation
+const chatViewRef = ref<InstanceType<typeof ChatViewMode> | null>(null);
 
 const { fullResults, loadingResults, failedResults, loadFullResult: handleLoadFullResult, retryFullResult: handleRetryResult } = useToolResultLoader(
   () => store.sessionId
@@ -45,10 +47,6 @@ const { isLockedToBottom, showScrollToTop, hasOverflow, scrollToBottom, scrollTo
 });
 
 // Scroll to a specific element when navigated from search.
-// Tries event-level first (via ?event=N), falls back to turn-level (via ?turn=N).
-// Uses IntersectionObserver so the highlight animation only starts once
-// the element is actually visible (loading can take a while).
-// Track timers and observers for cleanup on unmount
 const activeTimers: ReturnType<typeof setTimeout>[] = [];
 let activeObserver: IntersectionObserver | null = null;
 
@@ -93,8 +91,6 @@ function scrollToTarget(turnIndex: number, eventIndex: number | null) {
 }
 
 // Watch for turns to load, then scroll to the target.
-// Also re-scroll when query params change (e.g., clicking a different search result
-// in the same session without the component remounting).
 let lastScrolledKey: string | null = null;
 watch(
   [() => store.turns.length, () => route.query.turn, () => route.query.event],
@@ -107,20 +103,23 @@ watch(
     if (key === lastScrolledKey) return;
     if (!store.turns.some(t => t.turnIndex === turnIndex)) return;
     lastScrolledKey = key;
-    // Defer expansion to nextTick so useSessionTabLoader's onClear() runs first
+
     nextTick(() => {
+      // For chat view, delegate to ChatViewMode's revealEvent
+      if (activeView.value === 'chat' && chatViewRef.value) {
+        chatViewRef.value.revealEvent(turnIndex, eventIndex ?? undefined);
+        return;
+      }
+
+      // Compact/Timeline: use original expand logic
       if (eventIndex != null) {
-        if (!expandedTools.has(turnIndex)) expandedTools.toggle(turnIndex);
         const turn = store.turns.find(t => t.turnIndex === turnIndex);
         if (turn) {
           const tc = turn.toolCalls.find(t => t.eventIndex === eventIndex);
           if (tc) {
-            if (tc.parentToolCallId) {
-              const subKey = `${turnIndex}-${tc.parentToolCallId}`;
-              if (collapsedSubagents.has(subKey)) collapsedSubagents.toggle(subKey);
-            }
             const idx = findToolCallIndex(turn, tc);
-            const detailKey = `${turnIndex}-${idx}`;
+            const prefix = activeView.value === 'timeline' ? 'tl-' : 'compact-';
+            const detailKey = `${prefix}${turnIndex}-${idx}`;
             if (!expandedToolDetails.has(detailKey)) expandedToolDetails.toggle(detailKey);
           }
         }
@@ -142,10 +141,8 @@ useSessionTabLoader(
   () => store.loadTurns(),
   {
     onClear() {
-      expandedTools.clear();
       expandedToolDetails.clear();
       expandedReasoning.clear();
-      collapsedSubagents.clear();
       lastScrolledKey = null;
     },
   }
@@ -236,174 +233,7 @@ function retryLoadTurns() {
     <EmptyState v-if="store.turns.length === 0 && !store.turnsError" message="No conversation turns found." />
 
     <!-- ═══════════════ CHAT VIEW ═══════════════ -->
-    <div v-else-if="activeView === 'chat'" class="turn-group">
-      <div v-for="turn in store.turns" :key="turn.turnIndex" :id="`turn-${turn.turnIndex}`" class="conversation-turn">
-        <!-- User message -->
-        <div v-if="turn.userMessage" :id="turn.eventIndex != null ? `event-${turn.eventIndex}` : undefined" class="turn-item">
-          <div class="turn-avatar user">👤</div>
-          <div class="turn-body">
-            <div class="turn-header">
-              <span class="turn-author">You</span>
-              <span class="turn-meta">Turn {{ turn.turnIndex }}</span>
-              <span v-if="turn.timestamp" class="turn-meta">{{ formatTime(turn.timestamp) }}</span>
-            </div>
-            <div class="turn-bubble user">
-              <MarkdownContent :content="turn.userMessage" :render="preferences.isFeatureEnabled('renderMarkdown')" />
-            </div>
-          </div>
-        </div>
-
-        <!-- Agent-grouped content -->
-        <template v-for="(section, sIdx) in getSections(turn.turnIndex)" :key="sIdx">
-          <!-- ── Main Agent Section ── -->
-          <template v-if="!section.agentId">
-            <!-- Reasoning (main agent) -->
-            <ReasoningBlock
-              class="turn-reasoning"
-              :reasoning="section.reasoning"
-              :expanded="expandedReasoning.has(`${turn.turnIndex}-main-${sIdx}`)"
-              @toggle="expandedReasoning.toggle(`${turn.turnIndex}-main-${sIdx}`)"
-            />
-
-            <!-- Assistant messages (main agent) -->
-            <div v-for="(msg, idx) in section.messages.filter(m => m.trim())" :key="`main-msg-${idx}`" class="turn-item">
-              <div class="turn-avatar assistant">🤖</div>
-              <div class="turn-body">
-                <div class="turn-header">
-                  <span class="turn-author">Copilot</span>
-                  <Badge v-if="turn.model" variant="done" style="font-size: 0.625rem; padding: 1px 6px;">{{ turn.model }}</Badge>
-                  <span v-if="turn.durationMs" class="turn-meta">{{ formatDuration(turn.durationMs) }}</span>
-                  <span v-if="turn.endTimestamp || turn.timestamp" class="turn-meta">{{ formatTime(turn.endTimestamp ?? turn.timestamp) }}</span>
-                  <Badge v-if="!turn.isComplete" variant="warning">Incomplete</Badge>
-                </div>
-                <div class="turn-bubble assistant">
-                  <MarkdownContent :content="msg" :render="preferences.isFeatureEnabled('renderMarkdown')" />
-                </div>
-              </div>
-            </div>
-
-            <!-- Tool calls (main agent — includes subagent launch calls) -->
-            <div v-if="section.toolCalls.length > 0" class="turn-tool-calls">
-              <div class="tool-calls-container">
-                <button
-                  class="tool-call-header w-full"
-                  :aria-expanded="expandedTools.has(turn.turnIndex)"
-                  @click="expandedTools.toggle(turn.turnIndex)"
-                >
-                  <ExpandChevron :expanded="expandedTools.has(turn.turnIndex)" />
-                  <span>{{ section.toolCalls.length }} tool call{{ section.toolCalls.length !== 1 ? "s" : "" }}</span>
-                  <span style="margin-left: auto; display: flex; gap: 6px;">
-                    <span class="tool-summary-badge tool-summary-pass">
-                      {{ section.toolCalls.filter((tc) => tc.success === true).length }} passed
-                    </span>
-                    <span
-                      v-if="section.toolCalls.some((tc) => tc.success === false)"
-                      class="tool-summary-badge tool-summary-fail"
-                    >
-                      {{ section.toolCalls.filter((tc) => tc.success === false).length }} failed
-                    </span>
-                  </span>
-                </button>
-
-                <div v-if="expandedTools.has(turn.turnIndex)">
-                  <ToolCallItem
-                    v-for="tc in section.toolCalls"
-                    :id="tc.eventIndex != null ? `event-${tc.eventIndex}` : undefined"
-                    :key="tc.toolCallId ?? tc.toolName"
-                    v-bind="tcProps(turn, tc)"
-                    @toggle="toggleToolDetail(turn, tc)"
-                    @load-full-result="handleLoadFullResult"
-                    @retry-full-result="handleRetryResult"
-                  />
-                </div>
-              </div>
-            </div>
-          </template>
-
-          <!-- ── Subagent Section ── -->
-          <div
-            v-else
-            :id="`subagent-${turn.turnIndex}-${section.agentId}`"
-            class="subagent-block"
-            :style="{ '--agent-border-color': getAgentColor(section.agentType) }"
-          >
-            <button
-              class="subagent-header"
-              :aria-expanded="!collapsedSubagents.has(`${turn.turnIndex}-${section.agentId}`)"
-              @click="collapsedSubagents.toggle(`${turn.turnIndex}-${section.agentId}`)"
-            >
-              <ExpandChevron :expanded="!collapsedSubagents.has(`${turn.turnIndex}-${section.agentId}`)" />
-              <AgentBadge
-                :agent-name="section.agentDisplayName"
-                :agent-type="section.agentType"
-                :model="section.model"
-                :status="section.status"
-              />
-              <span v-if="section.durationMs" class="turn-meta">{{ formatDuration(section.durationMs) }}</span>
-              <span v-if="section.toolCalls.length" class="turn-meta">
-                · {{ section.toolCalls.length }} tool{{ section.toolCalls.length !== 1 ? 's' : '' }}
-              </span>
-            </button>
-
-            <div v-if="!collapsedSubagents.has(`${turn.turnIndex}-${section.agentId}`)" class="subagent-content">
-              <!-- Subagent reasoning -->
-              <ReasoningBlock
-                class="turn-reasoning"
-                :reasoning="section.reasoning"
-                :expanded="expandedReasoning.has(`${turn.turnIndex}-${section.agentId}`)"
-                @toggle="expandedReasoning.toggle(`${turn.turnIndex}-${section.agentId}`)"
-              />
-
-              <!-- Subagent messages -->
-              <div v-for="(msg, idx) in section.messages.filter(m => m.trim())" :key="`sub-msg-${idx}`" class="turn-item subagent-message">
-                <div class="turn-avatar assistant" :style="{ fontSize: '0.9rem' }">
-                  {{ section.agentType === 'explore' ? '🔍' : section.agentType === 'code-review' ? '🔎' : section.agentType === 'general-purpose' ? '🛠️' : '📋' }}
-                </div>
-                <div class="turn-body">
-                  <div class="turn-header">
-                    <span class="turn-author" :style="{ color: getAgentColor(section.agentType) }">{{ section.agentDisplayName }}</span>
-                    <Badge v-if="section.model" variant="done" style="font-size: 0.625rem; padding: 1px 6px;">{{ section.model }}</Badge>
-                  </div>
-                  <div class="turn-bubble assistant">
-                  <MarkdownContent :content="msg" :render="preferences.isFeatureEnabled('renderMarkdown')" />
-                </div>
-                </div>
-              </div>
-
-              <!-- Subagent tool calls -->
-              <div v-if="section.toolCalls.length > 0" style="display: flex; flex-direction: column; gap: 4px; margin-top: 4px;">
-                <ToolCallItem
-                  v-for="tc in section.toolCalls"
-                  :id="tc.eventIndex != null ? `event-${tc.eventIndex}` : undefined"
-                  :key="tc.toolCallId ?? tc.toolName"
-                  v-bind="tcProps(turn, tc, '', 'compact')"
-                  @toggle="toggleToolDetail(turn, tc)"
-                  @load-full-result="handleLoadFullResult"
-                  @retry-full-result="handleRetryResult"
-                />
-              </div>
-
-              <!-- Empty state for subagents with no captured content -->
-              <div
-                v-if="section.messages.filter(m => m.trim()).length === 0 && section.reasoning.length === 0 && section.toolCalls.length === 0"
-                class="subagent-empty"
-              >
-                No content captured for this subagent
-              </div>
-            </div>
-          </div>
-        </template>
-
-        <!-- Session events (errors, compactions, etc.) -->
-        <div v-if="turn.sessionEvents?.length" class="session-events-list">
-          <div v-for="(se, seIdx) in turn.sessionEvents" :key="seIdx" class="session-event-row" :class="`session-event-${se.severity}`">
-            <Badge :variant="severityVariant(se.severity)" size="sm">{{ severityIcon(se.severity) }} {{ eventTypeLabel(se.eventType) }}</Badge>
-            <span class="session-event-summary">{{ se.summary }}</span>
-            <span v-if="se.timestamp" class="turn-meta">{{ formatTime(se.timestamp) }}</span>
-          </div>
-        </div>
-      </div>
-    </div>
+    <ChatViewMode v-else-if="activeView === 'chat'" ref="chatViewRef" />
 
     <!-- ═══════════════ COMPACT VIEW ═══════════════ -->
     <div v-else-if="activeView === 'compact'" class="turn-group">
@@ -618,50 +448,6 @@ function retryLoadTurns() {
 @keyframes turn-flash {
   0%, 30% { box-shadow: 0 0 0 3px var(--accent-emphasis); background: color-mix(in srgb, var(--accent-emphasis) 8%, transparent); }
   100% { box-shadow: 0 0 0 0 transparent; background: transparent; }
-}
-
-.subagent-block {
-  margin: 8px 0 8px 24px;
-  border-left: 3px solid var(--agent-border-color, var(--accent-emphasis));
-  border-radius: 0 8px 8px 0;
-  background: color-mix(in srgb, var(--agent-border-color) 4%, var(--canvas-subtle));
-  overflow: hidden;
-}
-
-.subagent-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  background: transparent;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-}
-
-.subagent-header:hover {
-  background: color-mix(in srgb, var(--agent-border-color) 8%, transparent);
-}
-
-.subagent-content {
-  padding: 4px 12px 12px;
-}
-
-.subagent-empty {
-  padding: 8px 12px;
-  font-size: 0.75rem;
-  opacity: 0.5;
-  font-style: italic;
-}
-
-.subagent-message .turn-avatar {
-  width: 28px;
-  height: 28px;
-  min-width: 28px;
-  font-size: 0.85rem;
 }
 
 .compact-agent-dot {


### PR DESCRIPTION
## Conversation (Chat) UI/UX Overhaul

Comprehensive redesign of the Conversation > Chat tab rendering, focusing on subagent display, performance, and user experience.

### Problem

The Chat tab rendered messages, reasoning, and tool calls as separate vertical blocks per turn, with subagents displayed inline in the same vertical flow as the main agent. This was cluttered, confusing for multi-subagent sessions, and performed poorly on large sessions (900+ turns).

### Solution

**New Chat View Architecture:**
- **Slide-out Subagent Panel** — Click any subagent card to open a fixed-position detail panel showing full activity, prompt, result, and child tools
- **Chronological timeline** — Reasoning, tool calls, intent pills, and messages rendered in natural order within each turn
- **Rich rendering** — All tool calls use the existing rich renderer pipeline (diffs, terminal output, file views, etc.)
- **Subagent completion pills** — Inline indicators when background agents complete
- **Progressive disclosure** — Tools capped at 5 visible with "Show all N" expansion

### Key Changes

**New Files (6):**
- `ChatViewMode.vue` — Main chat view component (~1050 lines)
- `SubagentPanel.vue` — Slide-out detail panel (~930 lines)
- `SubagentCard.vue` — Clickable subagent card in timeline (~195 lines)
- `chatViewUtils.ts` — Tool call segmentation and grouping (~142 lines)
- `useCrossTurnSubagents.ts` — Cross-turn subagent data aggregation (~83 lines)
- `useSubagentPanel.ts` — Panel state management with keyboard shortcuts (~111 lines)

**Modified Files:**
- `ConversationTab.vue` — Chat section replaced with `<ChatViewMode />`
- `sessionDetail.ts` — Smart-merge turns on refresh (performance)
- `layout.css` — Panel breakout styling

**Deleted Files:**
- `ChatToolRow.vue` — Replaced by rich ToolCallItem

### Features
- 🎯 Slide-out subagent panel (click to open, re-click or Escape to close)
- 🔍 Full subagent activity: prompt (markdown), result, child tools, reasoning
- ⏰ Timestamps on both user and Copilot messages
- 🎨 Color-coded left borders on turns with subagent activity
- ✅ Subagent completion pills (deduplicated, one per agent)
- 📋 ask_user rendered via rich renderer pipeline
- 🏷️ Intent pills shown inline in timeline
- 📱 Panel-aware layout (content shifts left when panel opens, fills available space)

### Performance Optimizations
- Memoized per-turn render data into single `computed` Map (avoids re-segmenting on every render)
- `toolCallTurnIndex` for O(1) lookups (fixed O(N²) in `subagentTurnColors`)
- Smart-merge turns on auto-refresh — mutates reactive array in-place instead of wholesale replacement
- Only the last turn + newly appended turns trigger Vue reactivity updates

### Unchanged
- Compact view — not modified
- Timeline view — not modified
- All existing rich renderers — used as-is
- Data model / Rust backend — no changes
- All 860 tests pass, vue-tsc clean

### Verification Checklist
- [ ] Open any session → Chat view renders with new turn card layout
- [ ] Sessions with subagents show clickable SubagentCards in timeline
- [ ] Clicking a subagent opens the slide-out panel; re-clicking closes it
- [ ] Panel shows full prompt (markdown), result, activity stream, child tools
- [ ] Timestamps visible on user and Copilot messages
- [ ] Subagent completion pills appear after last relevant tool call
- [ ] ask_user tool calls render via rich AskUserRenderer
- [ ] Content shifts left when panel opens, fills to panel edge
- [ ] Escape key closes panel (doesn't fire from text inputs)
- [ ] Auto-refresh on active sessions doesn't freeze UI
- [ ] Compact and Timeline views still work correctly
- [ ] Search deep-links still scroll to correct turn/event
- [ ] Dark and light themes render correctly