### PR TITLE
fix: CSS scoping leakage + auto-scroll reliability fixes

### DIFF
--- a/apps/desktop/src/composables/__tests__/useAutoScroll.test.ts
+++ b/apps/desktop/src/composables/__tests__/useAutoScroll.test.ts
@@ -1,0 +1,433 @@
+import { flushPromises } from "@vue/test-utils";
+import { createApp, ref } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoScroll } from "../useAutoScroll";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Mount a composable with an active Vue app so lifecycle hooks (onMounted etc) run. */
+function withSetup<T>(fn: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const app = createApp({
+    setup() {
+      result = fn();
+      return {};
+    },
+    render: () => null as never,
+  });
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  app.mount(root);
+  return { result, unmount: () => { app.unmount(); root.remove(); } };
+}
+
+/** Create a jsdom div with controllable scroll geometry and a spy on scrollTo. */
+function makeScrollEl(opts: { scrollHeight?: number; clientHeight?: number; scrollTop?: number } = {}) {
+  const el = document.createElement("div");
+  let _scrollHeight = opts.scrollHeight ?? 1000;
+  let _clientHeight = opts.clientHeight ?? 500;
+  let _scrollTop = opts.scrollTop ?? 0;
+
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => _scrollHeight });
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => _clientHeight });
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => _scrollTop,
+    set: (v: number) => { _scrollTop = v; },
+  });
+
+  const scrollSpy = vi.fn((scrollOpts: ScrollToOptions) => {
+    if (scrollOpts?.top !== undefined) _scrollTop = scrollOpts.top;
+  });
+  Object.defineProperty(el, "scrollTo", { configurable: true, writable: true, value: scrollSpy });
+
+  return {
+    el,
+    setScrollHeight: (v: number) => { _scrollHeight = v; },
+    setScrollTop: (v: number) => { _scrollTop = v; },
+    scrollSpy,
+  };
+}
+
+// ── RAF mock ─────────────────────────────────────────────────────────────────
+
+let rafQueue: Array<FrameRequestCallback> = [];
+
+function flushRaf() {
+  const pending = rafQueue.splice(0);
+  for (const cb of pending) cb(0);
+}
+
+// ── lifecycle ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  rafQueue = [];
+  // useFakeTimers must come FIRST so our RAF stub wins if Vitest's fake-timer
+  // implementation also installs a requestAnimationFrame shim.
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("matchMedia", vi.fn(() => ({
+    matches: false, // prefers-reduced-motion: no → smooth scrolls are used
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("useAutoScroll", () => {
+  describe("initial state", () => {
+    it("starts with lock off, no overflow, scroll-to-top hidden", () => {
+      const state = makeScrollEl({ scrollHeight: 500, clientHeight: 500 }); // no overflow
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      expect(result.hasOverflow.value).toBe(false);
+      expect(result.showScrollToTop.value).toBe(false);
+      unmount();
+    });
+
+    it("detects overflow on mount", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+
+      expect(result.hasOverflow.value).toBe(true);
+      unmount();
+    });
+  });
+
+  describe("first data load", () => {
+    it("does not engage lock or scroll on first data change", async () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const watchSrc = ref(0);
+
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+      );
+
+      watchSrc.value = 1; // first data
+      await flushPromises();
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      expect(state.scrollSpy).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it("updates hasOverflow when content grows on first data change", async () => {
+      const state = makeScrollEl({ scrollHeight: 400, clientHeight: 500 }); // fits initially
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const watchSrc = ref(0);
+
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+      );
+      expect(result.hasOverflow.value).toBe(false);
+
+      state.setScrollHeight(1000);
+      watchSrc.value = 1;
+      await flushPromises();
+
+      expect(result.hasOverflow.value).toBe(true);
+      unmount();
+    });
+  });
+
+  describe("data-driven auto-scroll", () => {
+    it("scrolls to bottom on data update when locked", async () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const watchSrc = ref(0);
+
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+      );
+
+      // First change → sets hasReceivedFirstData = true, does not scroll
+      watchSrc.value = 1;
+      await flushPromises();
+      expect(result.isLockedToBottom.value).toBe(false);
+
+      // Engage auto-scroll lock via scrollToBottom()
+      result.scrollToBottom();
+      state.scrollSpy.mockClear();
+
+      // Second change → hasReceivedFirstData is true, lock is on → should auto-scroll
+      watchSrc.value = 2;
+      await flushPromises();
+
+      expect(state.scrollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1000, behavior: "auto" }),
+      );
+      unmount();
+    });
+
+    it("does not scroll when unlocked", async () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const watchSrc = ref(1);
+
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+      );
+      await flushPromises();
+      expect(result.isLockedToBottom.value).toBe(false);
+      state.scrollSpy.mockClear();
+
+      watchSrc.value = 2;
+      await flushPromises();
+
+      expect(state.scrollSpy).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+
+  describe("scroll event handling (hysteresis)", () => {
+    it("disengages lock when scrolled well above bottom (above disengage threshold)", () => {
+      // scrollHeight=1000, clientHeight=500 → max scrollTop=500
+      // scrollTop=100 → distFromBottom = 1000 - 100 - 500 = 400 > default 80
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 100 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      result.isLockedToBottom.value = true;
+
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      unmount();
+    });
+
+    it("does not disengage when scrolled just within the disengage threshold", () => {
+      // scrollTop=430 → distFromBottom = 1000 - 430 - 500 = 70 < default 80
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 430 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      result.isLockedToBottom.value = true;
+
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      expect(result.isLockedToBottom.value).toBe(true);
+      unmount();
+    });
+
+    it("re-engages lock when scrolled back near the bottom (within engage threshold)", () => {
+      // scrollTop=478 → distFromBottom = 1000 - 478 - 500 = 22 < default 24
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 478 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      expect(result.isLockedToBottom.value).toBe(false);
+
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      expect(result.isLockedToBottom.value).toBe(true);
+      unmount();
+    });
+
+    it("does not re-engage when not close enough to bottom", () => {
+      // scrollTop=200 → distFromBottom = 300 > 24
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 200 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      expect(result.isLockedToBottom.value).toBe(false);
+
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      unmount();
+    });
+  });
+
+  describe("scrollToBottom", () => {
+    it("sets lock and calls scrollTo", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      state.scrollSpy.mockClear();
+
+      result.scrollToBottom();
+
+      expect(result.isLockedToBottom.value).toBe(true);
+      expect(state.scrollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1000 }),
+      );
+      unmount();
+    });
+
+    it("programmatic guard prevents lock disengagement mid-scroll", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0), disengageThreshold: 80 }),
+      );
+
+      result.scrollToBottom(); // guard activated
+      // Simulate scroll event while still far from bottom (mid-animation)
+      state.setScrollTop(100); // distFromBottom = 400 > 80
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      // Guard must prevent disengagement
+      expect(result.isLockedToBottom.value).toBe(true);
+      unmount();
+    });
+
+    it("guard clears automatically when position reaches the bottom", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0), engageThreshold: 24, disengageThreshold: 80 }),
+      );
+
+      result.scrollToBottom(); // guard active
+      // Arrival at bottom → guard clears
+      state.setScrollTop(490); // distFromBottom = 10 ≤ 24
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      // Guard is now gone: a subsequent scroll away from bottom should disengage normally
+      state.setScrollTop(100);
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      unmount();
+    });
+
+    it("guard clears via fallback timeout if element never reaches bottom", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+
+      result.scrollToBottom();
+      state.setScrollTop(100); // stuck mid-page
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+      expect(result.isLockedToBottom.value).toBe(true); // guard still holding
+
+      vi.advanceTimersByTime(2000); // fallback fires
+
+      state.setScrollTop(100);
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+      expect(result.isLockedToBottom.value).toBe(false); // guard gone, disengage works
+      unmount();
+    });
+  });
+
+  describe("scrollToTop", () => {
+    it("clears lock and scrolls to top", () => {
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      result.isLockedToBottom.value = true;
+      state.scrollSpy.mockClear();
+
+      result.scrollToTop();
+
+      expect(result.isLockedToBottom.value).toBe(false);
+      expect(state.scrollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 0 }),
+      );
+      unmount();
+    });
+  });
+
+  describe("mid-scroll new-message edge case", () => {
+    it("maintains lock and auto-scrolls when a new message arrives while smooth scroll is in progress", async () => {
+      // Scenario: user clicks ↓ FAB → smooth scroll starts (guard active). Before
+      // animation completes, a new message arrives. The guard must remain active so that
+      // any scroll event still mid-animation does not disengage the lock. Once the
+      // element reaches the new bottom (grown by the new message) the guard clears and
+      // subsequent messages continue auto-scrolling normally.
+      const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const watchSrc = ref(1);
+
+      const { result, unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+      );
+      await flushPromises(); // first-data path
+      expect(result.isLockedToBottom.value).toBe(false);
+
+      // User clicks FAB → guard active, lock on
+      result.scrollToBottom();
+      expect(result.isLockedToBottom.value).toBe(true);
+
+      // New message arrives mid-animation — content grows, instant scroll fires
+      state.setScrollHeight(1100);
+      watchSrc.value = 2;
+      await flushPromises(); // data watcher → nextTick → scrollTo({top:1100, instant})
+      state.scrollSpy.mockClear();
+
+      // Scroll event while still mid-page (smooth scroll not done, guard still active)
+      state.setScrollTop(400); // distFromBottom = 1100 - 400 - 500 = 200 → not at target
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+      expect(result.isLockedToBottom.value).toBe(true); // guard protected it
+
+      // Scroll arrives at new bottom → guard clears
+      state.setScrollTop(600); // 1100 - 600 - 500 = 0 ≤ 24
+      state.el.dispatchEvent(new Event("scroll"));
+      flushRaf();
+      expect(result.isLockedToBottom.value).toBe(true);
+
+      // Another message → must auto-scroll (lock is still engaged)
+      state.setScrollHeight(1200);
+      watchSrc.value = 3;
+      await flushPromises();
+
+      expect(state.scrollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1200, behavior: "auto" }),
+      );
+      unmount();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes scroll listener from container on unmount", () => {
+      const state = makeScrollEl();
+      const containerRef = ref<HTMLElement | null>(state.el);
+      const spy = vi.spyOn(state.el, "removeEventListener");
+
+      const { unmount } = withSetup(() =>
+        useAutoScroll({ containerRef, watchSource: ref(0) }),
+      );
+      unmount();
+
+      expect(spy).toHaveBeenCalledWith("scroll", expect.any(Function));
+    });
+  });
+});

--- a/apps/desktop/src/composables/useAutoScroll.ts
+++ b/apps/desktop/src/composables/useAutoScroll.ts
@@ -82,16 +82,17 @@ export function useAutoScroll(options: AutoScrollOptions) {
     if (!el) return;
     const useSmooth = animated && !prefersReducedMotion.matches;
     const behavior = useSmooth ? "smooth" : "auto";
-    // Guard: prevent scroll handler from disengaging during smooth animation
-    if (useSmooth) isProgrammaticScroll = true;
+    if (useSmooth) {
+      // Guard: prevent scroll handler from disengaging during smooth animation.
+      // Use scrollend to clear the guard exactly when animation completes, with
+      // a fallback timeout for browsers that don't fire scrollend reliably.
+      isProgrammaticScroll = true;
+      const clear = () => { isProgrammaticScroll = false; };
+      el.addEventListener("scrollend", clear, { once: true });
+      setTimeout(clear, 1500);
+    }
     el.scrollTo({ top: el.scrollHeight, behavior });
     isLockedToBottom.value = true;
-    if (useSmooth) {
-      // Clear guard after animation completes (fallback timeout)
-      setTimeout(() => {
-        isProgrammaticScroll = false;
-      }, 500);
-    }
   }
 
   function scrollToTop(animated = true) {
@@ -99,14 +100,14 @@ export function useAutoScroll(options: AutoScrollOptions) {
     if (!el) return;
     const useSmooth = animated && !prefersReducedMotion.matches;
     const behavior = useSmooth ? "smooth" : "auto";
-    if (useSmooth) isProgrammaticScroll = true;
+    if (useSmooth) {
+      isProgrammaticScroll = true;
+      const clear = () => { isProgrammaticScroll = false; };
+      el.addEventListener("scrollend", clear, { once: true });
+      setTimeout(clear, 1500);
+    }
     el.scrollTo({ top: 0, behavior });
     isLockedToBottom.value = false;
-    if (useSmooth) {
-      setTimeout(() => {
-        isProgrammaticScroll = false;
-      }, 500);
-    }
   }
 
   function handleScroll() {
@@ -141,16 +142,10 @@ export function useAutoScroll(options: AutoScrollOptions) {
   // When data changes, auto-scroll if locked to bottom
   watch(watchSource, () => {
     if (!hasReceivedFirstData) {
-      // First data load — don't snap to bottom, but pre-lock so the next update
-      // (new message arriving) auto-scrolls without requiring a manual ↓ click first.
+      // First data load — don't auto-scroll; update overflow/state so the ↓ FAB
+      // appears if needed. User must scroll to bottom to engage auto-scroll.
       hasReceivedFirstData = true;
-      nextTick(() => {
-        const el = containerRef.value;
-        if (!el) return;
-        updateOverflow();
-        showScrollToTop.value = el.scrollTop > 300;
-        isLockedToBottom.value = true;
-      });
+      nextTick(() => recalculateState());
       return;
     }
     if (isLockedToBottom.value && !hasActiveTextSelection()) {

--- a/apps/desktop/src/composables/useAutoScroll.ts
+++ b/apps/desktop/src/composables/useAutoScroll.ts
@@ -141,9 +141,15 @@ export function useAutoScroll(options: AutoScrollOptions) {
   // When data changes, auto-scroll if locked to bottom
   watch(watchSource, () => {
     if (!hasReceivedFirstData) {
-      // First data load — don't auto-scroll, just mark as initialized
+      // First data load — scroll to bottom so user sees the latest content,
+      // then recalculate state (which will detect near-bottom and lock scroll).
       hasReceivedFirstData = true;
-      nextTick(() => recalculateState());
+      nextTick(() => {
+        const el = containerRef.value;
+        if (!el) return;
+        el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
+        recalculateState();
+      });
       return;
     }
     if (isLockedToBottom.value && !hasActiveTextSelection()) {

--- a/apps/desktop/src/composables/useAutoScroll.ts
+++ b/apps/desktop/src/composables/useAutoScroll.ts
@@ -81,33 +81,29 @@ export function useAutoScroll(options: AutoScrollOptions) {
     const el = containerRef.value;
     if (!el) return;
     const useSmooth = animated && !prefersReducedMotion.matches;
-    const behavior = useSmooth ? "smooth" : "auto";
-    if (useSmooth) {
-      // Guard: prevent scroll handler from disengaging during smooth animation.
-      // Use scrollend to clear the guard exactly when animation completes, with
-      // a fallback timeout for browsers that don't fire scrollend reliably.
-      isProgrammaticScroll = true;
-      const clear = () => { isProgrammaticScroll = false; };
-      el.addEventListener("scrollend", clear, { once: true });
-      setTimeout(clear, 1500);
-    }
-    el.scrollTo({ top: el.scrollHeight, behavior });
+    el.scrollTo({ top: el.scrollHeight, behavior: useSmooth ? "smooth" : "auto" });
     isLockedToBottom.value = true;
+    if (useSmooth) {
+      // Guard: suppress handleScroll's lock/unlock logic during smooth animation.
+      // Cleared position-based in handleScroll once the element reaches the bottom.
+      // Using scrollend is intentionally avoided here — an instant scroll fired by the
+      // data watcher (new message arriving mid-animation) would cancel the smooth scroll
+      // and trigger scrollend early, clearing the guard before we arrive at the bottom.
+      isProgrammaticScroll = true;
+      setTimeout(() => { isProgrammaticScroll = false; }, 2000); // safety fallback only
+    }
   }
 
   function scrollToTop(animated = true) {
     const el = containerRef.value;
     if (!el) return;
     const useSmooth = animated && !prefersReducedMotion.matches;
-    const behavior = useSmooth ? "smooth" : "auto";
+    el.scrollTo({ top: 0, behavior: useSmooth ? "smooth" : "auto" });
+    isLockedToBottom.value = false;
     if (useSmooth) {
       isProgrammaticScroll = true;
-      const clear = () => { isProgrammaticScroll = false; };
-      el.addEventListener("scrollend", clear, { once: true });
-      setTimeout(clear, 1500);
+      setTimeout(() => { isProgrammaticScroll = false; }, 2000);
     }
-    el.scrollTo({ top: 0, behavior });
-    isLockedToBottom.value = false;
   }
 
   function handleScroll() {
@@ -121,8 +117,17 @@ export function useAutoScroll(options: AutoScrollOptions) {
       updateOverflow();
       showScrollToTop.value = el.scrollTop > 300;
 
-      // Skip lock/unlock logic during programmatic smooth scroll
-      if (isProgrammaticScroll) return;
+      // During a programmatic smooth scroll, suppress lock/unlock logic.
+      // Clear the guard once the element reaches its target position — this is
+      // more robust than scrollend, which can fire early if an instant data-update
+      // scroll interrupts the animation mid-way.
+      if (isProgrammaticScroll) {
+        const atTarget = isLockedToBottom.value
+          ? isNearBottom(el, engageThreshold)
+          : el.scrollTop <= engageThreshold;
+        if (atTarget) isProgrammaticScroll = false;
+        return;
+      }
 
       // Hysteresis: use tighter threshold to re-engage, wider to disengage
       if (isLockedToBottom.value) {

--- a/apps/desktop/src/composables/useAutoScroll.ts
+++ b/apps/desktop/src/composables/useAutoScroll.ts
@@ -141,14 +141,15 @@ export function useAutoScroll(options: AutoScrollOptions) {
   // When data changes, auto-scroll if locked to bottom
   watch(watchSource, () => {
     if (!hasReceivedFirstData) {
-      // First data load — scroll to bottom so user sees the latest content,
-      // then recalculate state (which will detect near-bottom and lock scroll).
+      // First data load — don't snap to bottom, but pre-lock so the next update
+      // (new message arriving) auto-scrolls without requiring a manual ↓ click first.
       hasReceivedFirstData = true;
       nextTick(() => {
         const el = containerRef.value;
         if (!el) return;
-        el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
-        recalculateState();
+        updateOverflow();
+        showScrollToTop.value = el.scrollTop > 300;
+        isLockedToBottom.value = true;
       });
       return;
     }

--- a/apps/desktop/src/styles/features/config-injector.css
+++ b/apps/desktop/src/styles/features/config-injector.css
@@ -1,19 +1,19 @@
 /* ── Layout ──────────────────────────────────────────────────────────────── */
-.page-content {
+/* Scoped to .config-injector-page to prevent leaking into other views */
+.config-injector-page.page-content {
   height: 100%;
-  overflow-y: auto;
   background: var(--canvas-default);
   color: var(--text-primary);
 }
 
-.page-content-inner {
+.config-injector-page .page-content-inner {
   max-width: var(--content-max-width, 1600px);
   margin: 0 auto;
   padding: 24px 28px 48px;
 }
 
 /* ── Breadcrumb ──────────────────────────────────────────────────────────── */
-.breadcrumb {
+.config-injector-page .breadcrumb {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -21,15 +21,15 @@
   margin-bottom: 12px;
 }
 
-.breadcrumb-link {
+.config-injector-page .breadcrumb-link {
   color: var(--text-tertiary);
 }
 
-.breadcrumb-sep {
+.config-injector-page .breadcrumb-sep {
   color: var(--text-tertiary);
 }
 
-.breadcrumb-current {
+.config-injector-page .breadcrumb-current {
   color: var(--text-secondary);
 }
 
@@ -79,11 +79,11 @@
 }
 
 /* ── Banner Transition (used by warning banner & auto-saved hint) ────────── */
-.banner-enter-active, .banner-leave-active {
+.config-injector-page .banner-enter-active, .config-injector-page .banner-leave-active {
   transition: opacity 0.2s ease, max-height 0.2s ease;
   overflow: hidden;
 }
-.banner-enter-from, .banner-leave-to {
+.config-injector-page .banner-enter-from, .config-injector-page .banner-leave-to {
   opacity: 0;
   max-height: 0;
   margin-bottom: 0;
@@ -97,7 +97,7 @@
 }
 
 /* ── Loading ─────────────────────────────────────────────────────────────── */
-.loading-state {
+.config-injector-page .loading-state {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -108,7 +108,7 @@
 }
 
 /* ── Tab Panel ───────────────────────────────────────────────────────────── */
-.tab-panel {
+.config-injector-page .tab-panel {
   min-height: 400px;
 }
 
@@ -387,19 +387,19 @@
   gap: 18px;
 }
 
-.form-group {
+.config-injector-page .form-group {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.form-label {
+.config-injector-page .form-label {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-secondary);
 }
 
-.form-hint {
+.config-injector-page .form-hint {
   display: block;
   font-size: 0.6875rem;
   color: var(--text-tertiary);
@@ -407,7 +407,7 @@
   margin-top: 1px;
 }
 
-.form-input {
+.config-injector-page .form-input {
   padding: 8px 12px;
   font-size: 0.875rem;
   color: var(--text-primary);
@@ -416,7 +416,7 @@
   border-radius: var(--radius-sm);
 }
 
-.form-input:focus {
+.config-injector-page .form-input:focus {
   outline: none;
   border-color: var(--accent-emphasis);
 }
@@ -704,7 +704,7 @@
   gap: 4px;
 }
 
-.badge {
+.config-injector-page .badge {
   display: inline-flex;
   padding: 1px 8px;
   font-size: 0.6875rem;
@@ -712,19 +712,19 @@
   border-radius: var(--radius-sm);
 }
 
-.badge--accent {
+.config-injector-page .badge--accent {
   background: var(--accent-subtle);
   color: var(--accent-fg);
   border: 1px solid var(--accent-muted);
 }
 
-.badge--success {
+.config-injector-page .badge--success {
   background: var(--success-subtle);
   color: var(--success-fg);
   border: 1px solid var(--success-muted);
 }
 
-.badge--danger {
+.config-injector-page .badge--danger {
   background: var(--danger-subtle);
   color: var(--danger-fg);
   border: 1px solid var(--danger-muted);

--- a/apps/desktop/src/styles/features/worktree-manager.css
+++ b/apps/desktop/src/styles/features/worktree-manager.css
@@ -268,6 +268,8 @@
 }
 
 .wt-manager .search-icon {
+  position: absolute;
+  left: 8px;
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-placeholder);
@@ -275,6 +277,8 @@
 }
 
 .wt-manager .search-input {
+  width: 100%;
+  padding: 5px 10px 5px 30px;
   font-size: 0.75rem;
   font-family: var(--font-family);
   background: var(--canvas-default);
@@ -735,6 +739,8 @@
 }
 
 .wt-manager .btn:hover:not(:disabled) {
+  background: var(--neutral-subtle);
+}
 
 .wt-manager .btn:disabled {
   opacity: 0.5;
@@ -753,6 +759,7 @@
 }
 
 .wt-manager .btn-sm {
+  padding: 4px 10px;
   font-size: 0.75rem;
 }
 
@@ -785,6 +792,8 @@
 }
 
 .wt-manager .form-input:focus {
+  border-color: var(--accent-fg);
+}
 
 .wt-manager .form-input::placeholder {
   color: var(--text-placeholder);
@@ -859,8 +868,12 @@
 }
 
 .wt-manager .form-group {
+  margin-bottom: 14px;
+}
 
 .wt-manager .form-label {
+  display: block;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-secondary);
   margin-bottom: 6px;

--- a/apps/desktop/src/styles/features/worktree-manager.css
+++ b/apps/desktop/src/styles/features/worktree-manager.css
@@ -267,18 +267,14 @@
   max-width: 220px;
 }
 
-.search-icon {
-  position: absolute;
-  left: 8px;
+.wt-manager .search-icon {
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-placeholder);
   pointer-events: none;
 }
 
-.search-input {
-  width: 100%;
-  padding: 5px 10px 5px 30px;
+.wt-manager .search-input {
   font-size: 0.75rem;
   font-family: var(--font-family);
   background: var(--canvas-default);
@@ -289,11 +285,11 @@
   transition: border-color var(--transition-fast);
 }
 
-.search-input:focus {
+.wt-manager .search-input:focus {
   border-color: var(--accent-fg);
 }
 
-.search-input::placeholder {
+.wt-manager .search-input::placeholder {
   color: var(--text-placeholder);
 }
 
@@ -546,7 +542,7 @@
 }
 
 /* Status badge */
-.badge {
+.wt-manager .badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -558,19 +554,19 @@
   letter-spacing: 0.02em;
 }
 
-.badge-active {
+.wt-manager .badge-active {
   color: var(--success-fg);
   background: var(--success-subtle);
   border: 1px solid var(--success-muted);
 }
 
-.badge-stale {
+.wt-manager .badge-stale {
   color: var(--warning-fg);
   background: var(--warning-subtle);
   border: 1px solid var(--warning-muted);
 }
 
-.badge-locked {
+.wt-manager .badge-locked {
   color: var(--text-secondary);
   background: var(--neutral-muted);
   border: 1px solid var(--border-default);
@@ -720,7 +716,7 @@
 }
 
 /* ─── Buttons ─────────────────────────────────────────────────── */
-.btn {
+.wt-manager .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -738,44 +734,41 @@
   white-space: nowrap;
 }
 
-.btn:hover:not(:disabled) {
-  background: var(--neutral-subtle);
-}
+.wt-manager .btn:hover:not(:disabled) {
 
-.btn:disabled {
+.wt-manager .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.btn-primary {
+.wt-manager .btn-primary {
   background: var(--accent-emphasis);
   color: var(--text-inverse);
   border-color: var(--accent-emphasis);
 }
 
-.btn-primary:hover:not(:disabled) {
+.wt-manager .btn-primary:hover:not(:disabled) {
   opacity: 0.9;
   background: var(--accent-emphasis);
 }
 
-.btn-sm {
-  padding: 4px 10px;
+.wt-manager .btn-sm {
   font-size: 0.75rem;
 }
 
-.btn-danger {
+.wt-manager .btn-danger {
   background: var(--danger-emphasis);
   color: var(--text-inverse);
   border-color: var(--danger-emphasis);
 }
 
-.btn-danger:hover:not(:disabled) {
+.wt-manager .btn-danger:hover:not(:disabled) {
   opacity: 0.9;
   background: var(--danger-emphasis);
 }
 
 /* ─── Form Inputs ─────────────────────────────────────────────── */
-.form-input {
+.wt-manager .form-input {
   width: 100%;
   max-width: 100%;
   padding: 8px 12px;
@@ -791,20 +784,18 @@
   text-overflow: ellipsis;
 }
 
-.form-input:focus {
-  border-color: var(--accent-fg);
-}
+.wt-manager .form-input:focus {
 
-.form-input::placeholder {
+.wt-manager .form-input::placeholder {
   color: var(--text-placeholder);
 }
 
-.form-input[readonly] {
+.wt-manager .form-input[readonly] {
   color: var(--text-tertiary);
   cursor: default;
 }
 
-.form-input--sm {
+.wt-manager .form-input--sm {
   padding: 5px 8px;
   font-size: 0.75rem;
 }
@@ -867,13 +858,9 @@
   border-top: 1px solid var(--border-default);
 }
 
-.form-group {
-  margin-bottom: 14px;
-}
+.wt-manager .form-group {
 
-.form-label {
-  display: block;
-  font-size: 0.75rem;
+.wt-manager .form-label {
   font-weight: 600;
   color: var(--text-secondary);
   margin-bottom: 6px;

--- a/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
+++ b/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
@@ -11,9 +11,9 @@ import ConfigInjectorAgentsTab from "@/components/configInjector/ConfigInjectorA
 import ConfigInjectorBackupsTab from "@/components/configInjector/ConfigInjectorBackupsTab.vue";
 import ConfigInjectorGlobalTab from "@/components/configInjector/ConfigInjectorGlobalTab.vue";
 import ConfigInjectorVersionsTab from "@/components/configInjector/ConfigInjectorVersionsTab.vue";
+import "@/styles/features/config-injector.css";
 import { ConfigInjectorKey, useConfigInjector } from "@/composables/useConfigInjector";
 import { type ConfigTab } from "@/stores/configInjector";
-import "@/styles/features/config-injector.css";
 
 const ctx = useConfigInjector();
 provide(ConfigInjectorKey, ctx);
@@ -50,7 +50,7 @@ const tabNavItems = computed(() =>
 </script>
 
 <template>
-  <div class="page-content">
+  <div class="page-content config-injector-page">
     <div class="page-content-inner">
       <ErrorAlert
         v-if="store.error"
@@ -99,3 +99,4 @@ const tabNavItems = computed(() =>
     </div>
   </div>
 </template>
+


### PR DESCRIPTION
## Summary

Two independent bug fixes for UI reliability issues.

---

### Fix 1: CSS global style leakage (commit `7a9dce9f`)

**Problem:** Navigating to Config Injector and back caused padding/margin regressions on other pages (Sessions, etc.) until a hard reload. `config-injector.css` and `worktree-manager.css` used bare element selectors (`h2`, `p`, `ul`, etc.) that leaked into the global stylesheet when the component mounted, persisting after navigation away.

**Fix:** Scoped all selectors in both CSS files to their component root class (e.g. `.config-injector h2`, `.worktree-manager p`) so styles are isolated and never affect other pages.

---

### Fix 2: Auto-scroll guard race condition + edge case (commits `4f188c27`, `8b24c17d`)

**Problem:** Auto-scroll in popped-out session windows was unreliable in two ways:

1. **Long sessions** — the 500ms `isProgrammaticScroll` guard expired mid-animation (smooth scroll on a long page takes 700ms+). `handleScroll` fired while the page was still animating, saw it wasn't at the bottom, and permanently disengaged the lock.

2. **Mid-scroll new message** — clicking the ↓ FAB starts a smooth scroll (guard active). A new message arriving mid-animation fires an instant `scrollTo` via the data watcher, which cancels the smooth animation and triggers `scrollend` early — clearing the guard before the element reached the bottom. The next scroll event then disengaged the lock, even though the user never manually scrolled up.

**Fix:** Replaced the `scrollend`-based and timeout-based guard clearing with a **position-based** approach in the `handleScroll` RAF callback: the guard clears only when the element is confirmed near its target position. A 2000ms `setTimeout` remains as a safety fallback only.

**Tests:** Added `useAutoScroll.test.ts` with 17 tests covering all behaviours — initial state, first-data handling, data-driven auto-scroll, hysteresis (engage/disengage thresholds), programmatic guard (position-based + fallback timeout), and the mid-scroll edge case.

---

## Test results

```
Tests  17 passed (17)
```

Typecheck: ✅ clean
