### PR TITLE
tech debt: 3 independent fixes (collapsible_if, runMutation consistency)

### DIFF
--- a/apps/desktop/src/stores/orchestrator.ts
+++ b/apps/desktop/src/stores/orchestrator.ts
@@ -15,7 +15,7 @@ import type {
   OrchestratorState,
 } from "@tracepilot/types";
 import { DEFAULT_ORCHESTRATOR_MODEL } from "@tracepilot/types";
-import { toErrorMessage, usePolling } from "@tracepilot/ui";
+import { runMutation, usePolling } from "@tracepilot/ui";
 import { defineStore } from "pinia";
 import { computed, ref, watch } from "vue";
 import { logWarn } from "@/utils/logger";
@@ -231,33 +231,27 @@ export const useOrchestratorStore = defineStore("orchestrator", () => {
   /** Launch the orchestrator. Uses selectedModel unless overridden. */
   async function startOrchestrator(model?: string) {
     starting.value = true;
-    error.value = null;
-    try {
+    const ok = await runMutation(error, async () => {
       handle.value = await taskOrchestratorStart(model ?? selectedModel.value);
       await checkHealth();
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      logWarn("[orchestrator] Start failed:", e);
-    } finally {
-      starting.value = false;
-    }
+      return true as const;
+    });
+    if (ok === null) logWarn("[orchestrator] Start failed:", error.value);
+    starting.value = false;
   }
 
   /** Gracefully stop the orchestrator via manifest shutdown flag. */
   async function stopOrchestrator() {
     stopping.value = true;
-    error.value = null;
-    try {
+    const ok = await runMutation(error, async () => {
       await taskOrchestratorStop();
       handle.value = null;
       attribution.value = null;
       await checkHealth();
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      logWarn("[orchestrator] Stop failed:", e);
-    } finally {
-      stopping.value = false;
-    }
+      return true as const;
+    });
+    if (ok === null) logWarn("[orchestrator] Stop failed:", error.value);
+    stopping.value = false;
   }
 
   return {

--- a/apps/desktop/src/stores/tasks.ts
+++ b/apps/desktop/src/stores/tasks.ts
@@ -193,16 +193,13 @@ export const useTasksStore = defineStore("tasks", () => {
     priority?: string,
     maxRetries?: number,
   ): Promise<Task | null> {
-    error.value = null;
-    try {
-      const task = await taskCreate(taskType, presetId, inputParams, priority, maxRetries);
+    const task = await runMutation(error, async () => {
+      const t = await taskCreate(taskType, presetId, inputParams, priority, maxRetries);
       await refreshTasks();
-      return task;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      logError("[tasks] Failed to create task:", e);
-      return null;
-    }
+      return t;
+    });
+    if (task === null) logError("[tasks] Failed to create task:", error.value);
+    return task;
   }
 
   async function createBatch(
@@ -210,16 +207,13 @@ export const useTasksStore = defineStore("tasks", () => {
     jobName: string,
     presetId?: string,
   ): Promise<Job | null> {
-    error.value = null;
-    try {
-      const job = await taskCreateBatch(newTasks, jobName, presetId);
+    const job = await runMutation(error, async () => {
+      const j = await taskCreateBatch(newTasks, jobName, presetId);
       await refreshTasks();
-      return job;
-    } catch (e) {
-      error.value = toErrorMessage(e);
-      logError("[tasks] Failed to create batch:", e);
-      return null;
-    }
+      return j;
+    });
+    if (job === null) logError("[tasks] Failed to create batch:", error.value);
+    return job;
   }
 
   async function cancelTask(id: string): Promise<boolean> {

--- a/crates/tracepilot-core/src/turns/postprocess.rs
+++ b/crates/tracepilot-core/src/turns/postprocess.rs
@@ -46,7 +46,10 @@ pub(crate) fn infer_subagent_models(turns: &mut [ConversationTurn]) {
 
         let mut changed = false;
         for turn in turns.iter_mut() {
-            // Propagate to subagents — prefer child model over parent's ToolExecComplete model
+            // Propagate to subagents — prefer child model over parent's ToolExecComplete model.
+            // When a subagent id is absent from child_models (no children resolved yet or model
+            // already set from an observed event) we leave tc.model as-is: `requested_model`
+            // tracks configuration; `model` must only be updated by observed SDK events.
             for tc in turn.tool_calls.iter_mut() {
                 if tc.is_subagent
                     && let Some(ref id) = tc.tool_call_id

--- a/crates/tracepilot-core/src/turns/postprocess.rs
+++ b/crates/tracepilot-core/src/turns/postprocess.rs
@@ -50,16 +50,11 @@ pub(crate) fn infer_subagent_models(turns: &mut [ConversationTurn]) {
             for tc in turn.tool_calls.iter_mut() {
                 if tc.is_subagent
                     && let Some(ref id) = tc.tool_call_id
+                    && let Some(model) = child_models.get(id)
+                    && tc.model.as_deref() != Some(model.as_str())
                 {
-                    if let Some(model) = child_models.get(id) {
-                        if tc.model.as_deref() != Some(model.as_str()) {
-                            tc.model = Some(model.clone());
-                            changed = true;
-                        }
-                    }
-                    // No children and model is already set (from terminal event or ToolExecStart
-                    // args): leave as-is. `requested_model` tracks what was configured;
-                    // `model` should only be updated by observed events.
+                    tc.model = Some(model.clone());
+                    changed = true;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Three independent tech-debt fixes on branch \cli/tech_debt_dd033bd8\. Each commit is self-contained and can be reverted independently.

---

## Fix 1 — Collapse nested if-chains in \infer_subagent_models\ (clippy::collapsible_if)

**File:** \crates/tracepilot-core/src/turns/postprocess.rs\

**What changed:** Three nested \if\/\if let\ guards (lines 51–63) are merged into a single let-chain using Rust 2024 let-chain syntax. The invariant comment explaining the \child_models\ miss-path was preserved at the enclosing loop comment.

**Why it's better:** Two pre-existing \clippy::collapsible_if\ errors blocked \cargo clippy -D warnings\ for \	racepilot-core\ and every downstream crate. No semantic change — let-chains evaluate left-to-right with the same short-circuit semantics as nested ifs.

**Evidence:**
- Before: \rror: could not compile \	racepilot-core\ (lib) due to 2 previous errors\
- After: \Finished \dev\ profile [unoptimized + debuginfo] target(s) in 4.06s\ (\cargo clippy -p tracepilot-core -- -D warnings\ exits 0)
- \cargo test -p tracepilot-core\: 10 passed; 0 failed

---

## Fix 2 — Convert \createTask\/\createBatch\ to \unMutation\ in tasks store

**File:** \pps/desktop/src/stores/tasks.ts\

**What changed:** \createTask\ and \createBatch\ replaced manual \rror.value = null; try/catch\ blocks with \unMutation\. Backend logging preserved via null-return check (\if (task === null) logError(...)\). Unused \logError\ import cleaned up and re-added at correct scope.

**Why it's better:** \cancelTask\, \etryTask\, and \deleteTask\ in the same file already use \unMutation\. \createTask\ and \createBatch\ were the only mutating operations in the store still hand-rolling the identical pattern (clear error → call API → return result/null). This makes error-surface behaviour uniform across all five mutations in the store.

**Evidence:**
- 5 mutations in tasks store: 3 already used \unMutation\ → now 5/5 use it
- \pnpm --filter @tracepilot/desktop typecheck\ exits 0

---

## Fix 3 — Convert \startOrchestrator\/\stopOrchestrator\ to \unMutation\ in orchestrator store

**File:** \pps/desktop/src/stores/orchestrator.ts\

**What changed:** \startOrchestrator\ and \stopOrchestrator\ replaced manual try/catch/finally with \unMutation\. \unMutation\ import added, unused \	oErrorMessage\ import removed. Backend logging preserved via null-return check (\if (ok === null) logWarn(...)\).

**Why it's better:** The orchestrator store was the only store in the codebase that used \	oErrorMessage\ directly in raw catch blocks for mutation error handling, while all other stores (\mcp\, \worktrees\, \presets\, \skills\) use \unMutation\. Two inline reimplementations of the shared helper are replaced.

**Evidence:**
- 2 inline error-handling implementations → \unMutation\; Tauri backend log preserved
- \pnpm --filter @tracepilot/desktop typecheck\ exits 0

---

## Tests / Lint

| Command | Exit code |
|---------|-----------|
| \cargo clippy -p tracepilot-core -- -D warnings\ | 0 |
| \cargo test -p tracepilot-core\ | 0 (10 passed) |
| \pnpm --filter @tracepilot/desktop typecheck\ | 0 |

> Note: \cargo clippy -p tracepilot-indexer\ has a pre-existing \	ype_complexity\ lint failure on \main\ that is unrelated to these changes (verified by checking out \main\ and reproducing the error).