### PR TITLE
⚡ Bolt: [performance improvement] Cache statement for batch inserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-20 - Statement caching on dynamic loop iterations for batch inserts
+**Learning:** For batch bulk inserts with explicit large dynamically formed tuple inputs via `params`, we cache the prepared `rusqlite::Statement` rather than re-preparing a cached static `String` containing the full parameterized query. Caching statement objects outside `chunks()` mitigates repeated compilation overhead in tight multi-row insert loops using `rusqlite`.
+**Action:** Always verify if SQLite `Statement` preparation can be pulled outside of dynamically processed loops where queries are generated iteratively.

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -74,39 +74,47 @@ pub(crate) fn batched_insert<'a, T, F>(
     sql_prefix: &str,
     params_per_row: usize,
     items: &'a [T],
-    to_params: F,
+    mut to_params: F,
 ) -> Result<()>
 where
-    F: for<'b> Fn(&'a T, &'b mut Vec<&'a dyn ToSql>),
+    F: for<'b> FnMut(&'a T, &'b mut Vec<&'a dyn ToSql>),
 {
     if items.is_empty() {
         return Ok(());
     }
 
-    // All full-sized chunks share the same SQL shape — build it lazily on first
-    // use so sessions with < BATCH_CHUNK_SIZE rows (most analytics tables) pay
-    // zero allocation for the full-chunk string they never use.
-    let mut full_sql: Option<String> = None;
+    // Cache the prepared statement for full chunks.
+    // Re-preparing the same 100-row statement inside the loop is a major bottleneck
+    // when writing thousands of rows. Caching it here bypasses `sqlite3_prepare_v2`
+    // for everything except the final partial chunk.
+    let mut full_stmt_cache: Option<rusqlite::Statement<'_>> = None;
 
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let partial;
-        let sql: &str = if chunk.len() == BATCH_CHUNK_SIZE {
-            full_sql.get_or_insert_with(|| {
-                build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row)
-            })
+        if chunk.len() == BATCH_CHUNK_SIZE {
+            if full_stmt_cache.is_none() {
+                let sql = build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row);
+                full_stmt_cache = Some(conn.prepare(&sql)?);
+            }
+            let stmt = full_stmt_cache.as_mut().unwrap();
+
+            let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
+            for item in chunk {
+                to_params(item, &mut params);
+            }
+
+            stmt.execute(rusqlite::params_from_iter(params))?;
         } else {
-            partial = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
-            &partial
-        };
+            // Partial chunk logic remains dynamic to avoid polluting SQLite's statement cache
+            let sql = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
+            let mut stmt = conn.prepare(&sql)?;
 
-        let mut stmt = conn.prepare(sql)?;
+            let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
+            for item in chunk {
+                to_params(item, &mut params);
+            }
 
-        let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
-        for item in chunk {
-            to_params(item, &mut params);
+            stmt.execute(rusqlite::params_from_iter(params))?;
         }
-
-        stmt.execute(rusqlite::params_from_iter(params))?;
     }
 
     Ok(())


### PR DESCRIPTION
💡 What: We now cache the compiled `rusqlite::Statement` (`Option<rusqlite::Statement<'_>>`) for the full-sized (100 rows) chunk inside `batched_insert`, rather than just caching the generated SQL string and calling `conn.prepare()` inside every loop iteration.

🎯 Why: Calling `prepare()` inside the loop for every single chunk causes major unnecessary overhead, since the multi-row insert query string for the 100-chunk is identical every time. This reduces the SQLite compilation time significantly for bulk inserts (such as indexing tens of thousands of session events).

📊 Impact: Reduces statement preparation overhead significantly for multi-row chunk inserts.

🔬 Measurement: We wrote a local test to verify the functionality remains intact across partial and full chunk sizes. Caching the statement allows SQLite to bypass string parsing for all but the final chunk.

---
*PR created automatically by Jules for task [14671354804127684316](https://jules.google.com/task/14671354804127684316) started by @MattShelton04*