### PR TITLE
fix: use mutex_poisoned() helper consistently for lock poison errors

### DIFF
--- a/crates/tracepilot-tauri-bindings/src/commands/config_cmds.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/config_cmds.rs
@@ -4,7 +4,7 @@ use crate::blocking_cmd;
 use crate::config::{self, SharedConfig, TracePilotConfig};
 use crate::error::{BindingsError, CmdResult};
 use crate::helpers::{
-    copilot_home, read_config, remove_index_db_files, validate_path_within,
+    copilot_home, mutex_poisoned, read_config, remove_index_db_files, validate_path_within,
     validate_write_path_within,
 };
 use crate::types::ValidateSessionDirResult;
@@ -32,7 +32,7 @@ pub async fn save_config(
 
     let mut guard = state
         .write()
-        .map_err(|_| BindingsError::Validation("Config lock poisoned".into()))?;
+        .map_err(|_| mutex_poisoned())?;
     *guard = Some(config);
     Ok(())
 }
@@ -97,7 +97,7 @@ pub async fn factory_reset(state: tauri::State<'_, SharedConfig>) -> CmdResult<(
 
     let mut guard = state
         .write()
-        .map_err(|_| BindingsError::Validation("Config lock poisoned".into()))?;
+        .map_err(|_| mutex_poisoned())?;
     *guard = None;
     Ok(())
 }

--- a/crates/tracepilot-tauri-bindings/src/commands/tasks/crud.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/tasks/crud.rs
@@ -87,7 +87,7 @@ pub async fn task_create(
 
                     // Serialize manifest writes to prevent TOCTOU races
                     let _manifest_guard = manifest_lock_clone.lock()
-                        .map_err(|_| BindingsError::Validation("manifest lock poisoned".into()))?;
+                        .map_err(|_| mutex_poisoned())?;
 
                     if let Err(e) = tracepilot_orchestrator::task_orchestrator::manifest::append_task_to_manifest(
                         &manifest_path,

--- a/crates/tracepilot-tauri-bindings/src/commands/tasks/ingest.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/tasks/ingest.rs
@@ -145,7 +145,7 @@ pub async fn task_ingest_results(
                     if manifest_path.exists() {
                         // Serialize manifest writes to prevent TOCTOU races
                         let _manifest_guard = manifest_lock_clone.lock()
-                            .map_err(|_| BindingsError::Validation("manifest lock poisoned".into()))?;
+                            .map_err(|_| mutex_poisoned())?;
 
                         for retry_id in &retried_ids {
                             // Re-read the task to get current state


### PR DESCRIPTION
## What

Four call sites were emitting \BindingsError::Validation\ (→ frontend \VALIDATION\ error code) for poisoned mutex/RwLock errors. A poisoned lock is an infrastructure failure — the result of a prior panic while the lock was held — not a validation error. The correct variant is \BindingsError::Internal\ (→ \INTERNAL\).

The \mutex_poisoned()\ helper in \helpers.rs\ was already purpose-built for this and is used correctly elsewhere in the same files; these four sites simply missed it.

## Changed files

| File | Site |
|---|---|
| \commands/config_cmds.rs\ | \save_config\ — SharedConfig RwLock write guard |
| \commands/config_cmds.rs\ | \actory_reset\ — SharedConfig RwLock write guard |
| \commands/tasks/crud.rs\ | \	ask_create\ — ManifestLock |
| \commands/tasks/ingest.rs\ | \	ask_ingest_results\ — ManifestLock |

## Impact

- Frontend error handling is not affected: all four call sites catch errors generically without branching on \VALIDATION\ vs \INTERNAL\.
- Zero logic changes — only the error variant is corrected.

## Tests

- \cargo test -p tracepilot-tauri-bindings\: **159 passed, 0 failed**
- \pnpm --filter @tracepilot/desktop typecheck\: **pass**