### PR TITLE
fix(skills): allow path separators in asset names at IPC boundary

### DIFF
--- a/crates/tracepilot-orchestrator/src/skills/assets.rs
+++ b/crates/tracepilot-orchestrator/src/skills/assets.rs
@@ -62,7 +62,11 @@ fn collect_assets(
 }
 
 /// Validate an asset name against path traversal and absolute paths.
-fn validate_asset_name(asset_name: &str) -> Result<(), SkillsError> {
+///
+/// Asset names may contain path separators (`/`, `\`) for nested files
+/// (e.g. `subdir/helper.py`), but must not contain `..`, start with a
+/// separator, or be absolute.
+pub fn validate_asset_name(asset_name: &str) -> Result<(), SkillsError> {
     // Check empty
     if asset_name.is_empty() {
         return Err(SkillsError::Asset("Asset name cannot be empty".into()));
@@ -369,6 +373,24 @@ mod tests {
     #[test]
     fn validate_asset_name_rejects_skill_md() {
         assert!(validate_asset_name("SKILL.md").is_err());
+    }
+
+    #[test]
+    fn read_asset_nested_path_works() {
+        let dir = TempDir::new().unwrap();
+        let skill_dir = setup_skill_with_assets(&dir);
+        let sub_dir = skill_dir.join("scripts");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+        std::fs::write(sub_dir.join("run.ps1"), "echo hello").unwrap();
+
+        let content = read_asset(&skill_dir, "scripts/run.ps1").unwrap();
+        assert_eq!(content, "echo hello");
+    }
+
+    #[test]
+    fn validate_asset_name_allows_nested_paths() {
+        assert!(validate_asset_name("subdir/file.txt").is_ok());
+        assert!(validate_asset_name("deep/nested/file.md").is_ok());
     }
 
     #[test]

--- a/crates/tracepilot-tauri-bindings/src/validators.rs
+++ b/crates/tracepilot-tauri-bindings/src/validators.rs
@@ -65,12 +65,8 @@ pub(crate) fn validate_skill_name(name: &str) -> CmdResult<()> {
 /// Asset names must be safe for use in filesystem operations. Uses the same
 /// rules as skill names to allow flexibility while preventing path traversal.
 pub(crate) fn validate_asset_name(name: &str) -> CmdResult<()> {
-    tracepilot_orchestrator::validation::validate_identifier(
-        name,
-        tracepilot_orchestrator::validation::SKILL_NAME_RULES,
-        "Asset name",
-    )
-    .map_err(BindingsError::Validation)
+    tracepilot_orchestrator::skills::assets::validate_asset_name(name)
+        .map_err(|e| BindingsError::Validation(e.to_string()))
 }
 
 // ── Session-ID validation ─────────────────────────────────────────────────
@@ -757,7 +753,19 @@ mod tests {
     }
 
     #[test]
-    fn asset_name_path_separator_fails() {
-        assert!(validate_asset_name("subdir/file.txt").is_err());
+    fn asset_name_nested_path_passes() {
+        assert!(validate_asset_name("subdir/file.txt").is_ok());
+        assert!(validate_asset_name("deep/nested/file.md").is_ok());
+    }
+
+    #[test]
+    fn asset_name_leading_separator_fails() {
+        assert!(validate_asset_name("/etc/passwd").is_err());
+        assert!(validate_asset_name("\\Windows\\file").is_err());
+    }
+
+    #[test]
+    fn asset_name_skill_md_fails() {
+        assert!(validate_asset_name("SKILL.md").is_err());
     }
 }


### PR DESCRIPTION
## Problem

Opening any asset file in the skill editor showed **'Unable to read file content — The file may be binary or could not be read as text.'** regardless of file type (.md, .ps1, etc).

## Root Cause

The Tauri bindings' \alidate_asset_name\ (added in #430) was using \SKILL_NAME_RULES\ which rejects **all** path separators (\/\ and \\\\). However, asset paths returned by \list_assets\ are relative paths that legitimately contain separators for nested files (e.g. \scripts/helper.ps1\).

This meant the IPC validation layer rejected every asset read before it even reached the filesystem, and the frontend silently caught the error and showed the binary-file fallback message.

## Fix

- Made the orchestrator's \alidate_asset_name\ in \ssets.rs\ public
- Changed the Tauri bindings' validator to delegate to the orchestrator's version (which correctly allows internal path separators while blocking traversal, absolute paths, and SKILL.md access)
- Added tests for nested paths in both orchestrator and bindings layers

## Tests

- **17/17** orchestrator asset tests pass (including new \ead_asset_nested_path_works\ and \alidate_asset_name_allows_nested_paths\)
- **69/69** Tauri bindings validator tests pass (updated \sset_name_nested_path_passes\, \sset_name_leading_separator_fails\, \sset_name_skill_md_fails\)