### PR TITLE
fix: robustly handle special characters in --interactive prompt on all platforms

### DIFF
--- a/crates/tracepilot-orchestrator/src/launcher.rs
+++ b/crates/tracepilot-orchestrator/src/launcher.rs
@@ -204,16 +204,25 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .collect();
 
         // Build the full PowerShell script with startup banner
-        // Append --interactive with PowerShell single-quote escaping for safe prompt handling
-        let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let escaped_prompt = prompt.replace('\'', "''");
-            format!(" --interactive '{}'", escaped_prompt)
+        // Decode the prompt from Base64 (UTF-8) into a PS variable so that
+        // single quotes, double quotes, newlines, and other special characters
+        // all survive the PS5.1 → Win32 command-line argument-passing layer.
+        // - Base64 alphabet is [A-Za-z0-9+/=]: safe inside PS single-quoted strings.
+        // - `-replace '"','\"'` fixes PS5.1's Win32 encoding bug that strips bare `"`.
+        // - `-replace '\r?\n',' '` collapses newlines (Win32 args cannot contain them).
+        let (interactive_setup, interactive_flag) = if let Some(prompt) = &config.prompt {
+            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
+            let setup = format!(
+                "$__tp_b=[System.Convert]::FromBase64String('{}');$__tp_r=[System.Text.Encoding]::UTF8.GetString($__tp_b);$__tp_e=($__tp_r -replace '\"','\\\"') -replace '\\r?\\n',' '; ",
+                b64
+            );
+            (setup, " --interactive $__tp_e".to_string())
         } else {
-            String::new()
+            (String::new(), String::new())
         };
         let ps_cmd = format!(
-            "{env_setup}$host.UI.RawUI.WindowTitle = 'Copilot Session'; Set-Location -LiteralPath '{}'; Write-Host 'Starting Copilot session in:' -ForegroundColor Cyan; Write-Host '  {}' -ForegroundColor White; Write-Host ''; {}{}{}",
-            escaped_dir, escaped_dir, checkout_step, copilot_cmd, interactive_suffix
+            "{env_setup}$host.UI.RawUI.WindowTitle = 'Copilot Session'; Set-Location -LiteralPath '{}'; Write-Host 'Starting Copilot session in:' -ForegroundColor Cyan; Write-Host '  {}' -ForegroundColor White; Write-Host ''; {}{}{}{}",
+            escaped_dir, escaped_dir, checkout_step, interactive_setup, copilot_cmd, interactive_flag
         );
 
         // Use -EncodedCommand (Base64 UTF-16LE) to avoid all escaping issues
@@ -232,10 +241,13 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .as_deref()
             .map(|c| format!("{} && ", c))
             .unwrap_or_default();
-        // Shell-escape prompt with single quotes for bash/zsh
+        // Base64-encode the prompt (UTF-8) and decode via shell command substitution.
+        // The Base64 alphabet [A-Za-z0-9+/=] is safe inside POSIX single-quoted strings
+        // AND inside AppleScript double-quoted strings, so no additional escaping is
+        // needed at any layer (shell or AppleScript).
         let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let escaped_prompt = prompt.replace('\'', "'\\''");
-            format!(" --interactive '{}'", escaped_prompt)
+            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
+            format!(" --interactive \"$(echo '{}' | base64 -d)\"", b64)
         } else {
             String::new()
         };
@@ -251,8 +263,8 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .map(|c| format!("{} && ", c))
             .unwrap_or_default();
         let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let escaped_prompt = prompt.replace('\'', "'\\''");
-            format!(" --interactive '{}'", escaped_prompt)
+            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
+            format!(" --interactive \"$(echo '{}' | base64 -d)\"", b64)
         } else {
             String::new()
         };

--- a/crates/tracepilot-orchestrator/src/launcher.rs
+++ b/crates/tracepilot-orchestrator/src/launcher.rs
@@ -203,18 +203,11 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .map(|(k, v)| format!("$env:{} = '{}'; ", k, v.replace('\'', "''")))
             .collect();
 
-        // Build the full PowerShell script with startup banner.
-        // PowerShell's `--% ` stop-parsing token causes PS to pass the remainder
-        // of the statement verbatim as the Win32 command line, bypassing PS5.1's
-        // Win32 encoding bug that strips bare `"` from variable values.
-        // Rust-side win32_quote_arg() applies the MSVCRT quoting rules so that
-        // CommandLineToArgvW reconstructs the exact original prompt.
-        let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let quoted = crate::process::win32_quote_arg(prompt);
-            format!(" --% --interactive {}", quoted)
-        } else {
-            String::new()
-        };
+        // `--% ` stops PS argument processing; win32_quote_arg applies MSVCRT rules
+        // so CommandLineToArgvW reconstructs the exact original prompt.
+        let interactive_suffix = config.prompt.as_deref()
+            .map(|p| format!(" --% --interactive {}", crate::process::win32_quote_arg(p)))
+            .unwrap_or_default();
         let ps_cmd = format!(
             "{env_setup}$host.UI.RawUI.WindowTitle = 'Copilot Session'; Set-Location -LiteralPath '{}'; Write-Host 'Starting Copilot session in:' -ForegroundColor Cyan; Write-Host '  {}' -ForegroundColor White; Write-Host ''; {}{}{}",
             escaped_dir, escaped_dir, checkout_step, copilot_cmd, interactive_suffix
@@ -230,39 +223,20 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
         )?
     };
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     let pid = {
         let checkout_prefix = checkout_cmd
             .as_deref()
             .map(|c| format!("{} && ", c))
             .unwrap_or_default();
-        // Base64-encode the prompt (UTF-8) and decode via shell command substitution.
-        // The Base64 alphabet [A-Za-z0-9+/=] is safe inside POSIX single-quoted strings
-        // AND inside AppleScript double-quoted strings, so no additional escaping is
-        // needed at any layer (shell or AppleScript).
-        let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
-            format!(" --interactive \"$(echo '{}' | base64 -d)\"", b64)
-        } else {
-            String::new()
-        };
-        let full_cmd = format!("{}{}{}", checkout_prefix, copilot_cmd, interactive_suffix);
-        let envs_ref = if envs.is_empty() { None } else { Some(&envs) };
-        crate::process::spawn_detached_terminal(&full_cmd, &[], &work_dir, envs_ref)?
-    };
-
-    #[cfg(target_os = "linux")]
-    let pid = {
-        let checkout_prefix = checkout_cmd
-            .as_deref()
-            .map(|c| format!("{} && ", c))
+        // Base64 chars are safe in POSIX single-quoted strings and AppleScript
+        // double-quoted strings; the shell decodes the prompt at runtime.
+        let interactive_suffix = config.prompt.as_deref()
+            .map(|p| format!(
+                " --interactive \"$(echo '{}' | base64 -d)\"",
+                crate::process::encode_prompt_utf8_base64(p)
+            ))
             .unwrap_or_default();
-        let interactive_suffix = if let Some(prompt) = &config.prompt {
-            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
-            format!(" --interactive \"$(echo '{}' | base64 -d)\"", b64)
-        } else {
-            String::new()
-        };
         let full_cmd = format!("{}{}{}", checkout_prefix, copilot_cmd, interactive_suffix);
         let envs_ref = if envs.is_empty() { None } else { Some(&envs) };
         crate::process::spawn_detached_terminal(&full_cmd, &[], &work_dir, envs_ref)?

--- a/crates/tracepilot-orchestrator/src/launcher.rs
+++ b/crates/tracepilot-orchestrator/src/launcher.rs
@@ -203,26 +203,21 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .map(|(k, v)| format!("$env:{} = '{}'; ", k, v.replace('\'', "''")))
             .collect();
 
-        // Build the full PowerShell script with startup banner
-        // Decode the prompt from Base64 (UTF-8) into a PS variable so that
-        // single quotes, double quotes, newlines, and other special characters
-        // all survive the PS5.1 → Win32 command-line argument-passing layer.
-        // - Base64 alphabet is [A-Za-z0-9+/=]: safe inside PS single-quoted strings.
-        // - `-replace '"','\"'` fixes PS5.1's Win32 encoding bug that strips bare `"`.
-        // - `-replace '\r?\n',' '` collapses newlines (Win32 args cannot contain them).
-        let (interactive_setup, interactive_flag) = if let Some(prompt) = &config.prompt {
-            let b64 = crate::process::encode_prompt_utf8_base64(prompt);
-            let setup = format!(
-                "$__tp_b=[System.Convert]::FromBase64String('{}');$__tp_r=[System.Text.Encoding]::UTF8.GetString($__tp_b);$__tp_e=($__tp_r -replace '\"','\\\"') -replace '\\r?\\n',' '; ",
-                b64
-            );
-            (setup, " --interactive $__tp_e".to_string())
+        // Build the full PowerShell script with startup banner.
+        // PowerShell's `--% ` stop-parsing token causes PS to pass the remainder
+        // of the statement verbatim as the Win32 command line, bypassing PS5.1's
+        // Win32 encoding bug that strips bare `"` from variable values.
+        // Rust-side win32_quote_arg() applies the MSVCRT quoting rules so that
+        // CommandLineToArgvW reconstructs the exact original prompt.
+        let interactive_suffix = if let Some(prompt) = &config.prompt {
+            let quoted = crate::process::win32_quote_arg(prompt);
+            format!(" --% --interactive {}", quoted)
         } else {
-            (String::new(), String::new())
+            String::new()
         };
         let ps_cmd = format!(
-            "{env_setup}$host.UI.RawUI.WindowTitle = 'Copilot Session'; Set-Location -LiteralPath '{}'; Write-Host 'Starting Copilot session in:' -ForegroundColor Cyan; Write-Host '  {}' -ForegroundColor White; Write-Host ''; {}{}{}{}",
-            escaped_dir, escaped_dir, checkout_step, interactive_setup, copilot_cmd, interactive_flag
+            "{env_setup}$host.UI.RawUI.WindowTitle = 'Copilot Session'; Set-Location -LiteralPath '{}'; Write-Host 'Starting Copilot session in:' -ForegroundColor Cyan; Write-Host '  {}' -ForegroundColor White; Write-Host ''; {}{}{}",
+            escaped_dir, escaped_dir, checkout_step, copilot_cmd, interactive_suffix
         );
 
         // Use -EncodedCommand (Base64 UTF-16LE) to avoid all escaping issues

--- a/crates/tracepilot-orchestrator/src/process.rs
+++ b/crates/tracepilot-orchestrator/src/process.rs
@@ -749,13 +749,65 @@ impl<W: std::io::Write> std::io::Write for Base64Encoder<W> {
     }
 }
 
+// ─── Windows Win32 argument quoting ─────────────────────────────────
+
+/// Quote a string as a single Win32 command-line argument (MSVCRT convention).
+///
+/// Used with PowerShell's `--% ` stop-parsing token so that PS never touches
+/// the value and `CommandLineToArgvW` receives it directly. Rules:
+/// - Backslashes before a `"` are doubled, then the `"` is escaped as `\"`
+/// - Trailing backslashes (before the closing `"`) are doubled
+/// - Newlines/carriage-returns are collapsed to a space (Win32 args are single-line)
+/// - The result is always wrapped in double-quotes
+#[cfg(windows)]
+pub(crate) fn win32_quote_arg(s: &str) -> String {
+    let s: String = s
+        .chars()
+        .map(|c| if c == '\r' || c == '\n' { ' ' } else { c })
+        .collect();
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    let mut i = 0;
+    while i < chars.len() {
+        let mut n_bs = 0;
+        while i < chars.len() && chars[i] == '\\' {
+            i += 1;
+            n_bs += 1;
+        }
+        if i == chars.len() {
+            // Trailing backslashes — double before closing quote
+            for _ in 0..n_bs * 2 {
+                out.push('\\');
+            }
+            break;
+        } else if chars[i] == '"' {
+            // Backslashes immediately before a quote — double, then escape the quote
+            for _ in 0..n_bs * 2 {
+                out.push('\\');
+            }
+            out.push_str("\\\"");
+            i += 1;
+        } else {
+            // Ordinary character — backslashes are literal
+            for _ in 0..n_bs {
+                out.push('\\');
+            }
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out.push('"');
+    out
+}
+
 // ─── Base64 prompt encoding ─────────────────────────────────────────
 
 /// Base64-encode a prompt string (UTF-8 bytes) for safe embedding in shell/PS scripts.
 ///
 /// The result contains only `[A-Za-z0-9+/=]` and therefore requires no escaping
 /// in PS single-quoted strings, POSIX single-quoted strings, or AppleScript
-/// double-quoted strings. Used by all platforms to safely pass `--interactive`
+/// double-quoted strings. Used by macOS/Linux to safely pass `--interactive`
 /// prompts containing arbitrary characters (quotes, newlines, backslashes, etc.).
 pub(crate) fn encode_prompt_utf8_base64(s: &str) -> String {
     const CHARS: &[u8] =
@@ -1069,6 +1121,53 @@ mod tests {
             .map(|c| char::from_u32(c as u32).unwrap_or('?'))
             .collect();
         assert_eq!(decoded, cmd);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_plain() {
+        assert_eq!(win32_quote_arg("hello"), "\"hello\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_with_spaces() {
+        assert_eq!(win32_quote_arg("hello world"), "\"hello world\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_double_quotes() {
+        // He said "hi" → "He said \"hi\""
+        assert_eq!(win32_quote_arg(r#"He said "hi""#), r#""He said \"hi\"""#);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_backslash_before_quote() {
+        // a\"b → "a\\\"b"  (backslash before quote: double the backslash, escape the quote)
+        assert_eq!(win32_quote_arg(r#"a\"b"#), r#""a\\\"b""#);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_trailing_backslash() {
+        // "hello\" → "hello\\"  (trailing backslash doubled before closing quote)
+        assert_eq!(win32_quote_arg("hello\\"), "\"hello\\\\\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_newlines_collapsed() {
+        assert_eq!(win32_quote_arg("line1\nline2"), "\"line1 line2\"");
+        assert_eq!(win32_quote_arg("line1\r\nline2"), "\"line1  line2\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_quote_arg_single_quotes() {
+        // Single quotes need no escaping in Win32 args
+        assert_eq!(win32_quote_arg("it's fine"), "\"it's fine\"");
     }
 
     #[test]

--- a/crates/tracepilot-orchestrator/src/process.rs
+++ b/crates/tracepilot-orchestrator/src/process.rs
@@ -751,88 +751,52 @@ impl<W: std::io::Write> std::io::Write for Base64Encoder<W> {
 
 // ─── Windows Win32 argument quoting ─────────────────────────────────
 
-/// Quote a string as a single Win32 command-line argument (MSVCRT convention).
-///
-/// Used with PowerShell's `--% ` stop-parsing token so that PS never touches
-/// the value and `CommandLineToArgvW` receives it directly. Rules:
-/// - Backslashes before a `"` are doubled, then the `"` is escaped as `\"`
-/// - Trailing backslashes (before the closing `"`) are doubled
-/// - Newlines/carriage-returns are collapsed to a space (Win32 args are single-line)
-/// - The result is always wrapped in double-quotes
+/// Quote a string as a single Win32 command-line argument (MSVCRT rules).
+/// Backslashes before `"` or at end-of-string are doubled; `"` is escaped as `\"`;
+/// newlines are collapsed to a space. Used with PS's `--% ` stop-parsing token.
 #[cfg(windows)]
 pub(crate) fn win32_quote_arg(s: &str) -> String {
-    let s: String = s
-        .chars()
-        .map(|c| if c == '\r' || c == '\n' { ' ' } else { c })
-        .collect();
-    let chars: Vec<char> = s.chars().collect();
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    let mut i = 0;
-    while i < chars.len() {
-        let mut n_bs = 0;
-        while i < chars.len() && chars[i] == '\\' {
-            i += 1;
-            n_bs += 1;
-        }
-        if i == chars.len() {
-            // Trailing backslashes — double before closing quote
-            for _ in 0..n_bs * 2 {
-                out.push('\\');
+    let s = s.replace(['\r', '\n'], " ");
+    let mut out = String::from('"');
+    let mut bs: u32 = 0;
+    for c in s.chars() {
+        match c {
+            '\\' => bs += 1,
+            '"' => {
+                (0..bs * 2).for_each(|_| out.push('\\'));
+                out.push_str("\\\"");
+                bs = 0;
             }
-            break;
-        } else if chars[i] == '"' {
-            // Backslashes immediately before a quote — double, then escape the quote
-            for _ in 0..n_bs * 2 {
-                out.push('\\');
+            c => {
+                (0..bs).for_each(|_| out.push('\\'));
+                out.push(c);
+                bs = 0;
             }
-            out.push_str("\\\"");
-            i += 1;
-        } else {
-            // Ordinary character — backslashes are literal
-            for _ in 0..n_bs {
-                out.push('\\');
-            }
-            out.push(chars[i]);
-            i += 1;
         }
     }
+    (0..bs * 2).for_each(|_| out.push('\\')); // double trailing backslashes
     out.push('"');
     out
 }
 
-// ─── Base64 prompt encoding ─────────────────────────────────────────
+// ─── Base64 prompt encoding (macOS / Linux) ──────────────────────────
 
-/// Base64-encode a prompt string (UTF-8 bytes) for safe embedding in shell/PS scripts.
-///
-/// The result contains only `[A-Za-z0-9+/=]` and therefore requires no escaping
-/// in PS single-quoted strings, POSIX single-quoted strings, or AppleScript
-/// double-quoted strings. Used by macOS/Linux to safely pass `--interactive`
-/// prompts containing arbitrary characters (quotes, newlines, backslashes, etc.).
+/// Base64-encode a prompt (UTF-8). Output is `[A-Za-z0-9+/=]` — safe inside
+/// POSIX single-quoted strings and AppleScript double-quoted strings with no
+/// further escaping. Decoded at runtime via `$(echo '...' | base64 -d)`.
 pub(crate) fn encode_prompt_utf8_base64(s: &str) -> String {
-    const CHARS: &[u8] =
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let bytes = s.as_bytes();
-    let mut out = Vec::with_capacity(4 * ((bytes.len() + 2) / 3));
-    for chunk in bytes.chunks(3) {
-        let b0 = chunk[0];
-        let b1 = if chunk.len() > 1 { chunk[1] } else { 0 };
-        let b2 = if chunk.len() > 2 { chunk[2] } else { 0 };
-        out.push(CHARS[(b0 >> 2) as usize]);
-        out.push(CHARS[((b0 & 0x03) << 4 | b1 >> 4) as usize]);
-        out.push(if chunk.len() > 1 {
-            CHARS[((b1 & 0x0f) << 2 | b2 >> 6) as usize]
-        } else {
-            b'='
-        });
-        out.push(if chunk.len() > 2 {
-            CHARS[(b2 & 0x3f) as usize]
-        } else {
-            b'='
-        });
+    const C: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut o = Vec::with_capacity(4 * ((s.len() + 2) / 3));
+    for c in s.as_bytes().chunks(3) {
+        let (b0, b1, b2) = (c[0], c.get(1).copied().unwrap_or(0), c.get(2).copied().unwrap_or(0));
+        o.extend_from_slice(&[
+            C[(b0 >> 2) as usize],
+            C[((b0 & 3) << 4 | b1 >> 4) as usize],
+            if c.len() > 1 { C[((b1 & 0xf) << 2 | b2 >> 6) as usize] } else { b'=' },
+            if c.len() > 2 { C[(b2 & 0x3f) as usize] } else { b'=' },
+        ]);
     }
-    // Safety: base64 output is always valid ASCII (subset of UTF-8)
-    String::from_utf8(out).expect("base64 output is always valid ASCII")
+    String::from_utf8(o).expect("base64 is ASCII")
 }
 
 // ─── Environment variable name validation ───────────────────────────

--- a/crates/tracepilot-orchestrator/src/process.rs
+++ b/crates/tracepilot-orchestrator/src/process.rs
@@ -749,6 +749,40 @@ impl<W: std::io::Write> std::io::Write for Base64Encoder<W> {
     }
 }
 
+// ─── Base64 prompt encoding ─────────────────────────────────────────
+
+/// Base64-encode a prompt string (UTF-8 bytes) for safe embedding in shell/PS scripts.
+///
+/// The result contains only `[A-Za-z0-9+/=]` and therefore requires no escaping
+/// in PS single-quoted strings, POSIX single-quoted strings, or AppleScript
+/// double-quoted strings. Used by all platforms to safely pass `--interactive`
+/// prompts containing arbitrary characters (quotes, newlines, backslashes, etc.).
+pub(crate) fn encode_prompt_utf8_base64(s: &str) -> String {
+    const CHARS: &[u8] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(4 * ((bytes.len() + 2) / 3));
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = if chunk.len() > 1 { chunk[1] } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] } else { 0 };
+        out.push(CHARS[(b0 >> 2) as usize]);
+        out.push(CHARS[((b0 & 0x03) << 4 | b1 >> 4) as usize]);
+        out.push(if chunk.len() > 1 {
+            CHARS[((b1 & 0x0f) << 2 | b2 >> 6) as usize]
+        } else {
+            b'='
+        });
+        out.push(if chunk.len() > 2 {
+            CHARS[(b2 & 0x3f) as usize]
+        } else {
+            b'='
+        });
+    }
+    // Safety: base64 output is always valid ASCII (subset of UTF-8)
+    String::from_utf8(out).expect("base64 output is always valid ASCII")
+}
+
 // ─── Environment variable name validation ───────────────────────────
 
 /// Validate that an environment variable name contains only safe characters.


### PR DESCRIPTION
## Problem

Passing prompts via `--interactive` containing double quotes, single quotes, or newlines would silently corrupt or truncate the prompt on all platforms.

**Root causes:**
- **Windows (PS5.1):** `CommandLineToArgvW` strips bare `"` from variables when PS5.1 builds the command line. Single-quote escaping never addressed this.
- **macOS:** The POSIX `'\''` escape was double-processed by AppleScript's backslash-escaping pass, turning the quote escape into a backslash.
- **Linux:** Same POSIX bug; literal newlines also broke terminal `-e` parsing.

## Solution

**Windows:** Use PowerShell's `--% ` stop-parsing token so PS never touches the argument. `win32_quote_arg()` in Rust applies MSVCRT quoting rules so `CommandLineToArgvW` reconstructs the exact original prompt.

**macOS / Linux:** Base64-encode the prompt in Rust and decode at runtime via shell command substitution. The base64 alphabet is safe in POSIX single-quoted strings and AppleScript double-quoted strings with no further escaping needed. The two platform blocks are now merged into one `#[cfg(any(...))]` block since they are identical.

## Changes

- `process.rs` — `win32_quote_arg()` (Windows), `encode_prompt_utf8_base64()` (macOS/Linux), 7 unit tests
- `launcher.rs` — Windows uses `--% ` suffix; macOS+Linux merged into one block

All 384 tests pass.
