### PR TITLE
perf: unified multi-row VALUES batching for all bulk inserts

### DIFF
--- a/crates/tracepilot-export/src/import/writer.rs
+++ b/crates/tracepilot-export/src/import/writer.rs
@@ -285,41 +285,64 @@ fn write_session_db(todos: &TodoExport, dir: &Path) -> Result<()> {
         message: format!("failed to create tables: {}", e),
     })?;
 
-    // Insert todos
-    let mut stmt = conn
-        .prepare("INSERT INTO todos (id, title, description, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)")
+    // Insert todos + deps in a single transaction
+    conn.execute_batch("BEGIN")
         .map_err(|e| ExportError::SessionData {
-            message: format!("failed to prepare insert: {}", e),
+            message: format!("failed to begin transaction: {}", e),
         })?;
 
-    for item in &todos.items {
-        stmt.execute(rusqlite::params![
-            item.id,
-            item.title,
-            item.description,
-            item.status,
-            item.created_at,
-            item.updated_at,
-        ])
-        .map_err(|e| ExportError::SessionData {
-            message: format!("failed to insert todo '{}': {}", item.id, e),
-        })?;
-    }
-    drop(stmt);
+    let insert_result = (|| -> std::result::Result<(), ExportError> {
+        {
+            let mut stmt = conn
+                .prepare("INSERT INTO todos (id, title, description, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)")
+                .map_err(|e| ExportError::SessionData {
+                    message: format!("failed to prepare insert: {}", e),
+                })?;
 
-    // Insert deps
-    let mut dep_stmt = conn
-        .prepare("INSERT INTO todo_deps (todo_id, depends_on) VALUES (?1, ?2)")
-        .map_err(|e| ExportError::SessionData {
-            message: format!("failed to prepare dep insert: {}", e),
-        })?;
+            for item in &todos.items {
+                stmt.execute(rusqlite::params![
+                    item.id,
+                    item.title,
+                    item.description,
+                    item.status,
+                    item.created_at,
+                    item.updated_at,
+                ])
+                .map_err(|e| ExportError::SessionData {
+                    message: format!("failed to insert todo '{}': {}", item.id, e),
+                })?;
+            }
+        }
 
-    for dep in &todos.deps {
-        dep_stmt
-            .execute(rusqlite::params![dep.todo_id, dep.depends_on])
-            .map_err(|e| ExportError::SessionData {
-                message: format!("failed to insert dep: {}", e),
+        {
+            let mut dep_stmt = conn
+                .prepare("INSERT INTO todo_deps (todo_id, depends_on) VALUES (?1, ?2)")
+                .map_err(|e| ExportError::SessionData {
+                    message: format!("failed to prepare dep insert: {}", e),
+                })?;
+
+            for dep in &todos.deps {
+                dep_stmt
+                    .execute(rusqlite::params![dep.todo_id, dep.depends_on])
+                    .map_err(|e| ExportError::SessionData {
+                        message: format!("failed to insert dep: {}", e),
+                    })?;
+            }
+        }
+
+        Ok(())
+    })();
+
+    match insert_result {
+        Ok(()) => {
+            conn.execute_batch("COMMIT").map_err(|e| ExportError::SessionData {
+                message: format!("failed to commit transaction: {}", e),
             })?;
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(e);
+        }
     }
 
     Ok(())

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -1,0 +1,147 @@
+//! Multi-row INSERT batching for SQLite child-table writes.
+//!
+//! Instead of executing N individual `INSERT ... VALUES (?)` statements,
+//! this builds `INSERT ... VALUES (?,...),(?,...), ...` in chunks of 50,
+//! reducing statement count from N to ⌈N/50⌉. Within an explicit
+//! transaction (SAVEPOINT), the main win is fewer SQLite VM step() calls.
+
+use crate::Result;
+use rusqlite::types::Value;
+
+/// Maximum rows per multi-row INSERT statement.
+///
+/// With 9 columns (the widest child table), 50 × 9 = 450 bind parameters,
+/// well within SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32 766 since 3.32).
+const BATCH_CHUNK_SIZE: usize = 50;
+
+/// Execute a multi-row INSERT in chunks of up to [`BATCH_CHUNK_SIZE`] rows.
+///
+/// `sql_prefix` is everything up to (but not including) the first VALUES
+/// tuple, e.g. `"INSERT INTO t (a, b) VALUES"`.
+///
+/// Uses `prepare()` — **not** `prepare_cached()` — because the SQL string
+/// varies by chunk size (the last chunk is typically smaller).
+pub(crate) fn batched_insert<T>(
+    conn: &rusqlite::Connection,
+    sql_prefix: &str,
+    params_per_row: usize,
+    items: &[T],
+    to_values: impl Fn(&T) -> Vec<Value>,
+) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    for chunk in items.chunks(BATCH_CHUNK_SIZE) {
+        let placeholders: String = (0..chunk.len())
+            .map(|i| {
+                let start = i * params_per_row + 1;
+                let p: String = (start..start + params_per_row)
+                    .map(|n| format!("?{n}"))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("({p})")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let sql = format!("{sql_prefix} {placeholders}");
+        let mut stmt = conn.prepare(&sql)?;
+
+        let values: Vec<Value> = chunk.iter().flat_map(&to_values).collect();
+        stmt.execute(rusqlite::params_from_iter(values.iter()))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn empty_items_is_noop() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (a TEXT, b INTEGER)").unwrap();
+        let items: Vec<(String, i64)> = vec![];
+        batched_insert(
+            &conn,
+            "INSERT INTO t (a, b) VALUES",
+            2,
+            &items,
+            |_| unreachable!(),
+        )
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn inserts_exact_chunk_boundary() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (v INTEGER)").unwrap();
+        // Insert exactly BATCH_CHUNK_SIZE items
+        let items: Vec<i64> = (0..BATCH_CHUNK_SIZE as i64).collect();
+        batched_insert(&conn, "INSERT INTO t (v) VALUES", 1, &items, |&v| {
+            vec![Value::Integer(v)]
+        })
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, BATCH_CHUNK_SIZE as i64);
+    }
+
+    #[test]
+    fn inserts_across_chunk_boundary() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (v INTEGER)").unwrap();
+        let n = BATCH_CHUNK_SIZE as i64 + 7;
+        let items: Vec<i64> = (0..n).collect();
+        batched_insert(&conn, "INSERT INTO t (v) VALUES", 1, &items, |&v| {
+            vec![Value::Integer(v)]
+        })
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, n);
+    }
+
+    #[test]
+    fn handles_multi_column_with_nulls() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (a TEXT, b TEXT)").unwrap();
+        let items = vec![
+            (String::from("x"), Some(String::from("y"))),
+            (String::from("z"), None),
+        ];
+        batched_insert(
+            &conn,
+            "INSERT INTO t (a, b) VALUES",
+            2,
+            &items,
+            |(a, b)| {
+                vec![
+                    Value::Text(a.clone()),
+                    match b {
+                        Some(s) => Value::Text(s.clone()),
+                        None => Value::Null,
+                    },
+                ]
+            },
+        )
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+        let null_count: i64 = conn
+            .query_row("SELECT count(*) FROM t WHERE b IS NULL", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(null_count, 1);
+    }
+}

--- a/crates/tracepilot-indexer/src/index_db/mod.rs
+++ b/crates/tracepilot-indexer/src/index_db/mod.rs
@@ -9,6 +9,7 @@
 //! - `analytics_queries` — Aggregate analytics, tool analysis, code impact queries
 
 mod analytics_queries;
+pub(crate) mod batch_insert;
 mod helpers;
 mod migrations;
 mod row_helpers;

--- a/crates/tracepilot-indexer/src/index_db/search_writer/mod.rs
+++ b/crates/tracepilot-indexer/src/index_db/search_writer/mod.rs
@@ -13,6 +13,9 @@ mod tool_extraction;
 #[cfg(test)]
 mod tests;
 
+use rusqlite::types::Value;
+use super::batch_insert::batched_insert;
+
 use crate::Result;
 use rusqlite::params;
 use std::path::Path;
@@ -117,31 +120,40 @@ impl IndexDb {
                 [session_id],
             )?;
 
-            // Batch insert new content
-            let mut stmt = self.conn.prepare(
-                "INSERT INTO search_content
-                    (session_id, content_type, turn_number, event_index,
-                     timestamp_unix, tool_name, content, metadata_json)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            // Batch insert new content (skip empty rows)
+            let non_empty: Vec<&SearchContentRow> =
+                rows.iter().filter(|r| !r.content.is_empty()).collect();
+            batched_insert(
+                &self.conn,
+                "INSERT INTO search_content \
+                    (session_id, content_type, turn_number, event_index, \
+                     timestamp_unix, tool_name, content, metadata_json) VALUES",
+                8,
+                &non_empty,
+                |row| vec![
+                    Value::Text(row.session_id.clone()),
+                    Value::Text(row.content_type.to_string()),
+                    match row.turn_number {
+                        Some(n) => Value::Integer(n),
+                        None => Value::Null,
+                    },
+                    Value::Integer(row.event_index),
+                    match row.timestamp_unix {
+                        Some(n) => Value::Integer(n),
+                        None => Value::Null,
+                    },
+                    match &row.tool_name {
+                        Some(s) => Value::Text(s.clone()),
+                        None => Value::Null,
+                    },
+                    Value::Text(row.content.clone()),
+                    match &row.metadata_json {
+                        Some(s) => Value::Text(s.clone()),
+                        None => Value::Null,
+                    },
+                ],
             )?;
-
-            let mut inserted = 0;
-            for row in rows {
-                if row.content.is_empty() {
-                    continue;
-                }
-                stmt.execute(params![
-                    row.session_id,
-                    row.content_type,
-                    row.turn_number,
-                    row.event_index,
-                    row.timestamp_unix,
-                    row.tool_name,
-                    row.content,
-                    row.metadata_json,
-                ])?;
-                inserted += 1;
-            }
+            let inserted = non_empty.len();
 
             // Update search indexing timestamp and extractor version
             let now = chrono::Utc::now().to_rfc3339();
@@ -207,13 +219,6 @@ impl IndexDb {
             )?;
 
             // Step 2: Delete + insert content rows (no FTS overhead)
-            let mut stmt = self.conn.prepare(
-                "INSERT INTO search_content
-                    (session_id, content_type, turn_number, event_index,
-                     timestamp_unix, tool_name, content, metadata_json)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            )?;
-
             let now = chrono::Utc::now().to_rfc3339();
             let mut total_inserted = 0;
 
@@ -224,22 +229,39 @@ impl IndexDb {
                     [session_id.as_str()],
                 )?;
 
-                for row in rows {
-                    if row.content.is_empty() {
-                        continue;
-                    }
-                    stmt.execute(params![
-                        row.session_id,
-                        row.content_type,
-                        row.turn_number,
-                        row.event_index,
-                        row.timestamp_unix,
-                        row.tool_name,
-                        row.content,
-                        row.metadata_json,
-                    ])?;
-                    total_inserted += 1;
-                }
+                let non_empty: Vec<&SearchContentRow> =
+                    rows.iter().filter(|r| !r.content.is_empty()).collect();
+                batched_insert(
+                    &self.conn,
+                    "INSERT INTO search_content \
+                        (session_id, content_type, turn_number, event_index, \
+                         timestamp_unix, tool_name, content, metadata_json) VALUES",
+                    8,
+                    &non_empty,
+                    |row| vec![
+                        Value::Text(row.session_id.clone()),
+                        Value::Text(row.content_type.to_string()),
+                        match row.turn_number {
+                            Some(n) => Value::Integer(n),
+                            None => Value::Null,
+                        },
+                        Value::Integer(row.event_index),
+                        match row.timestamp_unix {
+                            Some(n) => Value::Integer(n),
+                            None => Value::Null,
+                        },
+                        match &row.tool_name {
+                            Some(s) => Value::Text(s.clone()),
+                            None => Value::Null,
+                        },
+                        Value::Text(row.content.clone()),
+                        match &row.metadata_json {
+                            Some(s) => Value::Text(s.clone()),
+                            None => Value::Null,
+                        },
+                    ],
+                )?;
+                total_inserted += non_empty.len();
 
                 // Mark session as indexed
                 self.conn.execute(

--- a/crates/tracepilot-indexer/src/index_db/session_writer.rs
+++ b/crates/tracepilot-indexer/src/index_db/session_writer.rs
@@ -2,6 +2,7 @@
 
 use crate::Result;
 use rusqlite::params;
+use rusqlite::types::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -191,121 +192,130 @@ impl IndexDb {
             )?;
 
             // ──────────────────────────────────────────────────────────────
-            // INSERT child rows using prepared statement batching
+            // INSERT child rows using multi-row VALUES batching
             // ──────────────────────────────────────────────────────────────
-            // Pattern: Prepare SQL once, execute N times (2-10x faster than
-            // individual execute() calls). Empty arrays are skipped to avoid
-            // unnecessary prepare() overhead.
-            //
-            // For 300-700+ child rows per session across 6 tables:
-            //   Before: 300-700 prepare() + execute() calls
-            //   After:  6 prepare() calls + 300-700 execute() calls
+            // Builds INSERT ... VALUES (...),(...),... in chunks of 50,
+            // reducing round-trips from N to ceil(N/50).
             // ──────────────────────────────────────────────────────────────
+            use super::batch_insert::batched_insert;
 
-            // INSERT child rows: model metrics (batch)
-            if !analytics.model_rows.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT INTO session_model_metrics
-                        (session_id, model_name, input_tokens, output_tokens,
-                         cache_read_tokens, cache_write_tokens, cost, request_count)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                )?;
-                for row in &analytics.model_rows {
-                    stmt.execute(params![
-                        &session_id,
-                        &row.model,
-                        row.input_tokens,
-                        row.output_tokens,
-                        row.cache_read_tokens,
-                        row.cache_write_tokens,
-                        row.cost,
-                        row.premium_requests
-                    ])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT INTO session_model_metrics \
+                    (session_id, model_name, input_tokens, output_tokens, \
+                     cache_read_tokens, cache_write_tokens, cost, request_count) VALUES",
+                8,
+                &analytics.model_rows,
+                |row| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Text(row.model.clone()),
+                    Value::Integer(row.input_tokens),
+                    Value::Integer(row.output_tokens),
+                    Value::Integer(row.cache_read_tokens),
+                    Value::Integer(row.cache_write_tokens),
+                    Value::Real(row.cost),
+                    Value::Integer(row.premium_requests),
+                ],
+            )?;
 
-            // INSERT child rows: tool calls (batch)
-            if !analytics.tool_call_rows.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT INTO session_tool_calls
-                        (session_id, tool_name, call_count, success_count, failure_count, total_duration_ms, calls_with_duration)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                )?;
-                for row in &analytics.tool_call_rows {
-                    stmt.execute(params![
-                        &session_id,
-                        &row.name,
-                        row.calls,
-                        row.success,
-                        row.failure,
-                        row.duration_ms,
-                        row.calls_with_duration
-                    ])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT INTO session_tool_calls \
+                    (session_id, tool_name, call_count, success_count, \
+                     failure_count, total_duration_ms, calls_with_duration) VALUES",
+                7,
+                &analytics.tool_call_rows,
+                |row| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Text(row.name.clone()),
+                    Value::Integer(row.calls),
+                    Value::Integer(row.success),
+                    Value::Integer(row.failure),
+                    Value::Integer(row.duration_ms),
+                    Value::Integer(row.calls_with_duration),
+                ],
+            )?;
 
-            // INSERT child rows: modified files (batch)
-            if !analytics.modified_file_rows.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT OR IGNORE INTO session_modified_files (session_id, file_path, extension)
-                     VALUES (?1, ?2, ?3)",
-                )?;
-                for row in &analytics.modified_file_rows {
-                    stmt.execute(params![&session_id, &row.file_path, &row.extension])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT OR IGNORE INTO session_modified_files \
+                    (session_id, file_path, extension) VALUES",
+                3,
+                &analytics.modified_file_rows,
+                |row| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Text(row.file_path.clone()),
+                    match &row.extension {
+                        Some(ext) => Value::Text(ext.clone()),
+                        None => Value::Null,
+                    },
+                ],
+            )?;
 
-            // INSERT child rows: activity heatmap (batch)
-            if !analytics.activity_rows.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT INTO session_activity (session_id, day_of_week, hour, tool_call_count)
-                     VALUES (?1, ?2, ?3, ?4)",
-                )?;
-                for row in &analytics.activity_rows {
-                    stmt.execute(params![&session_id, row.day_of_week, row.hour, row.tool_call_count])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT INTO session_activity \
+                    (session_id, day_of_week, hour, tool_call_count) VALUES",
+                4,
+                &analytics.activity_rows,
+                |row| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Integer(row.day_of_week),
+                    Value::Integer(row.hour),
+                    Value::Integer(row.tool_call_count),
+                ],
+            )?;
 
-            // INSERT child rows: session segments (batch)
-            if !analytics.session_segment_rows.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT INTO session_segments (session_id, start_timestamp, end_timestamp, total_tokens, total_requests, total_premium_requests, total_api_duration_ms, current_model, model_metrics_json)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                )?;
-                for row in &analytics.session_segment_rows {
-                    stmt.execute(params![
-                        &session_id,
-                        &row.start_timestamp,
-                        &row.end_timestamp,
-                        row.tokens,
-                        row.total_requests,
-                        row.premium_requests,
-                        row.api_duration_ms,
-                        &row.current_model,
-                        &row.model_metrics_json
-                    ])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT INTO session_segments \
+                    (session_id, start_timestamp, end_timestamp, total_tokens, \
+                     total_requests, total_premium_requests, total_api_duration_ms, \
+                     current_model, model_metrics_json) VALUES",
+                9,
+                &analytics.session_segment_rows,
+                |row| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Text(row.start_timestamp.clone()),
+                    Value::Text(row.end_timestamp.clone()),
+                    Value::Integer(row.tokens),
+                    Value::Integer(row.total_requests),
+                    Value::Real(row.premium_requests),
+                    Value::Integer(row.api_duration_ms),
+                    match &row.current_model {
+                        Some(m) => Value::Text(m.clone()),
+                        None => Value::Null,
+                    },
+                    match &row.model_metrics_json {
+                        Some(j) => Value::Text(j.clone()),
+                        None => Value::Null,
+                    },
+                ],
+            )?;
 
-            // INSERT child rows: incidents (batch)
-            if !analytics.incidents.is_empty() {
-                let mut stmt = self.conn.prepare(
-                    "INSERT INTO session_incidents
-                        (session_id, event_type, source_event_type, timestamp, severity, summary, detail_json)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                )?;
-                for inc in &analytics.incidents {
-                    stmt.execute(params![
-                        &session_id,
-                        &inc.event_type,
-                        &inc.source_event_type,
-                        &inc.timestamp,
-                        &inc.severity,
-                        &inc.summary,
-                        &inc.detail_json
-                    ])?;
-                }
-            }
+            batched_insert(
+                &self.conn,
+                "INSERT INTO session_incidents \
+                    (session_id, event_type, source_event_type, timestamp, \
+                     severity, summary, detail_json) VALUES",
+                7,
+                &analytics.incidents,
+                |inc| vec![
+                    Value::Text(session_id.clone()),
+                    Value::Text(inc.event_type.clone()),
+                    Value::Text(inc.source_event_type.clone()),
+                    match &inc.timestamp {
+                        Some(t) => Value::Text(t.clone()),
+                        None => Value::Null,
+                    },
+                    Value::Text(inc.severity.clone()),
+                    Value::Text(inc.summary.clone()),
+                    match &inc.detail_json {
+                        Some(d) => Value::Text(d.clone()),
+                        None => Value::Null,
+                    },
+                ],
+            )?;
 
             Ok(())
         })();
@@ -400,27 +410,21 @@ impl IndexDb {
 
         self.conn.execute_batch("BEGIN")?;
         let result = (|| -> Result<()> {
-            self.conn.execute_batch(
-                "CREATE TEMP TABLE IF NOT EXISTS _live_ids (id TEXT PRIMARY KEY)",
-            )?;
-            self.conn.execute_batch("DELETE FROM _live_ids")?;
+            // Use json_each() to pass all live IDs as a single JSON array parameter,
+            // avoiding the N individual INSERT statements into a temp table.
+            let live_json = serde_json::to_string(
+                &live_ids.iter().collect::<Vec<_>>(),
+            )
+            .expect("string serialization is infallible");
 
-            let mut stmt = self
-                .conn
-                .prepare("INSERT OR IGNORE INTO _live_ids (id) VALUES (?1)")?;
-            for id in live_ids {
-                stmt.execute([id])?;
-            }
-
-            self.conn.execute_batch(
-                "DELETE FROM sessions WHERE id NOT IN (SELECT id FROM _live_ids)",
+            self.conn.execute(
+                "DELETE FROM sessions WHERE id NOT IN (SELECT value FROM json_each(?1))",
+                [&live_json],
             )?;
-            // search_content rows cascade-deleted via FK, but clean up explicitly
-            self.conn.execute_batch(
-                "DELETE FROM search_content WHERE session_id NOT IN (SELECT id FROM _live_ids)",
+            self.conn.execute(
+                "DELETE FROM search_content WHERE session_id NOT IN (SELECT value FROM json_each(?1))",
+                [&live_json],
             )?;
-            self.conn
-                .execute_batch("DROP TABLE IF EXISTS _live_ids")?;
             Ok(())
         })();
 


### PR DESCRIPTION
## Summary

Consolidates the best performance approaches from PRs #398, #393, #397, and #403 into a single coherent implementation with a shared helper.

## Changes

### New: `batch_insert.rs` — Shared multi-row helper
- `batched_insert<T>()` builds `INSERT ... VALUES (...),(...), ...` in chunks of 50 rows
- Uses `rusqlite::types::Value` for heterogeneous parameters
- Uses `prepare()` (not `prepare_cached()`) since dynamic SQL varies per chunk size
- Includes 4 unit tests (empty, single, exact boundary, multi-chunk)

### `session_writer.rs` — 6 child table inserts converted
- Replaces 6 prepare-once/execute-N loops with `batched_insert` calls
- Reduces statement count from ~300-700 per session to ceil(N/50) per table

### `session_writer.rs` — `prune_deleted` uses `json_each()`
- Replaces temp table creation → N inserts → DELETE → DROP pattern
- Single `json_each(?1)` parameter passes all live IDs as JSON array
- Eliminates temp table overhead entirely

### `search_writer/mod.rs` — Both insert paths converted
- `upsert_search_content`: single-session path uses `batched_insert`
- `bulk_write_search_content`: multi-session rebuild path uses `batched_insert`
- Pre-filters empty content rows before batch insert

### `import/writer.rs` — Transaction wrapping
- Wraps todo + dependency inserts in `BEGIN/COMMIT` with proper rollback on failure
- Scope blocks manage statement lifetimes correctly

## Testing
- All 151 indexer tests pass
- All 171 export tests pass (127 + 44)
- 4 new unit tests for `batched_insert` helper

## Supersedes
This PR is intended to replace PRs #398, #393, #397, #403 (and their duplicates #400, #395, #394, #390, #392, #391) with a single unified implementation.