### PR TITLE
refactor(skills-store): migrate 12 actions to runMutation helper

### DIFF
--- a/apps/desktop/src/stores/skills.ts
+++ b/apps/desktop/src/stores/skills.ts
@@ -102,16 +102,12 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function getSkill(dir: string): Promise<Skill | null> {
-    error.value = null;
     selectedSkill.value = null;
-    try {
+    return runMutation(error, async () => {
       const skill = await skillsGetSkill(dir);
       selectedSkill.value = skill;
       return skill;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function createSkill(name: string, desc: string, body: string): Promise<string | null> {
@@ -123,27 +119,23 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function updateSkill(dir: string, fm: SkillFrontmatter, body: string): Promise<boolean> {
-    error.value = null;
-    try {
-      await skillsUpdate(dir, fm, body);
-      await loadSkills();
-      return true;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return false;
-    }
+    return (
+      (await runMutation(error, async () => {
+        await skillsUpdate(dir, fm, body);
+        await loadSkills();
+        return true as const;
+      })) ?? false
+    );
   }
 
   async function updateSkillRaw(dir: string, content: string): Promise<boolean> {
-    error.value = null;
-    try {
-      await skillsUpdateRaw(dir, content);
-      await loadSkills();
-      return true;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return false;
-    }
+    return (
+      (await runMutation(error, async () => {
+        await skillsUpdateRaw(dir, content);
+        await loadSkills();
+        return true as const;
+      })) ?? false
+    );
   }
 
   async function deleteSkill(dir: string): Promise<boolean> {
@@ -160,27 +152,19 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function renameSkill(dir: string, newName: string): Promise<string | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const newDir = await skillsRename(dir, newName);
       await loadSkills();
       return newDir;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function duplicateSkill(dir: string, newName: string): Promise<string | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const newDir = await skillsDuplicate(dir, newName);
       await loadSkills();
       return newDir;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   // ─── Asset Actions ────────────────────────────────────────────────
@@ -195,25 +179,21 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function addAsset(dir: string, name: string, content: number[]): Promise<boolean> {
-    error.value = null;
-    try {
-      await skillsAddAsset(dir, name, content);
-      return true;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return false;
-    }
+    return (
+      (await runMutation(error, async () => {
+        await skillsAddAsset(dir, name, content);
+        return true as const;
+      })) ?? false
+    );
   }
 
   async function copyAssetFrom(dir: string, name: string, sourcePath: string): Promise<boolean> {
-    error.value = null;
-    try {
-      await skillsCopyAssetFrom(dir, name, sourcePath);
-      return true;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return false;
-    }
+    return (
+      (await runMutation(error, async () => {
+        await skillsCopyAssetFrom(dir, name, sourcePath);
+        return true as const;
+      })) ?? false
+    );
   }
 
   async function readAsset(dir: string, name: string): Promise<string | null> {
@@ -226,14 +206,12 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function removeAsset(dir: string, name: string): Promise<boolean> {
-    error.value = null;
-    try {
-      await skillsRemoveAsset(dir, name);
-      return true;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return false;
-    }
+    return (
+      (await runMutation(error, async () => {
+        await skillsRemoveAsset(dir, name);
+        return true as const;
+      })) ?? false
+    );
   }
 
   // ─── Import Actions ───────────────────────────────────────────────
@@ -243,15 +221,11 @@ export const useSkillsStore = defineStore("skills", () => {
     scope?: string,
     repoRoot?: string,
   ): Promise<SkillImportResult | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const result = await skillsImportLocal(sourceDir, scope, repoRoot);
       await loadSkills();
       return result;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function importFile(
@@ -259,15 +233,11 @@ export const useSkillsStore = defineStore("skills", () => {
     scope?: string,
     repoRoot?: string,
   ): Promise<SkillImportResult | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const result = await skillsImportFile(path, scope, repoRoot);
       await loadSkills();
       return result;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function importGitHub(
@@ -278,15 +248,11 @@ export const useSkillsStore = defineStore("skills", () => {
     scope?: string,
     repoRoot?: string,
   ): Promise<SkillImportResult | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const result = await skillsImportGitHub(owner, repo, skillPath, gitRef, scope, repoRoot);
       await loadSkills();
       return result;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function discoverGitHub(
@@ -295,6 +261,7 @@ export const useSkillsStore = defineStore("skills", () => {
     path?: string,
     gitRef?: string,
   ): Promise<GitHubSkillPreview[]> {
+    error.value = null;
     try {
       return await skillsDiscoverGitHub(owner, repo, path, gitRef);
     } catch (e) {
@@ -311,18 +278,15 @@ export const useSkillsStore = defineStore("skills", () => {
     scope?: string,
     repoRoot?: string,
   ): Promise<SkillImportResult | null> {
-    error.value = null;
-    try {
+    return runMutation(error, async () => {
       const result = await skillsImportGitHubSkill(owner, repo, skillPath, gitRef, scope, repoRoot);
       await loadSkills();
       return result;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      return null;
-    }
+    });
   }
 
   async function discoverLocal(dir: string): Promise<LocalSkillPreview[]> {
+    error.value = null;
     try {
       return await skillsDiscoverLocal(dir);
     } catch (e) {
@@ -332,6 +296,7 @@ export const useSkillsStore = defineStore("skills", () => {
   }
 
   async function discoverRepos(repos: [string, string][]): Promise<RepoSkillsResult[]> {
+    error.value = null;
     try {
       return await skillsDiscoverRepos(repos);
     } catch (e) {


### PR DESCRIPTION
## What

Migrates 12 action functions in useSkillsStore from a manual try/catch error-handling pattern to the shared runMutation helper from @tracepilot/ui, and fixes a missing error.value = null pre-reset bug in the three discover functions.

## Why

runMutation was already imported and used correctly by createSkill and deleteSkill in the same file. The remaining 12 mutation functions bypassed it, each manually reimplementing the same 6-line pattern. Subtle divergences were already appearing: discoverGitHub, discoverLocal, and discoverRepos were all missing the error.value = null pre-reset, meaning a stale error leaked to the UI after a successful follow-up call.

## Changes

- 12 functions migrated to runMutation: getSkill, updateSkill, updateSkillRaw, renameSkill, duplicateSkill, addAsset, copyAssetFrom, removeAsset, importLocal, importFile, importGitHub, importGitHubSkill
- Bug fix: Added missing error.value = null pre-reset to discoverGitHub, discoverLocal, and discoverRepos
- Net: -35 lines (49 insertions, 84 deletions)

## Behaviour

All changes are semantically identical to the prior state. runMutation clears error.value = null as its first synchronous step. Boolean-returning functions use (await runMutation(...)) ?? false. getSkill sets selectedSkill.value = null before calling runMutation, then assigns inside the action closure.

## Tests

- pnpm --filter @tracepilot/desktop typecheck passed (vue-tsc --noEmit, exit 0)
- Rust code review confirmed all 14 Tauri command signatures match across Rust to client wrapper to store
