### PR TITLE
⚡ Bolt: Optimize batch insert query generation

### DIFF
--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -55,19 +55,30 @@ where
     }
 
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let placeholders: String = (0..chunk.len())
-            .map(|i| {
-                let start = i * params_per_row + 1;
-                let p: String = (start..start + params_per_row)
-                    .map(|n| format!("?{n}"))
-                    .collect::<Vec<_>>()
-                    .join(",");
-                format!("({p})")
-            })
-            .collect::<Vec<_>>()
-            .join(",");
+        use std::fmt::Write;
 
-        let sql = format!("{sql_prefix} {placeholders}");
+        // Pre-allocate a string to avoid intermediate allocations and joining.
+        // Each parameter is ~3-4 chars (e.g. "?123"), plus commas and parens
+        let est_capacity = sql_prefix.len() + 1 + chunk.len() * (params_per_row * 5 + 2);
+        let mut sql = String::with_capacity(est_capacity);
+        sql.push_str(sql_prefix);
+        sql.push(' ');
+
+        for i in 0..chunk.len() {
+            if i > 0 {
+                sql.push(',');
+            }
+            sql.push('(');
+            let start = i * params_per_row + 1;
+            for j in 0..params_per_row {
+                if j > 0 {
+                    sql.push(',');
+                }
+                write!(&mut sql, "?{}", start + j).expect("String formatting should not fail");
+            }
+            sql.push(')');
+        }
+
         let mut stmt = conn.prepare(&sql)?;
 
         let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);


### PR DESCRIPTION
## ⚡ Bolt: Optimize batch insert query generation
### 💡 What
This pull request modifies the `batched_insert` function inside `tracepilot-indexer` to optimize how the `INSERT INTO` placeholder arrays are generated. We eliminated the chaining of `.map().collect().join()` and replaced it with a pre-allocated capacity `String` where the formatted text is dynamically loaded in place using `write!(&mut sql, ...)`.

### 🎯 Why
When generating a batch insert query across multiple columns in SQLite, generating thousands of permutations dynamically inside standard formatting vectors creates intermediate array allocations that bloat memory overhead and slightly slow down insert transactions inside the FTS engine.

### 📊 Impact
Eliminates overhead for intermediate vectors inside `batched_insert`. Memory usage scales consistently during bulk save actions with significantly lower CPU cycle footprints inside the allocator since there's no more `Vec<_>` joining. Overall database ingest speed during indexing gains a marginal improvement.

### 🔬 Measurement
Run `cargo bench -p tracepilot-bench --bench indexer`. Also `cargo test -p tracepilot-indexer` passes the current logic constraints to verify queries generate identical placeholders format as expected.

---
*PR created automatically by Jules for task [7211724803173126541](https://jules.google.com/task/7211724803173126541) started by @MattShelton04*