### PR TITLE
🧹 Remove deprecated `exportSession` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project loosely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## [Unreleased]
 
+### Removed
+- Deprecated `exportSession()` client API — use `exportSessions()` instead (same functionality, accepts a single config)
+
 ## [0.6.1] - 2026-03-31
 
 ### Added

--- a/apps/desktop/src/__tests__/client/mockFallback.test.ts
+++ b/apps/desktop/src/__tests__/client/mockFallback.test.ts
@@ -12,7 +12,6 @@
 
 import type { ContextSnippet, FtsHealthInfo } from "@tracepilot/client";
 import {
-  exportSession,
   exportSessions,
   ftsHealth,
   ftsIntegrityCheck,
@@ -81,16 +80,6 @@ describe("Export mock fallback", () => {
     expect(typeof result.filePath).toBe("string");
     expect(typeof result.fileSizeBytes).toBe("number");
     expect(typeof result.exportedAt).toBe("string");
-  });
-
-  it("exportSession (deprecated) delegates to exportSessions", async () => {
-    const result = await exportSession({
-      sessionIds: ["sess-1"],
-      format: "json",
-      sections: ["conversation"],
-      outputPath: "/out.json",
-    });
-    expect(result.sessionsExported).toBeGreaterThanOrEqual(0);
   });
 
   it("previewExport resolves to an ExportPreviewResult", async () => {

--- a/docs/data-integration-guide.md
+++ b/docs/data-integration-guide.md
@@ -91,7 +91,7 @@ These functions bypass `invoke()` entirely and return hardcoded mock data:
 | `getToolAnalysis()` | `MOCK_TOOL_ANALYSIS` | `ToolAnalysisData` | `ToolAnalysisView` |
 | `getCodeImpact()` | `MOCK_CODE_IMPACT` | `CodeImpactData` | `CodeImpactView` |
 | `getHealthScores()` | `MOCK_HEALTH_SCORING` | `HealthScoringData` | `HealthScoringView` |
-| `exportSession(config)` | `MOCK_EXPORT_RESULT` | `ExportConfig → ExportResult` | `ExportView` |
+| `exportSessions(config)` | `MOCK_EXPORT_RESULT` | `ExportConfig → ExportResult` | `ExportView` |
 
 ---
 
@@ -278,7 +278,7 @@ These functions bypass `invoke()` entirely and return hardcoded mock data:
 - Return `ExportResult` (success, file path, count)
 - Tauri file dialog for choosing destination
 
-**Current state:** Calls `exportSession(config)` → returns `MOCK_EXPORT_RESULT`. The `tracepilot-export` crate already exists but isn't wired to the Tauri plugin.
+**Current state:** Calls `exportSessions(config)` → returns `MOCK_EXPORT_RESULT`. The `tracepilot-export` crate already exists but isn't wired to the Tauri plugin.
 
 **How to wire it:**
 
@@ -299,7 +299,7 @@ These functions bypass `invoke()` entirely and return hardcoded mock data:
 
 4. **Update client** — replace `MOCK_EXPORT_RESULT` return:
    ```typescript
-   export async function exportSession(config: ExportConfig): Promise<ExportResult> {
+   export async function exportSessions(config: ExportConfig): Promise<ExportResult> {
      return invoke<ExportResult>("export_session", { config });
    }
    ```

--- a/docs/reports/impl-plan-3-frontend-reliability.md
+++ b/docs/reports/impl-plan-3-frontend-reliability.md
@@ -391,7 +391,7 @@ async function getMockModule() {
 **Additional changes required**:
 - `getMockData()` must become `async` since it now depends on a dynamic import
 - All `invoke()` calls that use mock fallbacks must `await` the lazy import
-- `getHealthScores()` and `exportSession()` also reference mocks and must lazy-load them
+- `getHealthScores()` and `exportSessions()` also reference mocks and must lazy-load them
 - Instead of building one huge mock object eagerly, use an async switch-based resolver:
 
 ```ts

--- a/docs/tech-debt-report.md
+++ b/docs/tech-debt-report.md
@@ -512,7 +512,7 @@ Note: Lower severity for a Tauri desktop app, but window resizing still matters.
 |----------|-------|
 | 🟠 High | Zero tests — critical IPC bridge untested |
 | 🟠 High | No error handling layer — raw `invoke()` with no try/catch, retry, or error normalization |
-| 🟡 Medium | `getHealthScores()` and `exportSession()` are permanent stubs returning mocks even in Tauri |
+| 🟡 Medium | `getHealthScores()` and `exportSessions()` are permanent stubs returning mocks even in Tauri |
 | 🟡 Medium | No caching strategy — every call hits the backend |
 | 🟡 Medium | 46 KB mock data file (`mock/index.ts`) should be extracted to JSON or test-fixtures package |
 | 🟢 Low | Unnecessary `SessionHealth` re-export from types package |

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -658,13 +658,6 @@ export async function importSessions(config: ImportConfig): Promise<ImportResult
   });
 }
 
-/**
- * @deprecated Use `exportSessions` instead. Kept for backward compatibility.
- */
-export async function exportSession(config: ExportConfig): Promise<ExportResult> {
-  return exportSessions(config);
-}
-
 // ── Setup / Configuration Commands ────────────────────────────
 
 /** Check if TracePilot config.toml exists (determines if setup is needed). */


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `exportSession` function from `@tracepilot/client` and cleaned up its corresponding test dependencies in the desktop app.

💡 **Why:** The API `exportSession` was deprecated in favor of `exportSessions`. Removing it reduces technical debt, cleans up dead code, and improves the overall maintainability and readability of the codebase by eliminating legacy patterns.

✅ **Verification:** 
- Successfully ran `pnpm typecheck` and `pnpm test` ensuring no remaining references or failing tests in the workspace exist.
- Received code review approval confirming the correct and safe removal of the function and its legacy test footprint without breaking functionality.

✨ **Result:** Improved code health by stripping out unneeded, legacy backward-compatibility shims.

---
*PR created automatically by Jules for task [9037984255275497041](https://jules.google.com/task/9037984255275497041) started by @MattShelton04*