### PR TITLE
⚡ Bolt: Optimize SQL batch insert memory allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Optimized SQL String Allocation in batch_insert
+**Learning:** Found a specific performance bottleneck in `crates/tracepilot-indexer/src/index_db/batch_insert.rs` where SQL placeholder strings (like `(?1,?2),(?3,?4)`) for chunked batch insertion were generated using dynamic `.map()`, `format!()`, and `.join()` combinations. This resulted in O(N*M) unnecessary intermediate allocations.
+**Action:** When dynamically generating large SQL placeholder strings in Rust for batch inserts, avoid `.map()`, `format!()`, and `.join()`. Instead, use `String::with_capacity()` based on an explicit calculation of bytes, and construct the sequence iteratively using `std::fmt::Write` (e.g., `write!(&mut buffer, "?{}", start + j)`).

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -54,18 +54,28 @@ where
         return Ok(());
     }
 
+    use std::fmt::Write;
+
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let placeholders: String = (0..chunk.len())
-            .map(|i| {
-                let start = i * params_per_row + 1;
-                let p: String = (start..start + params_per_row)
-                    .map(|n| format!("?{n}"))
-                    .collect::<Vec<_>>()
-                    .join(",");
-                format!("({p})")
-            })
-            .collect::<Vec<_>>()
-            .join(",");
+        // Pre-allocate assuming ~5 bytes per placeholder (e.g., "?12,") plus parentheses and commas
+        // Typical structure per item: "(?1,?2,?3),"
+        let est_capacity = chunk.len() * (params_per_row * 5 + 3);
+        let mut placeholders = String::with_capacity(est_capacity);
+
+        for i in 0..chunk.len() {
+            if i > 0 {
+                placeholders.push(',');
+            }
+            placeholders.push('(');
+            let start = i * params_per_row + 1;
+            for j in 0..params_per_row {
+                if j > 0 {
+                    placeholders.push(',');
+                }
+                let _ = write!(&mut placeholders, "?{}", start + j);
+            }
+            placeholders.push(')');
+        }
 
         let sql = format!("{sql_prefix} {placeholders}");
         let mut stmt = conn.prepare(&sql)?;


### PR DESCRIPTION
⚡ Bolt: Optimized memory allocation in batch inserts

### 💡 What:
Optimized `crates/tracepilot-indexer/src/index_db/batch_insert.rs`. The `batched_insert` function previously constructed its SQL placeholder strings (e.g., `(?1,?2), (?3,?4)`) dynamically using `.map()`, `format!()`, `.collect()`, and `.join()`. This approach caused excessive intermediate heap allocations for every chunk. The new implementation pre-allocates a single `String` buffer using `String::with_capacity` and directly appends characters and numbers using `std::fmt::Write`.

### 🎯 Why:
To eliminate unnecessary memory overhead and speed up execution during the construction of large SQL statements in the indexer's high-throughput bulk insertion paths. Avoiding dynamic allocations in tight loops is a critical Rust performance pattern.

### 📊 Impact:
Reduces intermediate string heap allocations from O(N*M) to O(1) per chunk, reducing memory fragmentation and lowering CPU overhead for garbage collection/de-allocation during indexing.

### 🔬 Measurement:
1. `cargo bench -p tracepilot-bench --bench indexer` can be run to observe aggregate throughput improvements in indexing workflows.
2. Verified functionality using `cargo test -p tracepilot-indexer` and across the workspace.

---
*PR created automatically by Jules for task [14058234756178069494](https://jules.google.com/task/14058234756178069494) started by @MattShelton04*