### PR TITLE
🧪 Add unit tests for formatLiveDuration formatter

### DIFF
--- a/packages/types/tests/formatters.test.ts
+++ b/packages/types/tests/formatters.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatLiveDuration } from "../src/utils/formatters.js";
+
+describe("formatLiveDuration", () => {
+  it("should return empty string for null or undefined", () => {
+    expect(formatLiveDuration(null)).toBe("");
+    expect(formatLiveDuration(undefined)).toBe("");
+  });
+
+  it("should return empty string for non-finite values", () => {
+    expect(formatLiveDuration(NaN)).toBe("");
+    expect(formatLiveDuration(Infinity)).toBe("");
+    expect(formatLiveDuration(-Infinity)).toBe("");
+  });
+
+  it("should return empty string for negative values", () => {
+    expect(formatLiveDuration(-100)).toBe("");
+    expect(formatLiveDuration(-1000)).toBe("");
+  });
+
+  it("should format values under 1000ms as 0ms after flooring", () => {
+    expect(formatLiveDuration(0)).toBe("0ms");
+    expect(formatLiveDuration(500)).toBe("0ms");
+    expect(formatLiveDuration(999)).toBe("0ms");
+  });
+
+  it("should floor to nearest whole second", () => {
+    expect(formatLiveDuration(1000)).toBe("1s");
+    expect(formatLiveDuration(1500)).toBe("1s");
+    expect(formatLiveDuration(1999)).toBe("1s");
+    expect(formatLiveDuration(2000)).toBe("2s");
+  });
+
+  it("should handle larger durations properly based on formatDuration logic", () => {
+    // 60000ms = 1m
+    expect(formatLiveDuration(60000)).toBe("1m 0s");
+    expect(formatLiveDuration(65432)).toBe("1m 5s"); // floored to 65000
+
+    // 3600000ms = 1h
+    expect(formatLiveDuration(3600000)).toBe("1h 0m");
+    expect(formatLiveDuration(3665432)).toBe("1h 1m"); // floored to 3665000 = 1h 1m 5s but formatDuration returns "1h 1m" for hours > 0
+  });
+});


### PR DESCRIPTION
🎯 **What:** The untested `formatLiveDuration` function in `@tracepilot/types` was missing tests.
📊 **Coverage:** Added tests to cover:
- Happy paths (e.g. valid durations formatting to `1s`, `2s`, etc.)
- Edge cases (`null`, `undefined`, `NaN`, `Infinity`, `-Infinity`)
- Negative durations (returns empty string)
- Values under 1000ms (floored properly to `0ms`)
- Flooring to nearest whole second properly (e.g., `1500ms` -> `1s`, `1999ms` -> `1s`).
✨ **Result:** Enhanced test suite coverage preventing future regressions in UI formatting behaviors related to live timer durations.

Verification steps for user:
1. Run `pnpm -F @tracepilot/types test tests/formatters.test.ts` to verify the tests pass successfully.
2. Run `pnpm test` on the workspace to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [16948503982627968018](https://jules.google.com/task/16948503982627968018) started by @MattShelton04*