### PR TITLE
🧹 refactor(mcp): remove deprecated transport field from McpServerConfig

### DIFF
--- a/apps/desktop/src/components/mcp/McpConfigEditor.vue
+++ b/apps/desktop/src/components/mcp/McpConfigEditor.vue
@@ -45,7 +45,7 @@ function syncFromProps() {
   form.command = props.config.command ?? "";
   form.args = (props.config.args ?? []).join(", ");
   form.url = props.config.url ?? "";
-  form.transport = props.config.type ?? props.config.transport ?? "stdio";
+  form.transport = props.config.type ?? "stdio";
   form.description = props.config.description ?? "";
   form.tags = (props.config.tags ?? []).join(", ");
   form.tools = (props.config.tools ?? []).join(", ");

--- a/apps/desktop/src/components/mcp/McpServerCard.vue
+++ b/apps/desktop/src/components/mcp/McpServerCard.vue
@@ -17,7 +17,7 @@ const router = useRouter();
 
 const iconLetter = computed(() => props.server.name.charAt(0).toUpperCase());
 
-const transportLabel = computed(() => props.server.config.type ?? props.server.config.transport ?? "stdio");
+const transportLabel = computed(() => props.server.config.type ?? "stdio");
 
 const healthStatus = computed(() => props.server.health?.status ?? ("unknown" as const));
 

--- a/apps/desktop/src/views/mcp/McpServerDetailView.vue
+++ b/apps/desktop/src/views/mcp/McpServerDetailView.vue
@@ -66,7 +66,7 @@ const lastCheckedDisplay = computed(() => {
   }
 });
 
-const transportLabel = computed(() => server.value?.config.type ?? server.value?.config.transport ?? "stdio");
+const transportLabel = computed(() => server.value?.config.type ?? "stdio");
 
 const iconLetter = computed(() => server.value?.name.charAt(0).toUpperCase() ?? "?");
 
@@ -304,7 +304,7 @@ function goBack() {
                   <span class="transport-badge">{{ transportLabel }}</span>
                 </div>
               </div>
-              <template v-if="(server.config.type ?? server.config.transport) !== 'sse' && (server.config.type ?? server.config.transport) !== 'http' && (server.config.type ?? server.config.transport) !== 'streamable-http'">
+              <template v-if="server.config.type !== 'sse' && server.config.type !== 'http' && server.config.type !== 'streamable-http'">
                 <div v-if="server.config.command" class="config-row">
                   <div class="config-label">Command</div>
                   <div class="config-value">

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -6,7 +6,6 @@ export type McpTransport = "stdio" | "local" | "sse" | "streamable-http" | "http
 /** Configuration for a single MCP server.
  *
  * The `type` field matches the Copilot CLI `mcp-config.json` format.
- * `transport` is kept as an alias for backward compatibility.
  */
 export interface McpServerConfig {
   command?: string;
@@ -15,8 +14,6 @@ export interface McpServerConfig {
   url?: string;
   /** Transport type — serialized as `"type"` in JSON by the Rust backend. */
   type?: McpTransport;
-  /** @deprecated Use `type` instead. Kept for backward compat. */
-  transport?: McpTransport;
   /** HTTP headers for remote MCP servers. */
   headers?: Record<string, string>;
   /** Tool filter patterns (e.g. `["*"]`). */


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `transport` field from the TypeScript `McpServerConfig` interface and eliminated all frontend fallback checks referencing it.
💡 **Why:** The `transport` field was kept strictly for backwards compatibility in earlier configs. Removing it simplifies the type definition, cleans up frontend logic, and guarantees consistent reliance on the standard `type` field which maps natively to the Copilot CLI `mcp-config.json` format.
✅ **Verification:** Verified compilation via `pnpm typecheck` (no TS errors remaining). Verified frontend tests via `pnpm test` (all passed). Verified rust backend tests via `cargo test -p tracepilot-orchestrator` (all relevant passed).
✨ **Result:** A cleaner interface definition and frontend logic that relies on a single source of truth for transport type resolution.

---
*PR created automatically by Jules for task [3934804601870375812](https://jules.google.com/task/3934804601870375812) started by @MattShelton04*