### PR TITLE
🎨 Palette: Unify disabled button UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Disabled Button UX & Accessibility
+**Learning:** Adding `pointer-events: none;` to disabled buttons prevents `cursor: not-allowed;` from appearing and blocks mouse events needed for tooltip accessibility.
+**Action:** Always use `cursor: not-allowed;` alongside visual indicators like `opacity: 0.5`, but omit `pointer-events: none;` to ensure tooltips still function. Update `:active` state selectors (e.g. `:active:not(:disabled)`) so disabled buttons don't animate.

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -427,13 +427,17 @@
   box-shadow: 0 2px 8px var(--accent-muted);
   opacity: 0.95;
 }
-.btn:active {
+.btn:active:not(:disabled) {
   transform: scale(0.97);
   transition-duration: 50ms;
 }
-.btn-primary:active {
+.btn-primary:active:not(:disabled) {
   transform: scale(0.97);
   opacity: 0.9;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .btn-sm {
   padding: 4px 8px;

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,6 @@
+1. **Identify the UX Opportunity:** Add an appropriate visual representation for disabled buttons (`.btn:disabled`). Currently, there are many custom rules for `:disabled` buttons scattered across different feature CSS files (`mcp-server-detail.css`, `config-injector.css`, `agent-tree.css`, `session-launcher.css`, etc.). We can unify this by adding a `.btn:disabled` state directly to the core `components.css` which will provide immediate visual feedback (like reduced opacity and a `not-allowed` cursor) across the entire application for disabled states, significantly improving accessibility and interaction clarity.
+2. **Implementation Strategy:**
+   - Modify `apps/desktop/src/styles/components.css`.
+   - Add `.btn:disabled` styles (e.g., `opacity: 0.5`, `cursor: not-allowed`, `pointer-events: none`).
+   - Run tests to verify no regressions.
+3. **Pre-commit checks:** Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
💡 **What:** Added unified `:disabled` styles for `.btn` and `.btn-primary` to the core `components.css`. Disabled buttons now have 50% opacity, a `not-allowed` cursor, and do not trigger scale animations on click.
🎯 **Why:** Previously, there were disparate disabled styles scattered across multiple feature CSS files or missing entirely. This centralizes the logic to provide immediate visual feedback across the application.
♿ **Accessibility:** Ensures users immediately recognize inactive elements. Note: `pointer-events: none` was deliberately omitted to preserve tooltip accessibility on disabled buttons.

**Manual Verification Steps:**
1. Navigate to a feature with buttons (e.g. Session Detail).
2. Use developer tools to add the `disabled` attribute to a standard `.btn` and `.btn-primary`.
3. Verify the opacity is reduced, the cursor changes to `not-allowed`, and clicking the button does not trigger the "press down" animation.
4. Verify any tooltips attached to the button still trigger on hover.

---
*PR created automatically by Jules for task [2910294979659611823](https://jules.google.com/task/2910294979659611823) started by @MattShelton04*