### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/apps/desktop/src/components/configInjector/ConfigInjectorGlobalTab.vue
+++ b/apps/desktop/src/components/configInjector/ConfigInjectorGlobalTab.vue
@@ -101,7 +101,7 @@ const FAST_MODELS = getModelsByTier("fast").map((m) => m.id);
           <div class="folder-list">
             <div v-for="(folder, i) in editTrustedFolders" :key="i" class="folder-item">
               <span class="folder-path">{{ folder }}</span>
-              <button class="btn-icon-sm" title="Remove" @click="removeFolder(i)">✕</button>
+              <button class="btn-icon-sm" title="Remove folder" aria-label="Remove folder" @click="removeFolder(i)">✕</button>
             </div>
             <EmptyState v-if="!editTrustedFolders.length" compact message="No trusted folders configured." />
           </div>

--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,7 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button class="syntax-help-close" aria-label="Close" @click="$emit('close')">✕</button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">


### PR DESCRIPTION
## 💡 What
Added `aria-label` and `title` attributes to icon-only buttons that were previously missing them.

## 🎯 Why
Icon-only buttons must have descriptive text via `aria-label` for screen reader accessibility, ensuring all users can understand the button's action. This addresses a basic a11y requirement within the application's UX code standards.

## 📸 Before/After
*   **Before:** Icon-only buttons with just a `✕` character and no `aria-label`.
*   **After:** Icon-only buttons with `aria-label="Remove folder"` or `aria-label="Close"` ensuring screen reader compatibility. No visual styling changes were introduced.

## ♿ Accessibility
*   Added `aria-label="Remove folder"` and updated `title` to the Remove Folder button in `ConfigInjectorGlobalTab.vue`.
*   Added `aria-label="Close"` to the Close Modal button in `SearchSyntaxHelpModal.vue`.

## Verification Steps
1. Run `pnpm dev` to start the desktop app.
2. Navigate to **Settings** -> **Advanced** to view the Trusted Folders list.
3. Hover over the remove folder icon (`✕`) to verify the updated tooltip ("Remove folder").
4. Inspect the element or use a screen reader to verify the `aria-label` is present.
5. Open the **Search** palette and click the `?` icon to open the Search Syntax Help Modal.
6. Inspect the close button (`✕`) in the modal header to verify the `aria-label="Close"` is present.

---
*PR created automatically by Jules for task [14985532319801357900](https://jules.google.com/task/14985532319801357900) started by @MattShelton04*