### PR TITLE
🎨 Palette: Add loading state and aria-busy to ActionButton

### DIFF
--- a/packages/ui/src/components/ActionButton.vue
+++ b/packages/ui/src/components/ActionButton.vue
@@ -16,7 +16,6 @@ defineProps<{
     :class="[
       variant === 'primary' ? 'btn-primary' : variant === 'ghost' ? 'btn-ghost' : '',
       size === 'sm' ? 'btn-sm' : '',
-      { 'is-loading': loading }
     ]"
     :disabled="disabled || loading"
     :aria-busy="loading"
@@ -48,7 +47,6 @@ defineProps<{
   transition: opacity 0.15s ease;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
 }
 .opacity-0 {
   opacity: 0;

--- a/packages/ui/src/components/ActionButton.vue
+++ b/packages/ui/src/components/ActionButton.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import LoadingSpinner from "./LoadingSpinner.vue";
+
 defineProps<{
   disabled?: boolean;
+  loading?: boolean;
   size?: "sm" | "md";
   variant?: "primary" | "ghost" | "default";
 }>();
@@ -9,13 +12,45 @@ defineProps<{
 <template>
   <button
     type="button"
-    class="btn"
+    class="btn action-btn"
     :class="[
       variant === 'primary' ? 'btn-primary' : variant === 'ghost' ? 'btn-ghost' : '',
       size === 'sm' ? 'btn-sm' : '',
+      { 'is-loading': loading }
     ]"
-    :disabled="disabled"
+    :disabled="disabled || loading"
+    :aria-busy="loading"
   >
-    <slot />
+    <span v-if="loading" class="action-btn__spinner">
+      <LoadingSpinner size="sm" color="currentColor" />
+    </span>
+    <span class="action-btn__content" :class="{ 'opacity-0': loading }">
+      <slot />
+    </span>
   </button>
 </template>
+
+<style scoped>
+.action-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.action-btn__spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+}
+.action-btn__content {
+  transition: opacity 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.opacity-0 {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
💡 What: The UX enhancement added a `loading` property to the `ActionButton` component in `packages/ui`.
🎯 Why: Async operations need immediate visual feedback and disabling of the trigger to prevent multi-clicks.
♿ Accessibility: The button is disabled during loading and uses `aria-busy="true"` so screen readers are aware of the processing state.

To test: View any screen utilizing `ActionButton` and toggle its loading state. It should fade out the text, prevent width jumping, and display a standard LoadingSpinner.

---
*PR created automatically by Jules for task [10396490179019465272](https://jules.google.com/task/10396490179019465272) started by @MattShelton04*