### PR TITLE
Fix TypeScript strict-mode errors failing CI typecheck

### DIFF
--- a/apps/desktop/src/__tests__/composables/useCachedFetch.test.ts
+++ b/apps/desktop/src/__tests__/composables/useCachedFetch.test.ts
@@ -35,7 +35,7 @@ describe("useCachedFetch", () => {
     });
 
     it("sets loading state during fetch", async () => {
-      let resolvePromise: (value: any) => void;
+      let resolvePromise!: (value: any) => void;
       const fetcher = vi.fn(
         () =>
           new Promise((resolve) => {
@@ -203,7 +203,7 @@ describe("useCachedFetch", () => {
 
   describe("request deduplication", () => {
     it("deduplicates concurrent requests for same parameters", async () => {
-      let resolvePromise: (value: any) => void;
+      let resolvePromise!: (value: any) => void;
       const fetcher = vi.fn(
         () =>
           new Promise((resolve) => {
@@ -724,7 +724,7 @@ describe("useCachedFetch", () => {
 
   describe("silent mode", () => {
     it("does not update loading state when silent is true", async () => {
-      let resolvePromise: (value: any) => void;
+      let resolvePromise!: (value: any) => void;
       const fetcher = vi.fn(
         () =>
           new Promise((resolve) => {

--- a/apps/desktop/src/__tests__/stores/configInjector.test.ts
+++ b/apps/desktop/src/__tests__/stores/configInjector.test.ts
@@ -348,7 +348,7 @@ describe("useConfigInjectorStore", () => {
     });
 
     it("sets saving=true during operation", async () => {
-      let resolveSave: () => void;
+      let resolveSave!: () => void;
       const savePromise = new Promise<void>((resolve) => {
         resolveSave = resolve;
       });
@@ -410,7 +410,7 @@ describe("useConfigInjectorStore", () => {
     });
 
     it("sets saving=true during operation", async () => {
-      let resolveSave: () => void;
+      let resolveSave!: () => void;
       const savePromise = new Promise<void>((resolve) => {
         resolveSave = resolve;
       });

--- a/apps/desktop/src/__tests__/stores/worktrees.test.ts
+++ b/apps/desktop/src/__tests__/stores/worktrees.test.ts
@@ -247,7 +247,7 @@ describe("useWorktreesStore", () => {
 
     it("discards stale response when newer load is in progress", async () => {
       // First call resolves after second call
-      let resolveFirst: (v: WorktreeInfo[]) => void;
+      let resolveFirst!: (v: WorktreeInfo[]) => void;
       const firstPromise = new Promise<WorktreeInfo[]>((resolve) => {
         resolveFirst = resolve;
       });
@@ -277,7 +277,7 @@ describe("useWorktreesStore", () => {
 
     it("discards stale disk-hydration when a newer load starts", async () => {
       // Disk usage resolves AFTER a second loadWorktrees call starts
-      let resolveDiskUsage: (v: number) => void;
+      let resolveDiskUsage!: (v: number) => void;
       const diskPromise = new Promise<number>((resolve) => {
         resolveDiskUsage = resolve;
       });
@@ -379,7 +379,7 @@ describe("useWorktreesStore", () => {
     });
 
     it("discards results when a newer loadAllWorktrees call starts", async () => {
-      let resolveFirst: (v: WorktreeInfo[]) => void;
+      let resolveFirst!: (v: WorktreeInfo[]) => void;
       const firstPromise = new Promise<WorktreeInfo[]>((resolve) => {
         resolveFirst = resolve;
       });
@@ -433,7 +433,7 @@ describe("useWorktreesStore", () => {
 
     it("uses independent guard from loadWorktrees", async () => {
       // loadBranches should not be invalidated by loadWorktrees
-      let resolveBranches: (v: string[]) => void;
+      let resolveBranches!: (v: string[]) => void;
       const branchPromise = new Promise<string[]>((resolve) => {
         resolveBranches = resolve;
       });
@@ -987,7 +987,7 @@ describe("useWorktreesStore", () => {
       });
 
       it("prevents concurrent toggle for the same path", async () => {
-        let resolveToggle: (v: boolean) => void;
+        let resolveToggle!: (v: boolean) => void;
         const togglePromise = new Promise<boolean>((resolve) => {
           resolveToggle = resolve;
         });

--- a/apps/desktop/src/composables/__tests__/useAsyncData.test.ts
+++ b/apps/desktop/src/composables/__tests__/useAsyncData.test.ts
@@ -150,8 +150,8 @@ describe("useAsyncData", () => {
 
   describe("Stale Request Prevention", () => {
     it("should ignore results from superseded requests", async () => {
-      let resolveFirst: (value: string) => void;
-      let resolveSecond: (value: string) => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
 
       const firstPromise = new Promise<string>((resolve) => {
         resolveFirst = resolve;
@@ -185,8 +185,8 @@ describe("useAsyncData", () => {
     });
 
     it("should ignore errors from superseded requests", async () => {
-      let rejectFirst: (error: Error) => void;
-      let resolveSecond: (value: string) => void;
+      let rejectFirst!: (error: Error) => void;
+      let resolveSecond!: (value: string) => void;
 
       const firstPromise = new Promise<string>((_, reject) => {
         rejectFirst = reject;
@@ -221,8 +221,8 @@ describe("useAsyncData", () => {
     });
 
     it("should not update loading state for stale requests", async () => {
-      let resolveFirst: (value: string) => void;
-      let resolveSecond: (value: string) => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
 
       const firstPromise = new Promise<string>((resolve) => {
         resolveFirst = resolve;
@@ -311,8 +311,8 @@ describe("useAsyncData", () => {
 
     it("should not call onSuccess for stale requests", async () => {
       const onSuccess = vi.fn();
-      let resolveFirst: (value: string) => void;
-      let resolveSecond: (value: string) => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
 
       const firstPromise = new Promise<string>((resolve) => {
         resolveFirst = resolve;
@@ -562,7 +562,7 @@ describe("useAsyncData", () => {
     });
 
     it("should invalidate in-flight requests", async () => {
-      let resolveAsync: (value: string) => void;
+      let resolveAsync!: (value: string) => void;
       const asyncPromise = new Promise<string>((resolve) => {
         resolveAsync = resolve;
       });

--- a/apps/desktop/src/composables/__tests__/useAsyncGuard.test.ts
+++ b/apps/desktop/src/composables/__tests__/useAsyncGuard.test.ts
@@ -166,8 +166,8 @@ describe("useAsyncGuard", () => {
       const state = { data: null as string | null };
 
       // Simulate async operations with explicit timing control
-      let resolveFirst: (value: string) => void;
-      let resolveSecond: (value: string) => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
 
       const firstRequest = new Promise<string>((resolve) => {
         resolveFirst = resolve;

--- a/apps/desktop/src/composables/__tests__/useGitRepository.test.ts
+++ b/apps/desktop/src/composables/__tests__/useGitRepository.test.ts
@@ -371,7 +371,7 @@ describe("useGitRepository", () => {
     });
 
     it("should maintain reactivity of fetchingRemote", async () => {
-      let resolvePromise: () => void;
+      let resolvePromise!: () => void;
       const promise = new Promise<string>((resolve) => {
         resolvePromise = () => resolve("");
       });

--- a/apps/desktop/src/composables/__tests__/useIncidentChartData.test.ts
+++ b/apps/desktop/src/composables/__tests__/useIncidentChartData.test.ts
@@ -68,7 +68,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(false),
         layout,
       });
-      const bar = chartData.value?.bars[2]; // third bar has all incident types
+      const bar = chartData.value!.bars[2]; // third bar has all incident types
       // truncRect is at the bottom (highest y), rlRect is at the top (lowest y)
       expect(bar.truncRect.y).toBeGreaterThanOrEqual(bar.compRect.y);
       expect(bar.compRect.y).toBeGreaterThanOrEqual(bar.otherRect.y);
@@ -111,7 +111,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(true),
         layout,
       });
-      const bar = chartData.value?.bars[0];
+      const bar = chartData.value!.bars[0];
       expect(bar.rateLimits).toBeCloseTo(4 / 5);
       expect(bar.otherErrors).toBeCloseTo(6 / 5);
       expect(bar.compactions).toBeCloseTo(2 / 5);
@@ -131,7 +131,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(true),
         layout,
       });
-      const bar = chartData.value?.bars[0];
+      const bar = chartData.value!.bars[0];
       // With no activity, denominator is 1, so values are unchanged
       expect(bar.rateLimits).toBe(2);
       expect(bar.otherErrors).toBe(6);
@@ -174,7 +174,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(false),
         layout,
       });
-      expect(gridLines.value).toHaveLength(chartData.value?.yLabels.length);
+      expect(gridLines.value).toHaveLength(chartData.value!.yLabels.length);
     });
   });
 
@@ -188,7 +188,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(false),
         layout,
       });
-      const text = formatTooltip(chartData.value?.bars[0]);
+      const text = formatTooltip(chartData.value!.bars[0]);
       expect(text).toContain("2 rate limits");
       expect(text).toContain("3 errors");
       expect(text).toContain("3 compactions");
@@ -206,7 +206,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(false),
         layout,
       });
-      const text = formatTooltip(chartData.value?.bars[0]);
+      const text = formatTooltip(chartData.value!.bars[0]);
       expect(text).toContain("1 rate limit");
       expect(text).not.toMatch(/1 rate limits/);
       expect(text).toContain("1 compaction");
@@ -225,7 +225,7 @@ describe("useIncidentChartData", () => {
         normalize,
         layout,
       });
-      const text = formatTooltip(chartData.value?.bars[0]);
+      const text = formatTooltip(chartData.value!.bars[0]);
       expect(text).toContain("rate limits/session");
       expect(text).toContain("errors/session");
       expect(text).toContain("compactions/session");
@@ -241,7 +241,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(false),
         layout,
       });
-      const text = formatTooltip(chartData.value?.bars[0]);
+      const text = formatTooltip(chartData.value!.bars[0]);
       expect(text).toContain("no incidents");
     });
 
@@ -254,7 +254,7 @@ describe("useIncidentChartData", () => {
         normalize: ref(true),
         layout,
       });
-      const text = formatTooltip(chartData.value?.bars[0]);
+      const text = formatTooltip(chartData.value!.bars[0]);
       expect(text).toContain("no incidents");
     });
   });

--- a/apps/desktop/src/composables/__tests__/useLineAreaChartData.test.ts
+++ b/apps/desktop/src/composables/__tests__/useLineAreaChartData.test.ts
@@ -73,7 +73,7 @@ describe("useLineAreaChartData", () => {
         layout,
         accessor: (p) => p.tokens,
       });
-      const coords = chartData.value?.coords;
+      const coords = chartData.value!.coords;
       expect(coords[0]).toHaveProperty("date", "2025-01-01");
       expect(coords[0]).toHaveProperty("tokens", 100);
       expect(coords[0]).toHaveProperty("x");
@@ -87,7 +87,7 @@ describe("useLineAreaChartData", () => {
         accessor: (p) => p.tokens,
         yFormatter: (v) => `$${v.toFixed(2)}`,
       });
-      const labels = chartData.value?.yLabels;
+      const labels = chartData.value!.yLabels;
       expect(labels[0].value).toMatch(/^\$/);
     });
 
@@ -169,8 +169,8 @@ describe("useLineAreaChartData", () => {
         layout,
         accessor: (p) => p.tokens,
       });
-      expect(gridLines.value).toHaveLength(chartData.value?.yLabels.length);
-      expect(gridLines.value).toEqual(chartData.value?.yLabels.map((l) => l.y));
+      expect(gridLines.value).toHaveLength(chartData.value!.yLabels.length);
+      expect(gridLines.value).toEqual(chartData.value!.yLabels.map((l) => l.y));
     });
   });
 });

--- a/apps/desktop/src/composables/useTimelineToolState.ts
+++ b/apps/desktop/src/composables/useTimelineToolState.ts
@@ -189,11 +189,12 @@ export function useTimelineToolState(
   });
 
   // Turn ownership check (if provided)
-  const turnOwnsSelected = options.turnOwnershipCheck
+  const checkFn = options.turnOwnershipCheck;
+  const turnOwnsSelected = checkFn
     ? (turn: ConversationTurn) => {
         const sel = selectedTool.value;
         if (!sel) return false;
-        return options.turnOwnershipCheck?.(turn, sel);
+        return checkFn(turn, sel);
       }
     : undefined;
 


### PR DESCRIPTION
Fixes CI typecheck failure on main caused by TypeScript strict-mode errors in the desktop app.

Test files (8 files):
- Added definite assignment assertions to let vars assigned inside Promise constructors (TS2454)
- Used non-null assertions for array indexing in chart test files (TS18048/TS2345)

Production code (1 file):
- useTimelineToolState.ts: Fixed turnOwnsSelected return type by capturing turnOwnershipCheck in a local var, avoiding optional chaining that returned boolean|undefined (TS2322)

Verification:
- pnpm typecheck passes (all 6 workspace packages)
- All 296 tests in affected files pass