### PR TITLE
refactor(backendErrors): extract extractRawMessage helper to eliminate 3x duplicated ternary chain

### DIFF
--- a/apps/desktop/src/utils/backendErrors.ts
+++ b/apps/desktop/src/utils/backendErrors.ts
@@ -25,6 +25,19 @@ export function isBackendErrorEnvelope(e: unknown): e is BackendErrorEnvelope {
 }
 
 /**
+ * Extract a raw message string from an unknown error value.
+ * Returns `null` when no recognisable type matches, so callers can distinguish
+ * "matched but empty message" from "unrecognised type" (the latter may warrant
+ * a `String(error)` fallback while the former should stay empty/null).
+ */
+function extractRawMessage(error: unknown): string | null {
+  if (typeof error === "string") return error;
+  if (isBackendErrorEnvelope(error)) return error.message;
+  if (error instanceof Error) return error.message;
+  return null;
+}
+
+/**
  * Extract the stable backend error code (e.g. `"ALREADY_INDEXING"`) from an
  * error value, or `null` if the value is not a structured backend error.
  *
@@ -53,14 +66,7 @@ export function getErrorCode(e: unknown): string | null {
 export function isAlreadyIndexingError(error: unknown): boolean {
   if (getErrorCode(error) === "ALREADY_INDEXING") return true;
 
-  const msg =
-    typeof error === "string"
-      ? error
-      : isBackendErrorEnvelope(error)
-        ? error.message
-        : error instanceof Error
-          ? error.message
-          : "";
+  const msg = extractRawMessage(error) ?? "";
 
   if (!msg) return false;
   if (msg === "ALREADY_INDEXING") return true;
@@ -80,14 +86,7 @@ export function isAlreadyIndexingError(error: unknown): boolean {
  * JSON / YAML / session parsing elsewhere in the Rust backend.
  */
 export function isSearchSyntaxError(error: unknown): boolean {
-  const msg =
-    typeof error === "string"
-      ? error
-      : isBackendErrorEnvelope(error)
-        ? error.message
-        : error instanceof Error
-          ? error.message
-          : "";
+  const msg = extractRawMessage(error) ?? "";
   return msg.includes("fts5: syntax error") || msg.includes("fts5 syntax error");
 }
 
@@ -108,14 +107,7 @@ export function toFriendlyErrorMessage(error: unknown): string | null {
     return "Indexing is already in progress. Please wait for the current index to complete.";
   }
 
-  const msg =
-    typeof error === "string"
-      ? error
-      : isBackendErrorEnvelope(error)
-        ? error.message
-        : error instanceof Error
-          ? error.message
-          : String(error);
+  const msg = extractRawMessage(error) ?? String(error);
 
   return msg || null;
 }


### PR DESCRIPTION
## Summary

The same 4-branch ternary chain for extracting a raw message string from `unknown` was copy-pasted verbatim three times in `apps/desktop/src/utils/backendErrors.ts` — in `isAlreadyIndexingError`, `isSearchSyntaxError`, and `toFriendlyErrorMessage`.

## Fix

Extract a private `extractRawMessage(error: unknown): string | null` helper. Returning `null` (not `''`) for the "no type matched" branch is intentional — it lets callers distinguish:
- **matched but empty message** (`BackendErrorEnvelope{message:''}` or `new Error('')`) → callers treat as falsy/empty
- **unrecognised type** → only `toFriendlyErrorMessage` falls through to `String(error)` (as in the original)

Callers use `?? ''` or `?? String(error)` as appropriate, exactly preserving original semantics for all input types.

## Testing

- TypeScript typecheck (`pnpm --filter @tracepilot/desktop typecheck`): zero new errors introduced (48 pre-existing baseline failures in `@tracepilot/test-utils` / `@tauri-apps/plugin-notification` are unchanged)
- Two independent Sonnet 4.6 code-review agents verified semantic equivalence for all input types (string, BackendErrorEnvelope with empty/non-empty message, Error with empty/non-empty message, unrecognised objects, primitives)
- Integration review confirmed no Rust-side changes needed; all call sites pass `unknown` from `catch` blocks

## Diff stats

1 file changed, 16 insertions(+), 24 deletions(-)
