### PR TITLE
🧪 [testing improvement] Add error tests for parse_workspace_yaml

### DIFF
--- a/crates/tracepilot-core/src/parsing/workspace.rs
+++ b/crates/tracepilot-core/src/parsing/workspace.rs
@@ -111,4 +111,31 @@ updated_at: "2026-06-20T18:30:45.123Z"
         assert_eq!(updated.year(), 2026);
         assert_eq!(updated.month(), 6);
     }
+
+    #[test]
+    fn test_parse_workspace_yaml_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.yaml");
+        let err = parse_workspace_yaml(&path).unwrap_err();
+        match err {
+            TracePilotError::ParseError { context, .. } => {
+                assert!(context.starts_with("Failed to read"));
+            }
+            _ => panic!("Expected ParseError, got {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_parse_workspace_yaml_bad_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad-content.yaml");
+        std::fs::write(&path, "id: [invalid yaml").unwrap();
+        let err = parse_workspace_yaml(&path).unwrap_err();
+        match err {
+            TracePilotError::ParseError { context, .. } => {
+                assert!(context.starts_with("Failed to parse"));
+            }
+            _ => panic!("Expected ParseError, got {:?}", err),
+        }
+    }
 }

--- a/crates/tracepilot-core/src/parsing/workspace.rs
+++ b/crates/tracepilot-core/src/parsing/workspace.rs
@@ -117,9 +117,22 @@ updated_at: "2026-06-20T18:30:45.123Z"
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("does-not-exist.yaml");
         let err = parse_workspace_yaml(&path).unwrap_err();
-        match err {
-            TracePilotError::ParseError { context, .. } => {
-                assert!(context.starts_with("Failed to read"));
+        match &err {
+            TracePilotError::ParseError { context, source } => {
+                assert!(
+                    context.starts_with("Failed to read"),
+                    "expected 'Failed to read' prefix, got: {context}"
+                );
+                assert!(
+                    context.contains("does-not-exist.yaml"),
+                    "error context should include the filename, got: {context}"
+                );
+                let source = source.as_ref().expect("should have a source error");
+                assert!(
+                    source.to_string().contains("No such file")
+                        || source.to_string().contains("cannot find"),
+                    "source error should be IO not-found, got: {source}"
+                );
             }
             _ => panic!("Expected ParseError, got {:?}", err),
         }
@@ -131,9 +144,20 @@ updated_at: "2026-06-20T18:30:45.123Z"
         let path = dir.path().join("bad-content.yaml");
         std::fs::write(&path, "id: [invalid yaml").unwrap();
         let err = parse_workspace_yaml(&path).unwrap_err();
-        match err {
-            TracePilotError::ParseError { context, .. } => {
-                assert!(context.starts_with("Failed to parse"));
+        match &err {
+            TracePilotError::ParseError { context, source } => {
+                assert!(
+                    context.starts_with("Failed to parse"),
+                    "expected 'Failed to parse' prefix, got: {context}"
+                );
+                assert!(
+                    context.contains("bad-content.yaml"),
+                    "error context should include the filename, got: {context}"
+                );
+                assert!(
+                    source.is_some(),
+                    "should have a YAML parse source error"
+                );
             }
             _ => panic!("Expected ParseError, got {:?}", err),
         }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds missing error tests for `parse_workspace_yaml` in `crates/tracepilot-core/src/parsing/workspace.rs` to handle scenarios where the workspace metadata file fails to read or contains invalid content.

📊 **Coverage:** What scenarios are now tested
1. **Missing File:** Uses `tempdir` to simulate attempting to read a file that doesn't exist, asserting the `TracePilotError::ParseError` and context string.
2. **Bad Content:** Writes invalid YAML text (`id: [invalid yaml`) into a temporary file to test the parsing error handling, again asserting the correct error enum variant and context string.

✨ **Result:** The improvement in test coverage
Test coverage for `workspace.rs` has been improved, and both missing branches inside `parse_workspace_yaml` are now validated and safeguarded against regressions. All tests in `tracepilot-core` pass.

---
*PR created automatically by Jules for task [3643441501674544916](https://jules.google.com/task/3643441501674544916) started by @MattShelton04*