### PR TITLE
🎨 Palette: [a11y] Add aria-labels to RefreshToolbar components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Tooltip VS Aria-labels for icon-only buttons
+**Learning:** Even if an icon-only button has a `title` attribute, an explicit `aria-label` is recommended for robust screen reader support. Wait, `title` can provide an accessible name but it can be inconsistent across browsers and assistive technologies. Explicit `aria-label` is always preferred.
+**Action:** Always add an explicit `aria-label` to icon-only buttons, even if a `title` attribute is already present for visual tooltips.

--- a/apps/desktop/src/components/RefreshToolbar.vue
+++ b/apps/desktop/src/components/RefreshToolbar.vue
@@ -66,6 +66,7 @@ onUnmounted(() => {
       :class="{ 'refresh-btn--spinning': showSpinner }"
       :disabled="refreshing"
       title="Refresh data"
+      aria-label="Refresh data"
       @click="emit('refresh')"
     >
       <svg class="refresh-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -78,6 +79,7 @@ onUnmounted(() => {
       <input
         type="checkbox"
         :checked="autoRefreshEnabled"
+        aria-label="Enable auto-refresh"
         @change="emit('update:autoRefreshEnabled', ($event.target as HTMLInputElement).checked)"
       />
       <span class="auto-toggle-label">Auto</span>
@@ -87,6 +89,7 @@ onUnmounted(() => {
       v-if="autoRefreshEnabled"
       class="interval-cycle-btn"
       :title="`Auto-refresh every ${intervalLabel} (click to change)`"
+      aria-label="Change auto-refresh interval"
       @click="cycleInterval"
     >
       {{ intervalLabel }}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only refresh button, auto-refresh checkbox, and the auto-refresh interval cycle button in the `RefreshToolbar` component.
🎯 Why: To improve accessibility for screen readers, providing explicit context for these interactive elements.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader support for key toolbar controls.

---
*PR created automatically by Jules for task [13611168918215101688](https://jules.google.com/task/13611168918215101688) started by @MattShelton04*