### PR TITLE
fix: null-safe assertion in escape sequence test

### DIFF
--- a/apps/desktop/src/utils/__tests__/skillFrontmatter.test.ts
+++ b/apps/desktop/src/utils/__tests__/skillFrontmatter.test.ts
@@ -56,7 +56,10 @@ describe("skillFrontmatter", () => {
       const parsed = parseSkillContent(
         ["---", "name: test", 'description: "tab\\there"', "---", "Body"].join("\n"),
       );
-      expect(parsed.frontmatter.description).toBe("tab\\there");
+      expect(parsed.frontmatter).toEqual({
+        name: "test",
+        description: "tab\\there",
+      });
     });
 
     it("parses multiline descriptions, resource globs, auto_attach, and trailing multiline flush", () => {


### PR DESCRIPTION
Uses toEqual instead of direct property access to avoid TS18047 (possibly null) in the unknown-escape-sequence test added in PR #328.