### PR TITLE
Fix session overview auto-refresh subagent updates and chat read_agent visibility

### DIFF
--- a/apps/desktop/src/__tests__/stores/sessionDetail.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessionDetail.test.ts
@@ -79,6 +79,11 @@ describe("useSessionDetailStore", () => {
       expect(store.metricsError).toBeNull();
       expect(store.incidentsError).toBeNull();
     });
+
+    it("starts turnsVersion at 0", () => {
+      const store = useSessionDetailStore();
+      expect(store.turnsVersion).toBe(0);
+    });
   });
 
   describe("loadDetail", () => {
@@ -336,6 +341,126 @@ describe("useSessionDetailStore", () => {
 
       expect(store.todosError).toBeNull();
       expect(store.todos).toEqual(FIXTURE_TODOS);
+    });
+
+    it("updates non-tail turns when refresh returns retrospective subagent completion", async () => {
+      const store = useSessionDetailStore();
+      await store.loadDetail(SESSION_ID);
+
+      const initialTurns = {
+        turns: [
+          {
+            turnIndex: 0,
+            userMessage: "hello",
+            assistantMessages: [],
+            toolCalls: [
+              {
+                toolName: "task",
+                toolCallId: "sa-1",
+                isSubagent: true,
+                isComplete: false,
+              },
+            ],
+            isComplete: true,
+          },
+          { turnIndex: 1, userMessage: "next", assistantMessages: [], toolCalls: [], isComplete: true },
+        ],
+        eventsFileSize: 100,
+      };
+      mockGetSessionTurns.mockResolvedValue(initialTurns);
+      await store.loadTurns();
+
+      const beforeVersion = store.turnsVersion;
+      expect(store.turns[0]?.toolCalls[0]?.isComplete).toBe(false);
+
+      mockCheckSessionFreshness.mockResolvedValue({ eventsFileSize: 120 });
+      mockGetSessionTurns.mockResolvedValue({
+        turns: [
+          {
+            turnIndex: 0,
+            userMessage: "hello",
+            assistantMessages: [],
+            toolCalls: [
+              {
+                toolName: "task",
+                toolCallId: "sa-1",
+                isSubagent: true,
+                isComplete: true,
+                success: true,
+              },
+            ],
+            isComplete: true,
+          },
+          { turnIndex: 1, userMessage: "next", assistantMessages: [], toolCalls: [], isComplete: true },
+        ],
+        eventsFileSize: 120,
+      });
+
+      await store.refreshAll();
+
+      expect(store.turns[0]?.toolCalls[0]?.isComplete).toBe(true);
+      expect(store.turns[0]?.toolCalls[0]?.success).toBe(true);
+      expect(store.turnsVersion).toBeGreaterThan(beforeVersion);
+    });
+
+    it("does not bump turnsVersion when refresh turns payload is unchanged", async () => {
+      const store = useSessionDetailStore();
+      await store.loadDetail(SESSION_ID);
+      await store.loadTurns();
+
+      const beforeVersion = store.turnsVersion;
+      mockCheckSessionFreshness.mockResolvedValue({ eventsFileSize: FIXTURE_TURNS.eventsFileSize + 10 });
+      mockGetSessionTurns.mockResolvedValue({
+        turns: structuredClone(FIXTURE_TURNS.turns),
+        eventsFileSize: FIXTURE_TURNS.eventsFileSize + 10,
+      });
+
+      await store.refreshAll();
+
+      expect(store.turnsVersion).toBe(beforeVersion);
+    });
+
+    it("updates turn when only model changes", async () => {
+      const store = useSessionDetailStore();
+      await store.loadDetail(SESSION_ID);
+
+      mockGetSessionTurns.mockResolvedValue({
+        turns: [
+          {
+            turnIndex: 0,
+            model: "gpt-5.3-codex",
+            userMessage: "hello",
+            assistantMessages: [],
+            toolCalls: [],
+            isComplete: true,
+          },
+        ],
+        eventsFileSize: 200,
+      });
+      await store.loadTurns();
+
+      const beforeVersion = store.turnsVersion;
+      expect(store.turns[0]?.model).toBe("gpt-5.3-codex");
+
+      mockCheckSessionFreshness.mockResolvedValue({ eventsFileSize: 220 });
+      mockGetSessionTurns.mockResolvedValue({
+        turns: [
+          {
+            turnIndex: 0,
+            model: "claude-sonnet-4.6",
+            userMessage: "hello",
+            assistantMessages: [],
+            toolCalls: [],
+            isComplete: true,
+          },
+        ],
+        eventsFileSize: 220,
+      });
+
+      await store.refreshAll();
+
+      expect(store.turns[0]?.model).toBe("claude-sonnet-4.6");
+      expect(store.turnsVersion).toBeGreaterThan(beforeVersion);
     });
   });
 });

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -255,20 +255,28 @@ function parseAgentNameFromReadAgent(tc: TurnToolCall): string | null {
       typeof tc.arguments === "string"
         ? JSON.parse(tc.arguments)
         : (tc.arguments as Record<string, unknown> | null);
-    return (args?.agent_id as string) ?? null;
+    const candidates = [args?.agent_id, args?.agent_name, args?.name];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-/** Reverse map: agent launch name → subagentMap toolCallId */
+/** Reverse map: possible read_agent identifiers → subagentMap toolCallId */
 const agentNameToToolCallId = computed(() => {
   const map = new Map<string, string>();
   for (const [toolCallId, sa] of subagentMap.value) {
     const args = sa.toolCall.arguments as Record<string, unknown> | undefined;
-    const name = (args?.name as string) ?? undefined;
-    if (name) {
-      map.set(name, toolCallId);
+    const identifiers = [args?.name, args?.agent_id, args?.agent_name, sa.toolCall.toolCallId];
+    for (const identifier of identifiers) {
+      if (typeof identifier === "string" && identifier.trim().length > 0) {
+        map.set(identifier, toolCallId);
+      }
     }
   }
   return map;
@@ -533,6 +541,16 @@ defineExpose({ revealEvent });
                           <span class="cv-pill-icon" aria-hidden="true">🧠</span>
                           <span class="cv-pill-label">{{ truncateText(memoryLabel(item.toolCall), 80) }}</span>
                         </div>
+
+                        <!-- Read-agent row -->
+                        <ToolCallItem
+                          v-else-if="item.type === 'read-agent'"
+                          :id="item.toolCall.eventIndex != null ? `event-${item.toolCall.eventIndex}` : undefined"
+                          v-bind="tcProps(turn, item.toolCall)"
+                          @toggle="toggleToolDetail(turn, item.toolCall)"
+                          @load-full-result="handleLoadFullResult"
+                          @retry-full-result="handleRetryResult"
+                        />
 
                         <!-- Ask-user (rich renderer) -->
                         <ToolCallItem

--- a/apps/desktop/src/components/conversation/SubagentCard.vue
+++ b/apps/desktop/src/components/conversation/SubagentCard.vue
@@ -3,6 +3,7 @@ import type { TurnToolCall } from "@tracepilot/types";
 import {
   agentStatusFromToolCall,
   formatDuration,
+  formatLiveDuration,
   getAgentColor,
   getAgentIcon,
   inferAgentTypeFromToolCall,
@@ -39,7 +40,15 @@ const model = computed(() => {
   return (args?.model as string) || props.toolCall.model || "";
 });
 
-const duration = computed(() => formatDuration(props.toolCall.durationMs ?? 0));
+const duration = computed(() => {
+  if (status.value === "in-progress" && !props.toolCall.durationMs) {
+    return "";
+  }
+  if (status.value === "in-progress") {
+    return formatLiveDuration(props.toolCall.durationMs);
+  }
+  return formatDuration(props.toolCall.durationMs ?? 0);
+});
 
 function handleClick() {
   if (props.toolCall.toolCallId) {
@@ -66,7 +75,7 @@ function handleClick() {
         <span class="cv-subagent-desc">{{ description }}</span>
       </div>
       <span v-if="model" class="cv-subagent-model">{{ model }}</span>
-      <span class="cv-subagent-dur">{{ duration }}</span>
+      <span v-if="duration" class="cv-subagent-dur">{{ duration }}</span>
       <span
         :class="[
           'cv-subagent-status',

--- a/apps/desktop/src/components/conversation/SubagentPanel.vue
+++ b/apps/desktop/src/components/conversation/SubagentPanel.vue
@@ -4,6 +4,7 @@ import {
   agentStatusFromToolCall,
   formatArgsSummary,
   formatDuration,
+  formatLiveDuration,
   getAgentColor,
   getAgentIcon,
   inferAgentTypeFromToolCall,
@@ -75,6 +76,15 @@ const statusText = computed(() => {
   if (status.value === "completed") return "Completed";
   if (status.value === "failed") return "Failed";
   return "Running";
+});
+
+const headerDuration = computed(() => {
+  const ms = props.subagent?.toolCall.durationMs;
+  if (status.value === "in-progress") {
+    if (!ms) return "";
+    return formatLiveDuration(ms);
+  }
+  return formatDuration(ms ?? 0);
 });
 
 const model = computed(() => {
@@ -252,7 +262,7 @@ function pillIcon(type: "intent" | "memory" | "read_agent"): string {
           <div class="cv-panel-meta">
             <span v-if="model" class="cv-panel-model">{{ model }}</span>
             <span v-if="model" class="sep">·</span>
-            <span>{{ formatDuration(subagent.toolCall.durationMs ?? 0) }}</span>
+            <span v-if="headerDuration">{{ headerDuration }}</span>
             <span class="sep">·</span>
             <span>Turn {{ subagent.turnIndex }}</span>
           </div>

--- a/apps/desktop/src/components/conversation/chatViewUtils.test.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.test.ts
@@ -1,0 +1,53 @@
+import type { TurnToolCall } from "@tracepilot/types";
+import { describe, expect, it } from "vitest";
+import { segmentToolCalls } from "./chatViewUtils";
+
+function makeToolCall(overrides: Partial<TurnToolCall>): TurnToolCall {
+  return {
+    toolName: "view",
+    isComplete: true,
+    ...overrides,
+  };
+}
+
+describe("segmentToolCalls", () => {
+  it("keeps top-level read_agent visible as a tool-group item", () => {
+    const segments = segmentToolCalls([
+      makeToolCall({ toolName: "report_intent" }),
+      makeToolCall({ toolName: "read_agent", arguments: { agent_id: "reviewer-1" } }),
+      makeToolCall({ toolName: "ask_user" }),
+    ]);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.type).toBe("tool-group");
+
+    if (segments[0]?.type !== "tool-group") return;
+    expect(segments[0].items.map((item) => item.type)).toEqual([
+      "intent",
+      "read-agent",
+      "ask-user",
+    ]);
+  });
+
+  it("still skips child read_agent calls inside subagent internals", () => {
+    const segments = segmentToolCalls([
+      makeToolCall({ toolName: "task", toolCallId: "parent-1", isSubagent: true }),
+      makeToolCall({
+        toolName: "read_agent",
+        parentToolCallId: "parent-1",
+        arguments: { agent_id: "parent-1" },
+      }),
+      makeToolCall({ toolName: "view", parentToolCallId: "parent-1" }),
+      makeToolCall({ toolName: "powershell" }),
+    ]);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]?.type).toBe("subagent-group");
+    expect(segments[1]?.type).toBe("tool-group");
+
+    if (segments[1]?.type !== "tool-group") return;
+    expect(segments[1].items).toHaveLength(1);
+    expect(segments[1].items[0]?.type).toBe("tool");
+    expect(segments[1].items[0]?.toolCall.toolName).toBe("powershell");
+  });
+});

--- a/apps/desktop/src/components/conversation/chatViewUtils.ts
+++ b/apps/desktop/src/components/conversation/chatViewUtils.ts
@@ -17,6 +17,7 @@ export type ToolGroupItem =
   | { type: "intent"; toolCall: TurnToolCall }
   | { type: "memory"; toolCall: TurnToolCall }
   | { type: "ask-user"; toolCall: TurnToolCall }
+  | { type: "read-agent"; toolCall: TurnToolCall }
   | { type: "tool"; toolCall: TurnToolCall };
 
 /** Maximum tool rows shown before progressive disclosure collapse. */
@@ -33,7 +34,7 @@ export const COLLAPSE_THRESHOLD = 3;
  * - Regular tools are grouped together
  * - Consecutive subagent launches are grouped
  * - Child tools (parentToolCallId set) are skipped (belong to panel)
- * - read_agent calls become subagent-complete pills
+ * - top-level read_agent calls are shown as rows and can also drive completion pills
  */
 export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
   const segments: ToolSegment[] = [];
@@ -66,8 +67,6 @@ export function segmentToolCalls(toolCalls: TurnToolCall[]): ToolSegment[] {
       currentSubagents.push(tc);
     } else if (tc.parentToolCallId) {
       // Skip — child data belongs to subagent panel
-    } else if (tc.toolName === "read_agent") {
-      // Skip — completion pills are rendered separately via completionsByTurn
     } else {
       flushSubagents();
       currentRegular.push(tc);
@@ -88,6 +87,8 @@ function classifyTool(tc: TurnToolCall): ToolGroupItem {
       return { type: "memory", toolCall: tc };
     case "ask_user":
       return { type: "ask-user", toolCall: tc };
+    case "read_agent":
+      return { type: "read-agent", toolCall: tc };
     default:
       return { type: "tool", toolCall: tc };
   }

--- a/apps/desktop/src/stores/sessionDetail.ts
+++ b/apps/desktop/src/stores/sessionDetail.ts
@@ -10,6 +10,7 @@ import {
   getShutdownMetrics,
 } from "@tracepilot/client";
 import type {
+  AttributedMessage,
   CheckpointEntry,
   ConversationTurn,
   EventsResponse,
@@ -17,6 +18,7 @@ import type {
   SessionIncident,
   SessionPlan,
   ShutdownMetrics,
+  TurnToolCall,
   TodosResponse,
 } from "@tracepilot/types";
 import { toErrorMessage } from "@tracepilot/ui";
@@ -29,6 +31,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
   const sessionId = ref<string | null>(null);
   const detail = ref<SessionDetail | null>(null);
   const turns = ref<ConversationTurn[]>([]);
+  const turnsVersion = ref(0);
   const events = ref<EventsResponse | null>(null);
   const todos = ref<TodosResponse | null>(null);
   const checkpoints = ref<CheckpointEntry[]>([]);
@@ -51,34 +54,189 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
 
   // Track file size for freshness detection (avoids redundant turn re-fetches)
   let lastEventsFileSize = 0;
+  let turnFingerprints: string[] = [];
+
+  // Restrict deep fingerprinting to turns likely to change retroactively:
+  // any turn with an in-progress subagent, plus the tail turn.
+  let deepCompareTurnIndexes = new Set<number>();
+
+  function bumpTurnsVersion() {
+    turnsVersion.value += 1;
+  }
+
+  function hashText(value: string): number {
+    let hash = 2166136261;
+    for (let i = 0; i < value.length; i++) {
+      hash ^= value.charCodeAt(i);
+      hash +=
+        (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+    }
+    return hash >>> 0;
+  }
+
+  function messageFingerprint(msg: AttributedMessage): string {
+    return [
+      msg.parentToolCallId ?? "",
+      msg.agentDisplayName ?? "",
+      msg.content.length,
+      hashText(msg.content),
+    ].join("|");
+  }
+
+  function toolCallFingerprint(tc: TurnToolCall): string {
+    return [
+      tc.toolCallId ?? "",
+      tc.parentToolCallId ?? "",
+      tc.toolName,
+      tc.eventIndex ?? "",
+      tc.isSubagent ? "1" : "0",
+      tc.isComplete ? "1" : "0",
+      tc.success == null ? "u" : tc.success ? "1" : "0",
+      tc.startedAt ?? "",
+      tc.completedAt ?? "",
+      tc.durationMs ?? "",
+      tc.error ?? "",
+      tc.model ?? "",
+      tc.argsSummary ?? "",
+      tc.resultContent?.length ?? 0,
+      tc.resultContent ? hashText(tc.resultContent) : "",
+      tc.agentDisplayName ?? "",
+    ].join("|");
+  }
+
+  function turnFingerprint(turn: ConversationTurn): string {
+    const reasoning = turn.reasoningTexts ?? [];
+    const events = turn.sessionEvents ?? [];
+    return [
+      turn.turnIndex,
+      turn.eventIndex ?? "",
+      turn.turnId ?? "",
+      turn.interactionId ?? "",
+      turn.model ?? "",
+      turn.timestamp ?? "",
+      turn.endTimestamp ?? "",
+      turn.isComplete ? "1" : "0",
+      turn.durationMs ?? "",
+      turn.outputTokens ?? "",
+      turn.userMessage?.length ?? 0,
+      turn.assistantMessages.length,
+      turn.assistantMessages.map(messageFingerprint).join(","),
+      reasoning.length,
+      reasoning.map(messageFingerprint).join(","),
+      events.length,
+      events
+        .map(
+          (evt) =>
+            `${evt.eventType}:${evt.severity}:${evt.summary.length}:${hashText(evt.summary)}:${evt.timestamp ?? ""}`,
+        )
+        .join(","),
+      turn.toolCalls.length,
+      turn.toolCalls.map(toolCallFingerprint).join(","),
+    ].join("||");
+  }
+
+  function computeDeepCompareIndexes(turnList: ConversationTurn[]): Set<number> {
+    const indexes = new Set<number>();
+    if (turnList.length > 0) {
+      indexes.add(turnList.length - 1);
+    }
+    for (let i = 0; i < turnList.length; i++) {
+      if (turnList[i]?.toolCalls.some((tc) => tc.isSubagent && !tc.isComplete)) {
+        indexes.add(i);
+      }
+    }
+    return indexes;
+  }
+
+  function replaceTurns(incoming: ConversationTurn[]) {
+    const hadData = turns.value.length > 0;
+    const hasIncoming = incoming.length > 0;
+    turns.value = incoming;
+    turnFingerprints = incoming.map(turnFingerprint);
+    deepCompareTurnIndexes = computeDeepCompareIndexes(incoming);
+    if (hadData || hasIncoming) {
+      bumpTurnsVersion();
+    }
+  }
 
   /**
    * Smart-merge incoming turns into the reactive array.
    *
-   * During auto-refresh of active sessions, only the last turn changes
-   * (receives new tool calls) and new turns are appended. By mutating
-   * the existing reactive array in-place instead of wholesale replacement,
-   * Vue's reactivity system only triggers updates for the changed indices,
-   * dramatically reducing re-render work for long sessions (900+ turns).
+   * During auto-refresh of active sessions, updates are usually append-only,
+   * but subagent lifecycle events can retroactively update older turns.
+   * We preserve the in-place mutation strategy for performance by replacing
+   * only changed indices and appending new turns.
    *
    * Falls back to full replacement on first load or when lengths shrink.
    */
   function mergeTurns(incoming: ConversationTurn[]) {
     const existing = turns.value;
 
-    // Full replacement: first load, reset, or truncation (shouldn't happen)
+    // Full replacement: first load, reset, or truncation.
     if (existing.length === 0 || incoming.length < existing.length) {
-      turns.value = incoming;
+      replaceTurns(incoming);
       return;
     }
 
-    // Update the last existing turn (may have gained new tool calls / messages)
-    const lastIdx = existing.length - 1;
-    existing[lastIdx] = incoming[lastIdx];
+    const nextFingerprints = [...turnFingerprints];
+    let changed = false;
+    const overlapLength = Math.min(existing.length, incoming.length);
+
+    const candidateIndexes = new Set<number>([
+      Math.max(0, overlapLength - 1),
+      ...deepCompareTurnIndexes,
+    ]);
+    for (const idx of candidateIndexes) {
+      if (idx < 0 || idx >= overlapLength) continue;
+      const nextFingerprint = turnFingerprint(incoming[idx]);
+      nextFingerprints[idx] = nextFingerprint;
+      if (turnFingerprints[idx] !== nextFingerprint) {
+        existing[idx] = incoming[idx];
+        changed = true;
+      }
+    }
+
+    // Cheap metadata compare across all turns catches changes that don't require
+    // deep hashing (model, completion, timestamps, etc.).
+    for (let i = 0; i < overlapLength; i++) {
+      if (candidateIndexes.has(i)) continue;
+      const current = existing[i];
+      const next = incoming[i];
+      if (
+        current.turnIndex !== next.turnIndex ||
+        current.eventIndex !== next.eventIndex ||
+        current.turnId !== next.turnId ||
+        current.interactionId !== next.interactionId ||
+        current.model !== next.model ||
+        current.timestamp !== next.timestamp ||
+        current.endTimestamp !== next.endTimestamp ||
+        current.isComplete !== next.isComplete ||
+        current.durationMs !== next.durationMs ||
+        current.outputTokens !== next.outputTokens ||
+        current.userMessage !== next.userMessage
+      ) {
+        existing[i] = next;
+        nextFingerprints[i] = turnFingerprint(next);
+        changed = true;
+      }
+    }
 
     // Append any new turns
     for (let i = existing.length; i < incoming.length; i++) {
       existing.push(incoming[i]);
+      nextFingerprints[i] = turnFingerprint(incoming[i]);
+      changed = true;
+    }
+
+    if (turnFingerprints.length !== nextFingerprints.length) {
+      changed = true;
+    }
+
+    turnFingerprints = nextFingerprints;
+    deepCompareTurnIndexes = computeDeepCompareIndexes(incoming);
+
+    if (changed) {
+      bumpTurnsVersion();
     }
   }
 
@@ -296,7 +454,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
    *  Do NOT use in the cache-hit path — that restores specific fields. */
   function resetSectionData() {
     detail.value = null;
-    turns.value = [];
+    replaceTurns([]);
     events.value = null;
     for (const sec of standardSections) {
       sec.resetData();
@@ -325,7 +483,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
     if (cached) {
       // Restore ALL sections immediately — zero IPC, zero spinner
       detail.value = cached.detail;
-      turns.value = cached.turns;
+      replaceTurns(cached.turns);
       lastEventsFileSize = cached.eventsFileSize;
       checkpoints.value = cached.checkpoints;
       plan.value = cached.plan;
@@ -400,7 +558,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
     errorRef: turnsError,
     fetchFn: (id) => getSessionTurns(id),
     onResult: (result) => {
-      turns.value = result.turns;
+      replaceTurns(result.turns);
       lastEventsFileSize = result.eventsFileSize;
     },
   });
@@ -546,6 +704,7 @@ export const useSessionDetailStore = defineStore("sessionDetail", () => {
     sessionId,
     detail,
     turns,
+    turnsVersion,
     events,
     todos,
     checkpoints,

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -62,7 +62,7 @@ onMounted(() => {
 const { isLockedToBottom, showScrollToTop, hasOverflow, scrollToBottom, scrollToTop } =
   useAutoScroll({
     containerRef: scrollContainer,
-    watchSource: () => store.turns,
+    watchSource: () => store.turnsVersion,
     viewModeSource: () => activeView.value,
   });
 

--- a/crates/tracepilot-core/src/turns/ipc.rs
+++ b/crates/tracepilot-core/src/turns/ipc.rs
@@ -50,6 +50,14 @@ pub fn compute_args_summary(tool_name: &str, args: &serde_json::Value) -> String
                 return d;
             }
         }
+        "read_agent" => {
+            if let Some(id) = get_str("agent_id")
+                .or_else(|| get_str("agent_name"))
+                .or_else(|| get_str("name"))
+            {
+                return id;
+            }
+        }
         "report_intent" => {
             if let Some(i) = get_str("intent") {
                 return i;

--- a/packages/ui/src/__tests__/toolCall.test.ts
+++ b/packages/ui/src/__tests__/toolCall.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatArgsSummary } from "../utils/toolCall";
+
+describe("formatArgsSummary", () => {
+  it("summarizes read_agent from agent_id", () => {
+    const summary = formatArgsSummary({ agent_id: "explore-backend" }, "read_agent");
+    expect(summary).toBe("explore-backend");
+  });
+
+  it("falls back to agent_name and name for read_agent", () => {
+    expect(formatArgsSummary({ agent_name: "review-agent" }, "read_agent")).toBe("review-agent");
+    expect(formatArgsSummary({ name: "task-agent" }, "read_agent")).toBe("task-agent");
+  });
+});

--- a/packages/ui/src/utils/toolCall.ts
+++ b/packages/ui/src/utils/toolCall.ts
@@ -65,6 +65,10 @@ export function formatArgsSummary(args: unknown, toolName: string): string {
     return cmd.length > 150 ? `${cmd.slice(0, 150)}…` : cmd;
   }
   if (toolName === "task" && a.description) return String(a.description);
+  if (toolName === "read_agent") {
+    const candidate = a.agent_id ?? a.agent_name ?? a.name;
+    if (candidate) return String(candidate);
+  }
   if (toolName === "report_intent" && a.intent) return String(a.intent);
   if (toolName === "sql" && a.description) return String(a.description);
   if (toolName === "web_search" && a.query) return String(a.query);


### PR DESCRIPTION
## Summary
- fix session overview turn merging so auto-refresh can update non-tail turns (retrospective subagent completion updates)
- preserve performance by combining targeted deep comparison (tail + in-progress-subagent turns) with cheap metadata comparison
- add 	urnsVersion change token and use it for conversation auto-follow after clicking down-arrow
- render top-level ead_agent calls in chat and strengthen completion mapping across gent_id, gent_name, and 
ame
- align ead_agent args summary handling in both frontend (ormatArgsSummary) and backend IPC (compute_args_summary)
- add regression tests for turn merge/version behavior and chat read_agent segmentation/summaries

## Validation
- pnpm --filter @tracepilot/desktop test -- --run src/__tests__/stores/sessionDetail.test.ts src/components/conversation/chatViewUtils.test.ts
- pnpm --filter @tracepilot/ui test -- --run src/__tests__/toolCall.test.ts
- pnpm --filter @tracepilot/ui test
- cargo test -p tracepilot-core --lib ipc -- --nocapture

## Notes
- pnpm --filter @tracepilot/desktop typecheck currently fails due to pre-existing unrelated baseline issues in existing test/composable files; no new type errors introduced by this change set.
- External code reviews run with GPT-5.3-Codex, GPT-5.4, and Claude Opus 4.6; one substantive concern (over-broad deep hashing cost) was incorporated by scoping deep comparisons to likely-changing turns.