### PR TITLE
fix: batch of auto-refresh, CSS scope, viewport, SQLite viewer, MD bullets and Search filter bugs

### DIFF
--- a/apps/desktop/src/__tests__/stores/search.test.ts
+++ b/apps/desktop/src/__tests__/stores/search.test.ts
@@ -205,6 +205,26 @@ describe("useSearchStore – scheduling", () => {
     expect(store.loading).toBe(false);
   });
 
+  it("triggers an immediate search when contentTypes is replaced (no query change)", async () => {
+    // Regression: shallowRef filter arrays must be replaced wholesale (not
+    // mutated via splice/push) for the filter watcher in stores/search.ts
+    // to fire. If the sidebar falls back to splice/push, filter toggles
+    // won't re-run the search until the query changes — the bug this
+    // test guards against.
+    const store = useSearchStore();
+
+    // Replace the array wholesale, the way the sidebar now does.
+    store.contentTypes = ["tool_call"];
+
+    await vi.runAllTimersAsync();
+    await nextTick();
+    await Promise.resolve();
+
+    expect(mockSearchContent).toHaveBeenCalledTimes(1);
+    const [, options] = mockSearchContent.mock.calls[0];
+    expect(options.contentTypes).toEqual(["tool_call"]);
+  });
+
   it("passes unix timestamps for valid date range", async () => {
     const store = useSearchStore();
     store.dateFrom = "2025-01-01T00:00:00.000Z";

--- a/apps/desktop/src/__tests__/stores/sessionDetail.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessionDetail.test.ts
@@ -594,7 +594,7 @@ describe("useSessionDetailStore", () => {
       expect(mockGetSessionIncidents).toHaveBeenCalledWith(SESSION_ID);
     });
 
-    it("does not background-refresh events or todos on cache hit", async () => {
+    it("background-refreshes todos but not events on cache hit", async () => {
       const store = useSessionDetailStore();
       await fullyLoadSession(store, SESSION_ID);
       await store.loadTodos();
@@ -612,14 +612,18 @@ describe("useSessionDetailStore", () => {
       mockGetSessionPlan.mockResolvedValue(FIXTURE_PLAN);
       mockGetShutdownMetrics.mockResolvedValue(FIXTURE_METRICS);
       mockGetSessionIncidents.mockResolvedValue(FIXTURE_INCIDENTS);
+      mockGetSessionTodos.mockResolvedValue({ todos: [{ id: "fresh" }], deps: [] });
       mockCheckSessionFreshness.mockResolvedValue(ZERO_FRESHNESS);
 
       await store.loadDetail(SESSION_ID);
       await new Promise((r) => setTimeout(r, 50));
 
-      // Events and todos should NOT be refreshed in background
+      // Todos IS refreshed so agents writing new todos while cached are picked up
+      // (regression: previously the cache-hit path deleted todos from `loaded`
+      //  which caused the background refreshAll to skip todos entirely).
+      expect(mockGetSessionTodos).toHaveBeenCalledWith(SESSION_ID);
+      // Events remain paginated / not auto-refreshed (they manage their own cursor).
       expect(mockGetSessionEvents).not.toHaveBeenCalled();
-      expect(mockGetSessionTodos).not.toHaveBeenCalled();
     });
 
     it("sets section error refs when background refresh fails on cache hit", async () => {

--- a/apps/desktop/src/__tests__/stores/sessions.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessions.test.ts
@@ -220,16 +220,29 @@ describe("useSessionsStore", () => {
     expect(store.sessions).toHaveLength(2);
   });
 
-  it("ensureIndex({ force: true }) bypasses throttle (auto-refresh path)", async () => {
-    mockReindexSessions.mockResolvedValue([3, 10]);
-    mockListSessions.mockResolvedValue([MOCK_SESSION]);
-    const store = useSessionsStore();
+  it("ensureIndex({ force: true }) bypasses the long nav-throttle but has its own short throttle", async () => {
+    vi.useFakeTimers();
+    try {
+      mockReindexSessions.mockResolvedValue([3, 10]);
+      mockListSessions.mockResolvedValue([MOCK_SESSION]);
+      const store = useSessionsStore();
 
-    await store.ensureIndex();
-    expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+      await store.ensureIndex();
+      expect(mockReindexSessions).toHaveBeenCalledTimes(1);
 
-    // Forced refresh should reindex again even within the throttle window.
-    await store.ensureIndex({ force: true });
-    expect(mockReindexSessions).toHaveBeenCalledTimes(2);
+      // Within the 20s force-throttle window the list is still refreshed,
+      // but the expensive reindex is skipped.
+      await store.ensureIndex({ force: true });
+      expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+      expect(mockListSessions.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      // Past the force-throttle window: reindex runs again, bypassing the
+      // 2-minute navigation throttle.
+      vi.advanceTimersByTime(20_001);
+      await store.ensureIndex({ force: true });
+      expect(mockReindexSessions).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/__tests__/stores/sessions.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessions.test.ts
@@ -196,4 +196,40 @@ describe("useSessionsStore", () => {
     expect(store.error).toBeNull();
     expect(store.indexing).toBe(false);
   });
+
+  it("ensureIndex throttles repeat reindexes but still refreshes the list", async () => {
+    mockReindexSessions.mockResolvedValue([3, 10]);
+    mockListSessions.mockResolvedValue([MOCK_SESSION]);
+    const store = useSessionsStore();
+
+    // First call — reindex runs, list fetched.
+    await store.ensureIndex();
+    expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+    expect(mockListSessions).toHaveBeenCalledTimes(1);
+
+    // Second call immediately — within throttle window.
+    const UPDATED = { ...MOCK_SESSION, id: "new-session" };
+    mockListSessions.mockResolvedValue([MOCK_SESSION, UPDATED]);
+    await store.ensureIndex();
+
+    // Reindex is throttled (not re-run)...
+    expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+    // ...but the session list IS still refreshed so new sessions that appeared
+    // between navigations are picked up without requiring Ctrl+R.
+    expect(mockListSessions).toHaveBeenCalledTimes(2);
+    expect(store.sessions).toHaveLength(2);
+  });
+
+  it("ensureIndex({ force: true }) bypasses throttle (auto-refresh path)", async () => {
+    mockReindexSessions.mockResolvedValue([3, 10]);
+    mockListSessions.mockResolvedValue([MOCK_SESSION]);
+    const store = useSessionsStore();
+
+    await store.ensureIndex();
+    expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+
+    // Forced refresh should reindex again even within the throttle window.
+    await store.ensureIndex({ force: true });
+    expect(mockReindexSessions).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/__tests__/stores/sessions.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessions.test.ts
@@ -220,29 +220,24 @@ describe("useSessionsStore", () => {
     expect(store.sessions).toHaveLength(2);
   });
 
-  it("ensureIndex({ force: true }) bypasses the long nav-throttle but has its own short throttle", async () => {
-    vi.useFakeTimers();
-    try {
-      mockReindexSessions.mockResolvedValue([3, 10]);
-      mockListSessions.mockResolvedValue([MOCK_SESSION]);
-      const store = useSessionsStore();
+  it("ensureIndex({ force: true }) bypasses the throttle on every call", async () => {
+    mockReindexSessions.mockResolvedValue([3, 10]);
+    mockListSessions.mockResolvedValue([MOCK_SESSION]);
+    const store = useSessionsStore();
 
-      await store.ensureIndex();
-      expect(mockReindexSessions).toHaveBeenCalledTimes(1);
+    // First call — reindex runs.
+    await store.ensureIndex();
+    expect(mockReindexSessions).toHaveBeenCalledTimes(1);
 
-      // Within the 20s force-throttle window the list is still refreshed,
-      // but the expensive reindex is skipped.
-      await store.ensureIndex({ force: true });
-      expect(mockReindexSessions).toHaveBeenCalledTimes(1);
-      expect(mockListSessions.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Immediate force call bypasses the 2-minute nav throttle and reindexes
+    // again — this is the auto-refresh tick that must pick up new on-disk
+    // sessions without waiting for Ctrl+R.
+    await store.ensureIndex({ force: true });
+    expect(mockReindexSessions).toHaveBeenCalledTimes(2);
 
-      // Past the force-throttle window: reindex runs again, bypassing the
-      // 2-minute navigation throttle.
-      vi.advanceTimersByTime(20_001);
-      await store.ensureIndex({ force: true });
-      expect(mockReindexSessions).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
+    // Subsequent force ticks keep reindexing — we trade a cheap reindex
+    // per tick for guaranteed freshness of the session list.
+    await store.ensureIndex({ force: true });
+    expect(mockReindexSessions).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/desktop/src/components/search/SearchFilterSidebar.vue
+++ b/apps/desktop/src/components/search/SearchFilterSidebar.vue
@@ -42,24 +42,26 @@ function getContentTypeState(ct: SearchContentType): FilterState {
 
 function cycleContentType(ct: SearchContentType) {
   const state = getContentTypeState(ct);
-  const incIdx = store.contentTypes.indexOf(ct);
-  if (incIdx >= 0) store.contentTypes.splice(incIdx, 1);
-  const excIdx = store.excludeContentTypes.indexOf(ct);
-  if (excIdx >= 0) store.excludeContentTypes.splice(excIdx, 1);
+  // shallowRef: mutate via wholesale replacement so the store watcher fires.
+  const nextInclude = store.contentTypes.filter((t) => t !== ct);
+  const nextExclude = store.excludeContentTypes.filter((t) => t !== ct);
 
   if (state === "off") {
-    store.contentTypes.push(ct);
+    nextInclude.push(ct);
   } else if (state === "include") {
-    store.excludeContentTypes.push(ct);
+    nextExclude.push(ct);
   }
+
+  store.contentTypes = nextInclude;
+  store.excludeContentTypes = nextExclude;
 }
 
 function toggleAllContentTypes() {
   if (store.contentTypes.length > 0 || store.excludeContentTypes.length > 0) {
-    store.contentTypes.splice(0);
-    store.excludeContentTypes.splice(0);
+    store.contentTypes = [];
+    store.excludeContentTypes = [];
   } else {
-    store.contentTypes.splice(0, store.contentTypes.length, ...visibleContentTypes.value);
+    store.contentTypes = [...visibleContentTypes.value];
   }
 }
 

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="detail-panel" :class="{ 'detail-panel--open': worktree }">
+  <div class="wt-detail-panel" :class="{ 'wt-detail-panel--open': worktree }">
     <template v-if="worktree">
       <div class="detail-header">
         <div class="detail-header-left">

--- a/apps/desktop/src/composables/__tests__/useSessionFiles.test.ts
+++ b/apps/desktop/src/composables/__tests__/useSessionFiles.test.ts
@@ -327,4 +327,78 @@ describe("useSessionFiles", () => {
     expect(instance.files).toEqual(reloadedEntries);
     expect(mockSessionListFiles).toHaveBeenCalledTimes(2);
   });
+
+  it("silent reload does not toggle filesLoading and flags newly-added paths", async () => {
+    // BUG 1 regression: the file list used to flash + scroll to the top on
+    // every auto-refresh because loadFiles toggled filesLoading=true, which
+    // unmounted the list. Silent reload must keep the DOM stable.
+    const first = [
+      { path: "a.md", name: "a.md", sizeBytes: 1, isDirectory: false, fileType: "markdown" },
+    ];
+    const second = [
+      { path: "a.md", name: "a.md", sizeBytes: 1, isDirectory: false, fileType: "markdown" },
+      { path: "b.md", name: "b.md", sizeBytes: 2, isDirectory: false, fileType: "markdown" },
+    ];
+    mockSessionListFiles.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    const { instance } = mountComposable("sess-1");
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    // Observe filesLoading during reload — must never flip to true.
+    let sawLoading = false;
+    const reloadPromise = instance.reload();
+    // Sample immediately after calling reload (before the fetch resolves).
+    if (instance.filesLoading) sawLoading = true;
+    await reloadPromise;
+
+    expect(sawLoading).toBe(false);
+    expect(instance.filesLoading).toBe(false);
+    expect(instance.files).toEqual(second);
+    // New file is flagged for the green-fade highlight.
+    expect(Array.from(instance.newFilePaths)).toEqual(["b.md"]);
+
+    // Acknowledgement clears the transient highlight.
+    instance.ackNewPaths();
+    expect(instance.newFilePaths.size).toBe(0);
+  });
+
+  it("silent reload refetches open file content and records contentChangedAt", async () => {
+    // BUG 1 tail: when a file is open in the viewer and an agent edits it on
+    // disk, auto-refresh should show the new content without a manual re-click.
+    const entries = [
+      {
+        path: "plan.md",
+        name: "plan.md",
+        sizeBytes: 10,
+        isDirectory: false,
+        fileType: "markdown",
+      },
+    ];
+    mockSessionListFiles.mockResolvedValue(entries);
+    mockSessionReadFile
+      .mockResolvedValueOnce("v1")
+      .mockResolvedValueOnce("v2") // silent refetch
+      .mockResolvedValueOnce("v2"); // no-op silent refetch — unchanged
+
+    const { instance } = mountComposable("sess-1");
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    await instance.selectFile("plan.md", "markdown");
+    expect(instance.fileContent).toBe("v1");
+    expect(instance.contentChangedAt).toBeNull();
+
+    await instance.reload();
+    // Allow the fire-and-forget silent refetch kicked off inside loadFiles.
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    expect(instance.fileContent).toBe("v2");
+    expect(instance.contentChangedAt).not.toBeNull();
+
+    instance.ackContentChanged();
+    expect(instance.contentChangedAt).toBeNull();
+
+    // No-op refetch — same content, no pulse.
+    await instance.reload();
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    expect(instance.contentChangedAt).toBeNull();
+  });
 });

--- a/apps/desktop/src/composables/session/__tests__/cache.test.ts
+++ b/apps/desktop/src/composables/session/__tests__/cache.test.ts
@@ -11,6 +11,7 @@ const makeEntry = (id: string): CachedSession =>
     plan: null,
     shutdownMetrics: null,
     incidents: [],
+    todos: null,
     loadedSections: new Set(["detail"]),
   }) as CachedSession;
 

--- a/apps/desktop/src/composables/session/cache.ts
+++ b/apps/desktop/src/composables/session/cache.ts
@@ -10,6 +10,7 @@ import type {
   SessionIncident,
   SessionPlan,
   ShutdownMetrics,
+  TodosResponse,
 } from "@tracepilot/types";
 import type { EventsFingerprint } from "./sessionFingerprint";
 
@@ -21,6 +22,7 @@ export interface CachedSession {
   plan: SessionPlan | null;
   shutdownMetrics: ShutdownMetrics | null;
   incidents: SessionIncident[];
+  todos: TodosResponse | null;
   loadedSections: Set<string>;
 }
 

--- a/apps/desktop/src/composables/session/snapshot.ts
+++ b/apps/desktop/src/composables/session/snapshot.ts
@@ -30,6 +30,7 @@ export function buildCachedSessionSnapshot(
     plan: ctx.sections.planSection.data.value,
     shutdownMetrics: ctx.sections.metricsSection.data.value,
     incidents: ctx.sections.incidentsSection.data.value,
+    todos: ctx.sections.todosSection.data.value,
     loadedSections: new Set(ctx.loaded.value),
   } satisfies CachedSession;
 }
@@ -49,6 +50,7 @@ export function buildPrefetchedCachedSession(
     plan: null,
     shutdownMetrics: null,
     incidents: [],
+    todos: null,
     loadedSections: new Set(["detail", "turns"]),
   } satisfies CachedSession;
 }
@@ -61,5 +63,6 @@ export function restoreFromCachedSession(ctx: SnapshotContext, cached: CachedSes
   ctx.sections.planSection.data.value = cached.plan;
   ctx.sections.metricsSection.data.value = cached.shutdownMetrics;
   ctx.sections.incidentsSection.data.value = cached.incidents;
+  ctx.sections.todosSection.data.value = cached.todos;
   ctx.loaded.value = new Set(cached.loadedSections);
 }

--- a/apps/desktop/src/composables/useSessionDetail.ts
+++ b/apps/desktop/src/composables/useSessionDetail.ts
@@ -123,10 +123,15 @@ export function createSessionDetailInstance() {
     if (cached) {
       restoreFromCachedSession(snapshotCtx, cached);
       loading.value = false;
+      // Events are paginated and always refetched on the events tab
+      // (they manage their own fingerprint/cursor), so clear them here.
       events.value = null;
       loaded.value.delete("events");
-      sections.todosSection.data.value = null;
-      loaded.value.delete("todos");
+      // NOTE: todos are now cached alongside other sections. The subsequent
+      // `void refreshAll()` below will refresh them via refreshLoaded when
+      // "todos" is present in loadedSections, so we no longer need the
+      // ad-hoc `todos = null; loaded.delete("todos")` reset that previously
+      // caused new/updated todos to be missed until the Todos tab re-mounted.
 
       const lastFetched = lastFetchTimestamp.get(id) ?? 0;
       const shouldRefresh = Date.now() - lastFetched > REFRESH_THROTTLE_MS;

--- a/apps/desktop/src/composables/useSessionFiles.ts
+++ b/apps/desktop/src/composables/useSessionFiles.ts
@@ -67,7 +67,12 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
   let hasInitialLoad = false;
 
   // Monotonic counters used to discard results from superseded requests.
+  // `readSeq` tracks user-initiated selectFile() calls (which own the loading
+  // flags). `silentSeq` tracks background silentRefetchSelected() calls; kept
+  // separate so a silent refetch started mid-selectFile() cannot preempt the
+  // user call's sequence guard and leave loading flags stuck `true`.
   let readSeq = 0;
+  let silentSeq = 0;
   let loadSeq = 0;
 
   async function loadFiles(opts: { silent?: boolean } = {}) {
@@ -137,25 +142,25 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
     if (!sessionId || !path) return;
     if (fileType === "binary") return;
 
-    const seq = ++readSeq;
+    const seq = ++silentSeq;
     try {
       if (fileType === "sqlite") {
         const result = await sessionReadSqlite(sessionId, path);
-        if (seq !== readSeq) return;
+        if (seq !== silentSeq || selectedPath.value !== path) return;
         // Replace wholesale — SqliteViewer reacts to the prop change.
         dbData.value = result;
         dbDataError.value = null;
         return;
       }
       const result = await sessionReadFile(sessionId, path);
-      if (seq !== readSeq) return;
+      if (seq !== silentSeq || selectedPath.value !== path) return;
       if (result !== fileContent.value) {
         fileContent.value = result;
         contentChangedAt.value = Date.now();
       }
       fileContentError.value = null;
     } catch (err) {
-      if (seq !== readSeq) return;
+      if (seq !== silentSeq || selectedPath.value !== path) return;
       // Silent refresh failures should not clobber existing content — only
       // surface the error so the user sees a hint but keeps the stale view.
       if (fileType === "sqlite") {

--- a/apps/desktop/src/composables/useSessionFiles.ts
+++ b/apps/desktop/src/composables/useSessionFiles.ts
@@ -64,6 +64,11 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
   const newFilePaths = ref<Set<string>>(new Set());
   const contentChangedAt = ref<number | null>(null);
   let knownPaths: Set<string> = new Set();
+  // Track size-per-path so a size change (the common signal for "agent wrote
+  // to this file") can flash the entry even when it isn't the selected file.
+  // Imperfect vs mtime — a same-size rewrite won't flag — but catches the
+  // dominant append/save case without requiring a Rust-side schema change.
+  let knownSizes: Map<string, number> = new Map();
   let hasInitialLoad = false;
 
   // Monotonic counters used to discard results from superseded requests.
@@ -90,18 +95,25 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
       // Discard if session changed while we were awaiting
       if (seq !== loadSeq) return;
 
-      // Detect newly-appeared paths for the bonus highlight. Skip on the very
-      // first load so every file isn't flagged as "new".
+      // Detect newly-appeared paths and size-changed paths for the bonus
+      // highlight. Skip on the very first load so every file isn't flagged.
       if (hasInitialLoad) {
         const nextNew = new Set<string>();
         for (const entry of result) {
-          if (!entry.isDirectory && !knownPaths.has(entry.path)) {
+          if (entry.isDirectory) continue;
+          if (!knownPaths.has(entry.path)) {
             nextNew.add(entry.path);
+          } else {
+            const prevSize = knownSizes.get(entry.path);
+            if (prevSize !== undefined && prevSize !== entry.sizeBytes) {
+              nextNew.add(entry.path);
+            }
           }
         }
         if (nextNew.size > 0) newFilePaths.value = nextNew;
       }
       knownPaths = new Set(result.filter((e) => !e.isDirectory).map((e) => e.path));
+      knownSizes = new Map(result.filter((e) => !e.isDirectory).map((e) => [e.path, e.sizeBytes]));
       hasInitialLoad = true;
 
       files.value = result;
@@ -237,6 +249,7 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
       dbData.value = null;
       dbDataError.value = null;
       knownPaths = new Set();
+      knownSizes = new Map();
       newFilePaths.value = new Set();
       contentChangedAt.value = null;
       hasInitialLoad = false;

--- a/apps/desktop/src/composables/useSessionFiles.ts
+++ b/apps/desktop/src/composables/useSessionFiles.ts
@@ -14,8 +14,27 @@ export interface SessionFilesState {
   dbData: SessionDbTable[] | null;
   dbDataLoading: boolean;
   dbDataError: string | null;
+  /** Newly-seen file paths since the last reload — transient, cleared by `ackNewPaths()`. */
+  newFilePaths: Readonly<Set<string>>;
+  /**
+   * When a file is open in the viewer, tracks whether its content changed on the
+   * last silent refresh. Transient; cleared by `ackContentChanged()`.
+   */
+  contentChangedAt: number | null;
   selectFile: (path: string, fileType: SessionFileType) => Promise<void>;
-  reload: () => Promise<void>;
+  /**
+   * Reload files + (if a file is open) refetch its content in place.
+   *
+   * @param opts.silent When true (default for auto-refresh), skips toggling
+   *   `filesLoading`/`fileContentLoading`/`dbDataLoading` so the DOM stays
+   *   mounted and scroll position / focus are preserved. The file content
+   *   ref is only swapped if the new content differs from the current.
+   */
+  reload: (opts?: { silent?: boolean }) => Promise<void>;
+  /** Acknowledge the new-paths highlight so it fades on the next tick. */
+  ackNewPaths: () => void;
+  /** Acknowledge the content-changed highlight. */
+  ackContentChanged: () => void;
 }
 
 /**
@@ -38,22 +57,47 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
   const dbDataLoading = ref(false);
   const dbDataError = ref<string | null>(null);
 
+  // New-file highlight bookkeeping: set of paths that appeared on the most
+  // recent silent refresh. Cleared by the consumer after it has rendered the
+  // highlight (see `ackNewPaths`). This stays empty after the initial load so
+  // we don't flash every file green on first mount.
+  const newFilePaths = ref<Set<string>>(new Set());
+  const contentChangedAt = ref<number | null>(null);
+  let knownPaths: Set<string> = new Set();
+  let hasInitialLoad = false;
+
   // Monotonic counters used to discard results from superseded requests.
   let readSeq = 0;
   let loadSeq = 0;
 
-  async function loadFiles() {
+  async function loadFiles(opts: { silent?: boolean } = {}) {
     const sessionId = getSessionId();
     if (!sessionId) return;
 
+    const silent = opts.silent ?? false;
     const seq = ++loadSeq;
-    filesLoading.value = true;
+    // Silent refresh keeps the existing list mounted so scroll/focus survive.
+    if (!silent) filesLoading.value = true;
     filesError.value = null;
 
     try {
       const result = await sessionListFiles(sessionId);
       // Discard if session changed while we were awaiting
       if (seq !== loadSeq) return;
+
+      // Detect newly-appeared paths for the bonus highlight. Skip on the very
+      // first load so every file isn't flagged as "new".
+      if (hasInitialLoad) {
+        const nextNew = new Set<string>();
+        for (const entry of result) {
+          if (!entry.isDirectory && !knownPaths.has(entry.path)) {
+            nextNew.add(entry.path);
+          }
+        }
+        if (nextNew.size > 0) newFilePaths.value = nextNew;
+      }
+      knownPaths = new Set(result.filter((e) => !e.isDirectory).map((e) => e.path));
+      hasInitialLoad = true;
 
       files.value = result;
 
@@ -65,13 +109,60 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
         if (workspace) {
           await selectFile(workspace.path, workspace.fileType);
         }
+      } else if (silent) {
+        // Refetch the open file silently so agent-driven edits on disk show
+        // up without the user having to re-click the file.
+        const open = files.value.find((f) => f.path === selectedPath.value);
+        if (open && !open.isDirectory) {
+          void silentRefetchSelected(open.fileType);
+        }
       }
     } catch (err) {
       if (seq !== loadSeq) return;
       filesError.value = err instanceof Error ? err.message : String(err);
-      files.value = [];
+      if (!silent) files.value = [];
     } finally {
-      if (seq === loadSeq) filesLoading.value = false;
+      if (seq === loadSeq && !silent) filesLoading.value = false;
+    }
+  }
+
+  /**
+   * Re-read the currently-open file's content / SQLite tables in place.
+   * Does NOT toggle loading flags and only mutates the ref when content
+   * actually differs, so the viewer DOM stays stable and scroll is preserved.
+   */
+  async function silentRefetchSelected(fileType: SessionFileType) {
+    const sessionId = getSessionId();
+    const path = selectedPath.value;
+    if (!sessionId || !path) return;
+    if (fileType === "binary") return;
+
+    const seq = ++readSeq;
+    try {
+      if (fileType === "sqlite") {
+        const result = await sessionReadSqlite(sessionId, path);
+        if (seq !== readSeq) return;
+        // Replace wholesale — SqliteViewer reacts to the prop change.
+        dbData.value = result;
+        dbDataError.value = null;
+        return;
+      }
+      const result = await sessionReadFile(sessionId, path);
+      if (seq !== readSeq) return;
+      if (result !== fileContent.value) {
+        fileContent.value = result;
+        contentChangedAt.value = Date.now();
+      }
+      fileContentError.value = null;
+    } catch (err) {
+      if (seq !== readSeq) return;
+      // Silent refresh failures should not clobber existing content — only
+      // surface the error so the user sees a hint but keeps the stale view.
+      if (fileType === "sqlite") {
+        dbDataError.value = err instanceof Error ? err.message : String(err);
+      } else {
+        fileContentError.value = err instanceof Error ? err.message : String(err);
+      }
     }
   }
 
@@ -140,10 +231,22 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
       fileContentError.value = null;
       dbData.value = null;
       dbDataError.value = null;
+      knownPaths = new Set();
+      newFilePaths.value = new Set();
+      contentChangedAt.value = null;
+      hasInitialLoad = false;
       if (id) void loadFiles();
     },
     { immediate: true },
   );
+
+  function ackNewPaths() {
+    if (newFilePaths.value.size > 0) newFilePaths.value = new Set();
+  }
+
+  function ackContentChanged() {
+    contentChangedAt.value = null;
+  }
 
   return {
     get files() {
@@ -179,7 +282,15 @@ export function useSessionFiles(getSessionId: () => string | null | undefined): 
     get dbDataError() {
       return dbDataError.value;
     },
+    get newFilePaths() {
+      return newFilePaths.value;
+    },
+    get contentChangedAt() {
+      return contentChangedAt.value;
+    },
     selectFile,
-    reload: loadFiles,
+    reload: (opts) => loadFiles({ silent: true, ...(opts ?? {}) }),
+    ackNewPaths,
+    ackContentChanged,
   };
 }

--- a/apps/desktop/src/composables/useSessionSearch.ts
+++ b/apps/desktop/src/composables/useSessionSearch.ts
@@ -139,10 +139,9 @@ export function useSessionSearch(options: UseSessionSearchOptions) {
   // ── Content type tri-state toggle ─────────────────────────────
   // States: 'off' (not filtered) → 'include' → 'exclude' → 'off'
   function removeContentTypeFilter(ct: SearchContentType) {
-    const incIdx = store.contentTypes.indexOf(ct);
-    if (incIdx >= 0) store.contentTypes.splice(incIdx, 1);
-    const excIdx = store.excludeContentTypes.indexOf(ct);
-    if (excIdx >= 0) store.excludeContentTypes.splice(excIdx, 1);
+    // shallowRef: replace wholesale so the store's filter watcher fires.
+    store.contentTypes = store.contentTypes.filter((t) => t !== ct);
+    store.excludeContentTypes = store.excludeContentTypes.filter((t) => t !== ct);
   }
 
   // Active filter chips: collect all active include/exclude filters

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -216,8 +216,15 @@ export const useSessionsStore = defineStore("sessions", () => {
    * Throttled to at most once per MIN_INDEX_INTERVAL_MS to prevent redundant
    * reindexes when the user navigates back to the session list. The periodic
    * auto-refresh and explicit user-triggered reindex are unaffected.
+   *
+   * When `opts.force` is true (periodic auto-refresh path), the throttle is
+   * bypassed so new sessions that landed on disk show up without requiring
+   * a Ctrl+R or tab-away/back. When `opts.force` is false (navigation path)
+   * and the throttle skips the reindex, we still run a silent list refresh
+   * so a recently-indexed session that wasn't in memory yet appears.
    */
-  async function ensureIndex() {
+  async function ensureIndex(opts: { force?: boolean } = {}) {
+    const force = opts.force ?? false;
     const existingIndex = indexInflight.current();
     if (existingIndex) {
       try {
@@ -235,8 +242,14 @@ export const useSessionsStore = defineStore("sessions", () => {
       return;
     }
 
-    // Skip if we indexed recently — avoids 479ms reindexSessions on every re-navigation.
-    if (Date.now() - lastIndexedAt < MIN_INDEX_INTERVAL_MS) return;
+    // Skip reindex if we indexed recently — avoids 479ms reindexSessions on every
+    // re-navigation. Still refresh the list so new sessions indexed by another
+    // process (e.g. a running agent's own reindex) become visible without a manual
+    // Ctrl+R.
+    if (!force && Date.now() - lastIndexedAt < MIN_INDEX_INTERVAL_MS) {
+      await refreshSessions();
+      return;
+    }
 
     try {
       await indexInflight.run(() => reindexSessions());

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -25,13 +25,6 @@ export const useSessionsStore = defineStore("sessions", () => {
   let lastIndexedAt = 0;
   /** Minimum interval between ensureIndex calls (2 min). Explicit user-triggered reindex ignores this. */
   const MIN_INDEX_INTERVAL_MS = 2 * 60 * 1000;
-  /**
-   * Minimum interval for the force path (periodic auto-refresh).
-   * Without this, the 5s session-list auto-refresh would run a ~500ms
-   * reindex every 5s in perpetuity. 20s keeps new sessions visible quickly
-   * while cutting background CPU by 4x.
-   */
-  const MIN_INDEX_FORCE_INTERVAL_MS = 20 * 1000;
 
   // shallowRef: session list is always replaced wholesale (never index-mutated).
   const sessions = shallowRef<SessionListItem[]>([]);
@@ -225,10 +218,11 @@ export const useSessionsStore = defineStore("sessions", () => {
    * auto-refresh and explicit user-triggered reindex are unaffected.
    *
    * When `opts.force` is true (periodic auto-refresh path), the throttle is
-   * bypassed so new sessions that landed on disk show up without requiring
-   * a Ctrl+R or tab-away/back. When `opts.force` is false (navigation path)
-   * and the throttle skips the reindex, we still run a silent list refresh
-   * so a recently-indexed session that wasn't in memory yet appears.
+   * bypassed entirely so new sessions that land on disk show up on the
+   * next tick without requiring a Ctrl+R or tab-away/back. The reindex
+   * itself is incremental and cheap (~sub-second on typical session
+   * collections); coalescing is handled upstream via `indexInflight` so
+   * a genuinely concurrent reindex won't be duplicated.
    */
   async function ensureIndex(opts: { force?: boolean } = {}) {
     const force = opts.force ?? false;
@@ -249,13 +243,12 @@ export const useSessionsStore = defineStore("sessions", () => {
       return;
     }
 
-    // Skip reindex if we indexed recently. The navigation path uses a long
-    // throttle (MIN_INDEX_INTERVAL_MS); the force path (periodic auto-refresh)
-    // uses a shorter one so new on-disk sessions still appear quickly without
-    // paying the reindex cost every tick. Either way, still silently refresh
-    // the list so sessions indexed by another process become visible.
-    const throttleMs = force ? MIN_INDEX_FORCE_INTERVAL_MS : MIN_INDEX_INTERVAL_MS;
-    if (Date.now() - lastIndexedAt < throttleMs) {
+    // Navigation path: skip reindex if we indexed recently (2min). The
+    // force path (periodic auto-refresh) bypasses the throttle entirely so
+    // newly-created sessions on disk become visible on the next tick.
+    // Either way, still silently refresh the list so sessions indexed by
+    // another process become visible.
+    if (!force && Date.now() - lastIndexedAt < MIN_INDEX_INTERVAL_MS) {
       await refreshSessions();
       return;
     }

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -25,6 +25,13 @@ export const useSessionsStore = defineStore("sessions", () => {
   let lastIndexedAt = 0;
   /** Minimum interval between ensureIndex calls (2 min). Explicit user-triggered reindex ignores this. */
   const MIN_INDEX_INTERVAL_MS = 2 * 60 * 1000;
+  /**
+   * Minimum interval for the force path (periodic auto-refresh).
+   * Without this, the 5s session-list auto-refresh would run a ~500ms
+   * reindex every 5s in perpetuity. 20s keeps new sessions visible quickly
+   * while cutting background CPU by 4x.
+   */
+  const MIN_INDEX_FORCE_INTERVAL_MS = 20 * 1000;
 
   // shallowRef: session list is always replaced wholesale (never index-mutated).
   const sessions = shallowRef<SessionListItem[]>([]);
@@ -242,11 +249,13 @@ export const useSessionsStore = defineStore("sessions", () => {
       return;
     }
 
-    // Skip reindex if we indexed recently — avoids 479ms reindexSessions on every
-    // re-navigation. Still refresh the list so new sessions indexed by another
-    // process (e.g. a running agent's own reindex) become visible without a manual
-    // Ctrl+R.
-    if (!force && Date.now() - lastIndexedAt < MIN_INDEX_INTERVAL_MS) {
+    // Skip reindex if we indexed recently. The navigation path uses a long
+    // throttle (MIN_INDEX_INTERVAL_MS); the force path (periodic auto-refresh)
+    // uses a shorter one so new on-disk sessions still appear quickly without
+    // paying the reindex cost every tick. Either way, still silently refresh
+    // the list so sessions indexed by another process become visible.
+    const throttleMs = force ? MIN_INDEX_FORCE_INTERVAL_MS : MIN_INDEX_INTERVAL_MS;
+    if (Date.now() - lastIndexedAt < throttleMs) {
       await refreshSessions();
       return;
     }

--- a/apps/desktop/src/styles/features/session-search.css
+++ b/apps/desktop/src/styles/features/session-search.css
@@ -9,16 +9,16 @@
 }
 
 /* ÔöÇÔöÇ Search Hero ÔöÇÔöÇ */
-.search-hero {
+.search-view .search-hero {
   padding: 24px 0 0;
   flex-shrink: 0;
 }
 
-.search-hero-container {
+.search-view .search-hero-container {
   position: relative;
 }
 
-.search-hero-icon {
+.search-view .search-hero-icon {
   position: absolute;
   left: 16px;
   top: 50%;
@@ -29,7 +29,7 @@
   pointer-events: none;
 }
 
-.search-hero-input {
+.search-view .search-hero-input {
   width: 100%;
   padding: 14px 100px 14px 48px;
   background: var(--canvas-subtle);
@@ -42,17 +42,17 @@
   transition: all var(--transition-normal);
 }
 
-.search-hero-input::placeholder {
+.search-view .search-hero-input::placeholder {
   color: var(--text-placeholder);
 }
 
-.search-hero-input:focus {
+.search-view .search-hero-input:focus {
   border-color: var(--accent-emphasis);
   box-shadow: var(--shadow-glow-accent);
   background: var(--canvas-overlay);
 }
 
-.search-hero-kbd {
+.search-view .search-hero-kbd {
   position: absolute;
   right: 14px;
   top: 50%;
@@ -71,14 +71,14 @@
 }
 
 /* ÔöÇÔöÇ Search Hints ÔöÇÔöÇ */
-.search-hints {
+.search-view .search-hints {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 10px;
 }
 
-.search-hint {
+.search-view .search-hint {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -92,12 +92,12 @@
   transition: background var(--transition-fast);
 }
 
-.search-hint:hover {
+.search-view .search-hint:hover {
   background: var(--neutral-muted);
   color: var(--text-secondary);
 }
 
-.search-hint code {
+.search-view .search-hint code {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 0.625rem;
   color: var(--accent-fg);
@@ -106,20 +106,20 @@
   border-radius: 3px;
 }
 
-.syntax-help-btn {
+.search-view .syntax-help-btn {
   cursor: pointer;
   border: none;
   font-family: inherit;
   color: var(--accent-fg);
 }
 
-.syntax-help-btn:hover {
+.search-view .syntax-help-btn:hover {
   color: var(--accent-emphasis);
   background: var(--accent-subtle);
 }
 
 /* ÔöÇÔöÇ Controls Row ÔöÇÔöÇ */
-.search-controls {
+.search-view .search-controls {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -127,7 +127,7 @@
   flex-shrink: 0;
 }
 
-.filter-toggle-btn {
+.search-view .filter-toggle-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -143,28 +143,28 @@
   transition: all var(--transition-fast);
 }
 
-.filter-toggle-btn:hover {
+.search-view .filter-toggle-btn:hover {
   border-color: var(--border-accent);
   color: var(--text-primary);
 }
 
-.filter-toggle-btn.active {
+.search-view .filter-toggle-btn.active {
   background: var(--accent-subtle);
   border-color: var(--border-accent);
   color: var(--accent-fg);
 }
 
-.filter-toggle-btn:disabled {
+.search-view .filter-toggle-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.filter-toggle-btn svg {
+.search-view .filter-toggle-btn svg {
   width: 14px;
   height: 14px;
 }
 
-.filter-count-badge {
+.search-view .filter-count-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -178,7 +178,7 @@
   font-weight: 600;
 }
 
-.sort-select {
+.search-view .sort-select {
   appearance: none;
   background: var(--canvas-default);
   border: 1px solid var(--border-default);
@@ -195,17 +195,17 @@
   background-position: right 8px center;
 }
 
-.sort-select:hover {
+.search-view .sort-select:hover {
   border-color: var(--accent-emphasis);
 }
 
-.sort-select:focus {
+.search-view .sort-select:focus {
   border-color: var(--accent-emphasis);
   box-shadow: var(--shadow-glow-accent);
 }
 
 /* ÔöÇÔöÇ Page Layout ÔöÇÔöÇ */
-.search-page-layout {
+.search-view .search-page-layout {
   display: flex;
   gap: 0;
   flex: 1;
@@ -214,7 +214,7 @@
   margin-top: 16px;
 }
 
-.search-main {
+.search-view .search-main {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -222,14 +222,14 @@
   overflow: hidden;
 }
 
-.search-main-scroll {
+.search-view .search-main-scroll {
   flex: 1;
   overflow-y: auto;
   padding: 0 16px 28px;
 }
 
 /* ÔöÇÔöÇ Error ÔöÇÔöÇ */
-.search-error {
+.search-view .search-error {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -242,12 +242,12 @@
   margin-bottom: 12px;
 }
 
-.search-error svg {
+.search-view .search-error svg {
   flex-shrink: 0;
 }
 
 /* ÔöÇÔöÇ Results Summary ÔöÇÔöÇ */
-.results-summary {
+.search-view .results-summary {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -264,22 +264,22 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
-.results-summary-text {
+.search-view .results-summary-text {
   font-size: 0.8125rem;
   color: var(--text-secondary);
 }
 
-.results-summary-text strong {
+.search-view .results-summary-text strong {
   color: var(--text-primary);
   font-weight: 600;
 }
 
-.summary-speed {
+.search-view .summary-speed {
   color: var(--success-fg);
 }
 
 /* ── First-run state (no sessions indexed) ── */
-.first-run-state {
+.search-view .first-run-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -289,21 +289,21 @@
   text-align: center;
 }
 
-.first-run-icon {
+.search-view .first-run-icon {
   width: 48px;
   height: 48px;
   margin-bottom: 16px;
   opacity: 0.35;
 }
 
-.first-run-title {
+.search-view .first-run-title {
   font-size: 0.9375rem;
   font-weight: 500;
   color: var(--text-secondary);
   margin-bottom: 6px;
 }
 
-.first-run-subtitle {
+.search-view .first-run-subtitle {
   font-size: 0.8125rem;
   color: var(--text-tertiary);
   max-width: 380px;
@@ -311,7 +311,7 @@
   line-height: 1.5;
 }
 
-.first-run-rebuild-btn {
+.search-view .first-run-rebuild-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -326,16 +326,16 @@
   transition: background 0.15s ease;
 }
 
-.first-run-rebuild-btn:hover {
+.search-view .first-run-rebuild-btn:hover {
   background: var(--accent-fg);
 }
 
-.first-run-rebuild-btn svg {
+.search-view .first-run-rebuild-btn svg {
   opacity: 0.8;
 }
 
 /* ÔöÇÔöÇ Empty State ÔöÇÔöÇ */
-.search-empty-state {
+.search-view .search-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -345,27 +345,27 @@
   text-align: center;
 }
 
-.search-empty-icon {
+.search-view .search-empty-icon {
   width: 48px;
   height: 48px;
   margin-bottom: 16px;
   opacity: 0.35;
 }
 
-.empty-title {
+.search-view .empty-title {
   font-size: 0.9375rem;
   font-weight: 500;
   color: var(--text-secondary);
   margin-bottom: 6px;
 }
 
-.empty-subtitle {
+.search-view .empty-subtitle {
   font-size: 0.8125rem;
   color: var(--text-tertiary);
   max-width: 380px;
 }
 
-.empty-stats {
+.search-view .empty-stats {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -374,15 +374,15 @@
   color: var(--text-tertiary);
 }
 
-.empty-stat strong {
+.search-view .empty-stat strong {
   color: var(--accent-fg);
 }
 
-.empty-stat-sep {
+.search-view .empty-stat-sep {
   opacity: 0.3;
 }
 
-.clear-search-btn {
+.search-view .clear-search-btn {
   margin-top: 16px;
   padding: 8px 16px;
   border-radius: var(--radius-md);
@@ -396,18 +396,18 @@
   transition: all var(--transition-fast);
 }
 
-.clear-search-btn:hover {
+.search-view .clear-search-btn:hover {
   background: var(--accent-muted);
 }
 
 /* ÔöÇÔöÇ Result Cards ÔöÇÔöÇ */
-.results-list {
+.search-view .results-list {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.result-card {
+.search-view .result-card {
   background: var(--canvas-subtle);
   background-image: var(--gradient-card);
   border: 1px solid var(--border-default);
@@ -418,14 +418,14 @@
   animation: fadeSlideIn 0.25s ease both;
 }
 
-.result-card:hover {
+.search-view .result-card:hover {
   border-color: var(--border-accent);
   box-shadow:
     var(--shadow-md),
     0 0 0 1px var(--border-glow);
 }
 
-.result-header {
+.search-view .result-header {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -433,12 +433,12 @@
   margin-bottom: 10px;
 }
 
-.result-date {
+.search-view .result-date {
   font-size: 0.6875rem;
   color: var(--text-tertiary);
 }
 
-.ct-badge {
+.search-view .ct-badge {
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -449,7 +449,7 @@
   white-space: nowrap;
 }
 
-.result-snippet {
+.search-view .result-snippet {
   font-size: 0.8125rem;
   line-height: 1.65;
   color: var(--text-secondary);
@@ -460,14 +460,14 @@
   -webkit-box-orient: vertical;
 }
 
-.result-snippet mark {
+.search-view .result-snippet mark {
   background: rgba(251, 191, 36, 0.22);
   color: var(--warning-fg);
   border-radius: 2px;
   padding: 0 2px;
 }
 
-.result-snippet code {
+.search-view .result-snippet code {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 0.75rem;
   background: var(--neutral-subtle);
@@ -475,7 +475,7 @@
   border-radius: 3px;
 }
 
-.result-meta {
+.search-view .result-meta {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -484,11 +484,11 @@
   color: var(--text-tertiary);
 }
 
-.result-meta-sep {
+.search-view .result-meta-sep {
   opacity: 0.3;
 }
 
-.tool-name-badge {
+.search-view .tool-name-badge {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 0.625rem;
   background: var(--neutral-subtle);
@@ -497,7 +497,7 @@
   color: var(--text-secondary);
 }
 
-.result-view-btn {
+.search-view .result-view-btn {
   margin-left: auto;
   color: var(--accent-fg);
   text-decoration: none;
@@ -515,13 +515,13 @@
   flex-shrink: 0;
 }
 
-.result-view-btn:hover {
+.search-view .result-view-btn:hover {
   background: var(--accent-emphasis);
   color: var(--text-on-emphasis, #fff);
 }
 
 /* ÔöÇÔöÇ Pagination ÔöÇÔöÇ */
-.pagination {
+.search-view .pagination {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -530,7 +530,7 @@
   flex-wrap: wrap;
 }
 
-.pagination-btn {
+.search-view .pagination-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -548,23 +548,23 @@
   transition: all var(--transition-fast);
 }
 
-.pagination-btn:hover:not(:disabled) {
+.search-view .pagination-btn:hover:not(:disabled) {
   border-color: var(--border-accent);
   color: var(--text-primary);
 }
 
-.pagination-btn.active {
+.search-view .pagination-btn.active {
   background: var(--accent-emphasis);
   border-color: var(--accent-emphasis);
   color: white;
 }
 
-.pagination-btn:disabled {
+.search-view .pagination-btn:disabled {
   opacity: 0.35;
   cursor: not-allowed;
 }
 
-.pagination-ellipsis {
+.search-view .pagination-ellipsis {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -574,25 +574,25 @@
   color: var(--text-tertiary);
 }
 
-.pagination-info {
+.search-view .pagination-info {
   font-size: 0.75rem;
   color: var(--text-tertiary);
   margin-left: 12px;
 }
 
 /* ÔöÇÔöÇ Skeleton Loading ÔöÇÔöÇ */
-.skeleton-card {
+.search-view .skeleton-card {
   pointer-events: none;
 }
 
-.skeleton-header {
+.search-view .skeleton-header {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
 }
 
-.skeleton {
+.search-view .skeleton {
   background: linear-gradient(
     90deg,
     var(--neutral-subtle) 25%,
@@ -604,27 +604,27 @@
   border-radius: var(--radius-sm);
 }
 
-.skeleton-badge {
+.search-view .skeleton-badge {
   width: 100px;
   height: 20px;
 }
 
-.skeleton-badge-sm {
+.search-view .skeleton-badge-sm {
   width: 64px;
   height: 20px;
 }
 
-.skeleton-text {
+.search-view .skeleton-text {
   height: 14px;
   margin-bottom: 8px;
   width: 100%;
 }
 
-.skeleton-text.short {
+.search-view .skeleton-text.short {
   width: 65%;
 }
 
-.skeleton-meta {
+.search-view .skeleton-meta {
   display: flex;
   gap: 8px;
   margin-top: 4px;
@@ -651,12 +651,12 @@
   }
 }
 
-.spin-icon {
+.search-view .spin-icon {
   animation: spin 0.8s linear infinite;
 }
 
 /* ÔöÇÔöÇ Indexing Progress Banner ÔöÇÔöÇ */
-.indexing-banner {
+.search-view .indexing-banner {
   margin: 0 0 12px 0;
   padding: 12px 16px;
   background: var(--surface-secondary);
@@ -665,26 +665,26 @@
   animation: fadeSlideIn 0.3s ease both;
 }
 
-.indexing-banner-content {
+.search-view .indexing-banner-content {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.indexing-banner-icon {
+.search-view .indexing-banner-icon {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
   color: var(--accent-fg);
 }
 
-.indexing-banner-text {
+.search-view .indexing-banner-text {
   font-size: 0.8125rem;
   color: var(--text-secondary);
   white-space: nowrap;
 }
 
-.indexing-banner-bar-container {
+.search-view .indexing-banner-bar-container {
   flex: 1;
   min-width: 80px;
   height: 4px;
@@ -693,7 +693,7 @@
   overflow: hidden;
 }
 
-.indexing-banner-bar {
+.search-view .indexing-banner-bar {
   height: 100%;
   background: var(--accent-fg);
   border-radius: 2px;
@@ -701,27 +701,27 @@
 }
 
 /* ÔöÇÔöÇ Expanded Result Details ÔöÇÔöÇ */
-.result-expanded {
+.search-view .result-expanded {
   margin-top: 12px;
   padding-top: 12px;
   border-top: 1px solid var(--border-default);
   animation: fadeSlideIn 0.2s ease both;
 }
 
-.expanded-grid {
+.search-view .expanded-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px 16px;
   margin-bottom: 12px;
 }
 
-.expanded-item {
+.search-view .expanded-item {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.expanded-label {
+.search-view .expanded-label {
   font-size: 0.625rem;
   font-weight: 600;
   color: var(--text-tertiary);
@@ -729,7 +729,7 @@
   letter-spacing: 0.04em;
 }
 
-.expanded-value {
+.search-view .expanded-value {
   font-size: 0.75rem;
   color: var(--text-secondary);
   overflow: hidden;
@@ -737,12 +737,12 @@
   white-space: nowrap;
 }
 
-.expanded-mono {
+.search-view .expanded-mono {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 0.6875rem;
 }
 
-.expanded-view-btn {
+.search-view .expanded-view-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -758,17 +758,17 @@
   transition: all var(--transition-fast);
 }
 
-.expanded-view-btn:hover {
+.search-view .expanded-view-btn:hover {
   background: var(--accent-muted);
 }
 
-.result-card.expanded .result-snippet {
+.search-view .result-card.expanded .result-snippet {
   -webkit-line-clamp: unset;
   display: block;
 }
 
 /* ÔöÇÔöÇ Facets Sidebar (right) ÔöÇÔöÇ */
-.facets-sidebar {
+.search-view .facets-sidebar {
   width: 240px;
   min-width: 240px;
   background: var(--canvas-subtle);
@@ -781,13 +781,13 @@
   gap: 20px;
 }
 
-.facet-section {
+.search-view .facet-section {
   display: flex;
   flex-direction: column;
   gap: 0;
 }
 
-.facet-title {
+.search-view .facet-title {
   font-size: 0.6875rem;
   font-weight: 600;
   color: var(--text-tertiary);
@@ -796,13 +796,13 @@
   margin-bottom: 10px;
 }
 
-.facet-list {
+.search-view .facet-list {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.facet-row {
+.search-view .facet-row {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -814,27 +814,27 @@
   transition: background var(--transition-fast);
 }
 
-.facet-row:hover {
+.search-view .facet-row:hover {
   background: var(--neutral-subtle);
 }
 
-.facet-row-active {
+.search-view .facet-row-active {
   background: var(--neutral-subtle);
 }
 
-.facet-row-active .facet-label {
+.search-view .facet-row-active .facet-label {
   color: var(--text-primary);
   font-weight: 600;
 }
 
-.facet-empty {
+.search-view .facet-empty {
   font-size: 0.6875rem;
   color: var(--text-tertiary);
   padding: 4px 6px;
   font-style: italic;
 }
 
-.facet-bar {
+.search-view .facet-bar {
   position: absolute;
   left: 0;
   top: 0;
@@ -845,7 +845,7 @@
   transition: width var(--transition-normal);
 }
 
-.facet-dot {
+.search-view .facet-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -853,7 +853,7 @@
 }
 
 /* biome-ignore lint/style/noDescendingSpecificity: base .facet-label styles follow the dotted-indicator rule intentionally for readability of grouped facet rules. */
-.facet-label {
+.search-view .facet-label {
   flex: 1;
   font-size: 0.6875rem;
   color: var(--text-secondary);
@@ -865,12 +865,12 @@
   z-index: 1;
 }
 
-.facet-label-mono {
+.search-view .facet-label-mono {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 0.625rem;
 }
 
-.facet-count {
+.search-view .facet-count {
   font-size: 0.625rem;
   font-weight: 600;
   color: var(--text-tertiary);
@@ -882,14 +882,14 @@
 
 /* ÔöÇÔöÇ Responsive ÔöÇÔöÇ */
 @media (max-width: 1100px) {
-  .facets-sidebar {
+  .search-view .facets-sidebar {
     display: none;
   }
 }
 
 /* ÔöÇÔöÇ Responsive ÔöÇÔöÇ */
 @media (max-width: 900px) {
-  .search-hero {
+  .search-view .search-hero {
     padding: 16px 0 0;
   }
 }
@@ -899,7 +899,7 @@
 /* -- Filter facet count badges (moved to SearchFilterSidebar) -- */
 
 /* -- Session summary in meta (moved to SearchResultCard) -- */
-.result-session-summary {
+.search-view .result-session-summary {
   font-weight: 500;
   color: var(--text-secondary);
   overflow: hidden;
@@ -911,7 +911,7 @@
 /* -- Tri-state filter, filter sidebar, filter clear moved to SearchFilterSidebar -- */
 
 /* -- Active filter chips bar -- */
-.active-filters-bar {
+.search-view .active-filters-bar {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -919,21 +919,21 @@
   flex-shrink: 0;
 }
 
-.active-filters-label {
+.search-view .active-filters-label {
   font-size: 0.6875rem;
   color: var(--text-tertiary);
   flex-shrink: 0;
   white-space: nowrap;
 }
 
-.active-filter-chips {
+.search-view .active-filter-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
 }
 
-.filter-chip {
+.search-view .filter-chip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -945,39 +945,39 @@
   transition: all var(--transition-fast);
 }
 
-.filter-chip-include {
+.search-view .filter-chip-include {
   background: var(--accent-subtle);
   color: var(--accent-fg);
   border: 1px solid var(--accent-emphasis);
 }
 
-.filter-chip-exclude {
+.search-view .filter-chip-exclude {
   background: var(--danger-subtle);
   color: var(--danger-fg);
   border: 1px solid var(--danger-fg);
 }
 
-.filter-chip-neutral {
+.search-view .filter-chip-neutral {
   background: var(--neutral-subtle);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
 }
 
-.filter-chip-dot {
+.search-view .filter-chip-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.filter-chip-prefix {
+.search-view .filter-chip-prefix {
   font-weight: 700;
   font-size: 0.5625rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
-.filter-chip-remove {
+.search-view .filter-chip-remove {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -997,12 +997,12 @@
     background var(--transition-fast);
 }
 
-.filter-chip-remove:hover {
+.search-view .filter-chip-remove:hover {
   opacity: 1;
   background: var(--state-hover-overlay);
 }
 
-.filter-chip-clear-all {
+.search-view .filter-chip-clear-all {
   font-size: 0.6875rem;
   color: var(--text-tertiary);
   background: none;
@@ -1014,12 +1014,12 @@
   transition: color var(--transition-fast);
 }
 
-.filter-chip-clear-all:hover {
+.search-view .filter-chip-clear-all:hover {
   color: var(--accent-fg);
 }
 
 /* -- View mode toggle -- */
-.view-mode-toggle {
+.search-view .view-mode-toggle {
   display: flex;
   align-items: center;
   gap: 2px;
@@ -1030,7 +1030,7 @@
   border: 1px solid var(--border-default);
 }
 
-.view-mode-btn {
+.search-view .view-mode-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1044,24 +1044,24 @@
   transition: all var(--transition-fast);
 }
 
-.view-mode-btn:hover {
+.search-view .view-mode-btn:hover {
   color: var(--text-primary);
 }
 
-.view-mode-btn.active {
+.search-view .view-mode-btn.active {
   background: var(--canvas-default);
   color: var(--accent-fg);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 /* ── Keyboard focus indicator ────────────────────────────── */
-.result-focused {
+.search-view .result-focused {
   outline: 2px solid var(--accent-fg);
   outline-offset: -2px;
 }
 
 /* ── Copy button ─────────────────────────────────────────── */
-.result-copy-btn {
+.search-view .result-copy-btn {
   display: inline-flex;
   align-items: center;
   gap: 2px;
@@ -1075,14 +1075,14 @@
   transition: all var(--transition-fast);
   flex-shrink: 0;
 }
-.result-copy-btn:hover {
+.search-view .result-copy-btn:hover {
   color: var(--accent-fg);
   background: var(--accent-subtle);
   border-color: var(--accent-fg);
 }
 
 /* ── Keyboard hints ──────────────────────────────────────── */
-.keyboard-hints {
+.search-view .keyboard-hints {
   position: fixed;
   bottom: 16px;
   right: 24px;
@@ -1099,7 +1099,7 @@
   border: 1px solid var(--border-muted);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
-.keyboard-hints kbd {
+.search-view .keyboard-hints kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1119,7 +1119,7 @@
 /* ── Preset colors, syntax help, modal, first-run moved to child components ── */
 
 /* ── Health status bar ──────────────────────────────────────── */
-.search-health-bar {
+.search-view .search-health-bar {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1130,31 +1130,31 @@
   margin-top: 4px;
 }
 
-.health-separator {
+.search-view .health-separator {
   color: var(--border-muted);
 }
 
-.health-stat {
+.search-view .health-stat {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   white-space: nowrap;
 }
 
-.health-dot {
+.search-view .health-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
 }
 
-.health-dot.synced {
+.search-view .health-dot.synced {
   background: var(--success-fg, #3fb950);
 }
 
-.health-dot.pending {
+.search-view .health-dot.pending {
   background: var(--attention-fg, #d29922);
 }
 
-.health-pending {
+.search-view .health-pending {
   color: var(--attention-fg, #d29922);
 }

--- a/apps/desktop/src/styles/features/skill-editor.css
+++ b/apps/desktop/src/styles/features/skill-editor.css
@@ -14,10 +14,18 @@
    ═══════════════════════════════════════════════════════════ */
 
 /* ── Shell ──────────────────────────────────────────────── */
+.skill-editor-feature {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
 .skill-editor-feature .editor-shell {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  flex: 1 1 auto;
+  min-height: 0;
   background: var(--canvas-default);
   color: var(--text-primary);
   overflow: hidden;

--- a/apps/desktop/src/styles/features/waterfall.css
+++ b/apps/desktop/src/styles/features/waterfall.css
@@ -365,7 +365,7 @@
 }
 
 /* ── Pinned detail panel (positioned via ToolDetailPanel component) ── */
-.detail-panel {
+.waterfall-root .detail-panel {
   margin-top: 8px;
 }
 

--- a/apps/desktop/src/styles/features/worktree-manager.css
+++ b/apps/desktop/src/styles/features/worktree-manager.css
@@ -650,7 +650,7 @@
 }
 
 /* ─── Detail Panel ────────────────────────────────────────────── */
-.detail-panel {
+.wt-detail-panel {
   border-top: 1px solid var(--border-default);
   background: var(--canvas-subtle);
   max-height: 0;
@@ -659,7 +659,7 @@
   flex-shrink: 0;
 }
 
-.detail-panel--open {
+.wt-detail-panel--open {
   max-height: 500px;
 }
 

--- a/apps/desktop/src/views/SessionListView.vue
+++ b/apps/desktop/src/views/SessionListView.vue
@@ -33,7 +33,9 @@ const detailStore = useSessionDetailStore();
 const prefs = usePreferencesStore();
 const tabStore = useSessionTabsStore();
 const { refreshing, refresh } = useAutoRefresh({
-  onRefresh: () => store.ensureIndex(),
+  // Auto-refresh bypasses the ensureIndex throttle so new sessions that land
+  // on disk between navigations are picked up without requiring Ctrl+R.
+  onRefresh: () => store.ensureIndex({ force: true }),
   enabled: computed(() => prefs.autoRefreshEnabled),
   intervalSeconds: computed(() => prefs.autoRefreshIntervalSeconds),
 });

--- a/apps/desktop/src/views/tabs/ExplorerTab.vue
+++ b/apps/desktop/src/views/tabs/ExplorerTab.vue
@@ -80,7 +80,18 @@ watch(
     }, NEW_PATH_FADE_MS);
   },
 );
-const highlightedPaths = computed(() => sessionFiles.newFilePaths);
+const highlightedPaths = computed(() => {
+  // Union: newly-appeared files + the selected file when its content was just
+  // updated on disk (so the tree entry also flashes alongside the viewer
+  // border — a single cohesive "something updated" cue).
+  const base = sessionFiles.newFilePaths;
+  const selected = sessionFiles.selectedPath;
+  if (!viewerChanged.value || !selected) return base;
+  if (base.has(selected)) return base;
+  const union = new Set<string>(base);
+  union.add(selected);
+  return union;
+});
 
 // Clear content-changed highlight shortly after it flips so the viewer pulse fades.
 const CONTENT_FADE_MS = 1100;
@@ -190,21 +201,21 @@ onBeforeUnmount(() => {
 }
 
 /* Bonus: briefly highlight the viewer when the currently-open file's
-   content was updated on disk by an auto-refresh. Pure outline pulse — no
-   layout shift. Uses the accent colour (softer than success-green) to
-   feel like a premium "something updated" cue rather than a status flag. */
+   content was updated on disk by an auto-refresh. Pure inset ring — no
+   layout shift. Uses the success colour so the cue reads as "new content
+   landed" rather than "this is selected" (which already uses the accent). */
 .explorer-tab__viewer--changed::after {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
-  box-shadow: inset 0 0 0 2px var(--accent-fg);
+  box-shadow: inset 0 0 0 2px var(--success-fg);
   opacity: 0;
   animation: explorer-viewer-pulse 1.1s cubic-bezier(0.16, 1, 0.3, 1);
 }
 @keyframes explorer-viewer-pulse {
-  0%   { opacity: 0.32; }
-  55%  { opacity: 0.12; }
+  0%   { opacity: 0.7; }
+  55%  { opacity: 0.3; }
   100% { opacity: 0; }
 }
 </style>

--- a/apps/desktop/src/views/tabs/ExplorerTab.vue
+++ b/apps/desktop/src/views/tabs/ExplorerTab.vue
@@ -64,8 +64,8 @@ useAutoRefresh({
 });
 
 // ── New-file highlight (bonus) ─────────────────────────────────────────────
-// Clear the transient highlight set after ~1.6s so the CSS fade can play.
-const NEW_PATH_FADE_MS = 1600;
+// Clear the transient highlight set after the fade so the animation can play.
+const NEW_PATH_FADE_MS = 1100;
 let newPathTimer: ReturnType<typeof setTimeout> | null = null;
 let viewerPulseTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -83,7 +83,7 @@ watch(
 const highlightedPaths = computed(() => sessionFiles.newFilePaths);
 
 // Clear content-changed highlight shortly after it flips so the viewer pulse fades.
-const CONTENT_FADE_MS = 1600;
+const CONTENT_FADE_MS = 1100;
 watch(
   () => sessionFiles.contentChangedAt,
   (ts) => {
@@ -191,19 +191,20 @@ onBeforeUnmount(() => {
 
 /* Bonus: briefly highlight the viewer when the currently-open file's
    content was updated on disk by an auto-refresh. Pure outline pulse — no
-   layout shift. */
+   layout shift. Uses the accent colour (softer than success-green) to
+   feel like a premium "something updated" cue rather than a status flag. */
 .explorer-tab__viewer--changed::after {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
-  box-shadow: inset 0 0 0 2px var(--success-fg);
+  box-shadow: inset 0 0 0 2px var(--accent-fg);
   opacity: 0;
-  animation: explorer-viewer-pulse 1.6s ease-out;
+  animation: explorer-viewer-pulse 1.1s cubic-bezier(0.16, 1, 0.3, 1);
 }
 @keyframes explorer-viewer-pulse {
-  0%   { opacity: 0.45; }
-  60%  { opacity: 0.18; }
+  0%   { opacity: 0.32; }
+  55%  { opacity: 0.12; }
   100% { opacity: 0; }
 }
 </style>

--- a/apps/desktop/src/views/tabs/ExplorerTab.vue
+++ b/apps/desktop/src/views/tabs/ExplorerTab.vue
@@ -2,7 +2,7 @@
 import "@/styles/features/session-explorer.css";
 import type { SessionFileType } from "@tracepilot/types";
 import { FileBrowserTree, FileContentViewer, useAutoRefresh } from "@tracepilot/ui";
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { useSessionDetailContext } from "@/composables/useSessionDetailContext";
 import { useSessionFiles } from "@/composables/useSessionFiles";
 import { usePreferencesStore } from "@/stores/preferences";
@@ -55,10 +55,51 @@ onBeforeUnmount(() => {
 });
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
+// Silent refresh: the composable defaults `reload()` to silent=true so the
+// file list / viewer DOM stays mounted and scroll position survives.
 useAutoRefresh({
   onRefresh: () => sessionFiles.reload(),
   enabled: computed(() => prefs.autoRefreshEnabled),
   intervalSeconds: computed(() => prefs.autoRefreshIntervalSeconds),
+});
+
+// ── New-file highlight (bonus) ─────────────────────────────────────────────
+// Clear the transient highlight set after ~1.6s so the CSS fade can play.
+const NEW_PATH_FADE_MS = 1600;
+let newPathTimer: ReturnType<typeof setTimeout> | null = null;
+let viewerPulseTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => sessionFiles.newFilePaths,
+  (set) => {
+    if (set.size === 0) return;
+    if (newPathTimer) clearTimeout(newPathTimer);
+    newPathTimer = setTimeout(() => {
+      sessionFiles.ackNewPaths();
+      newPathTimer = null;
+    }, NEW_PATH_FADE_MS);
+  },
+);
+const highlightedPaths = computed(() => sessionFiles.newFilePaths);
+
+// Clear content-changed highlight shortly after it flips so the viewer pulse fades.
+const CONTENT_FADE_MS = 1600;
+watch(
+  () => sessionFiles.contentChangedAt,
+  (ts) => {
+    if (!ts) return;
+    if (viewerPulseTimer) clearTimeout(viewerPulseTimer);
+    viewerPulseTimer = setTimeout(() => {
+      sessionFiles.ackContentChanged();
+      viewerPulseTimer = null;
+    }, CONTENT_FADE_MS);
+  },
+);
+const viewerChanged = computed(() => sessionFiles.contentChangedAt !== null);
+
+onBeforeUnmount(() => {
+  if (newPathTimer) clearTimeout(newPathTimer);
+  if (viewerPulseTimer) clearTimeout(viewerPulseTimer);
 });
 </script>
 
@@ -69,6 +110,7 @@ useAutoRefresh({
         :entries="sessionFiles.files"
         :loading="sessionFiles.filesLoading"
         :selected-path="sessionFiles.selectedPath ?? undefined"
+        :highlighted-paths="highlightedPaths"
         title="Session Files"
         :auto-collapse-threshold="10"
         @view-file="onViewFile"
@@ -82,7 +124,7 @@ useAutoRefresh({
       @mousedown.prevent="startDrag"
     />
 
-    <div class="explorer-tab__viewer">
+    <div class="explorer-tab__viewer" :class="{ 'explorer-tab__viewer--changed': viewerChanged }">
       <FileContentViewer
         :file-path="sessionFiles.selectedPath ?? undefined"
         :content="sessionFiles.fileContent ?? undefined"
@@ -144,5 +186,24 @@ useAutoRefresh({
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+/* Bonus: briefly highlight the viewer when the currently-open file's
+   content was updated on disk by an auto-refresh. Pure outline pulse — no
+   layout shift. */
+.explorer-tab__viewer--changed::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 2px var(--success-fg);
+  opacity: 0;
+  animation: explorer-viewer-pulse 1.6s ease-out;
+}
+@keyframes explorer-viewer-pulse {
+  0%   { opacity: 0.45; }
+  60%  { opacity: 0.18; }
+  100% { opacity: 0; }
 }
 </style>

--- a/apps/desktop/src/views/tabs/ExplorerTab.vue
+++ b/apps/desktop/src/views/tabs/ExplorerTab.vue
@@ -64,8 +64,10 @@ useAutoRefresh({
 });
 
 // ── New-file highlight (bonus) ─────────────────────────────────────────────
-// Clear the transient highlight set after the fade so the animation can play.
-const NEW_PATH_FADE_MS = 1100;
+// Clear the transient highlight set AFTER the fade has fully completed so
+// the class removal can't interrupt the animation mid-frame. Matches the
+// 1.1s keyframes in FileBrowserTree.vue (+ small safety buffer).
+const NEW_PATH_FADE_MS = 1200;
 let newPathTimer: ReturnType<typeof setTimeout> | null = null;
 let viewerPulseTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/crates/tracepilot-core/src/parsing/session_db.rs
+++ b/crates/tracepilot-core/src/parsing/session_db.rs
@@ -39,6 +39,35 @@ pub struct CustomTableInfo {
     pub name: String,
     pub columns: Vec<String>,
     pub rows: Vec<Vec<serde_json::Value>>,
+    /// Column schema (names, types, PK, nullability, defaults) from `PRAGMA table_info`.
+    pub column_info: Vec<ColumnSchema>,
+    /// Index metadata from `PRAGMA index_list` + `PRAGMA index_info`.
+    pub indexes: Vec<IndexSchema>,
+}
+
+/// A single column's schema metadata, sourced from `PRAGMA table_info`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnSchema {
+    pub name: String,
+    /// Declared type (may be empty for typeless columns).
+    pub type_name: String,
+    /// True when `NOT NULL` was declared.
+    pub notnull: bool,
+    /// Primary-key position (0 if not a PK column; 1-based otherwise for composite PKs).
+    pub pk: i64,
+    /// Declared default expression, if any.
+    pub default_value: Option<String>,
+}
+
+/// Index metadata from `PRAGMA index_list` + `PRAGMA index_info`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexSchema {
+    pub name: String,
+    pub unique: bool,
+    /// Column names the index covers, in index order.
+    pub columns: Vec<String>,
 }
 
 /// Read all todo items from a session database (opened read-only).
@@ -125,6 +154,8 @@ pub fn read_custom_table(db_path: &Path, table_name: &str) -> Result<CustomTable
             name: table_name.to_string(),
             columns: Vec::new(),
             rows: Vec::new(),
+            column_info: Vec::new(),
+            indexes: Vec::new(),
         });
     };
 
@@ -133,15 +164,53 @@ pub fn read_custom_table(db_path: &Path, table_name: &str) -> Result<CustomTable
             name: table_name.to_string(),
             columns: Vec::new(),
             rows: Vec::new(),
+            column_info: Vec::new(),
+            indexes: Vec::new(),
         });
     }
 
     // Discover columns via PRAGMA — escape table name for safe SQL interpolation
     let safe_name = table_name.replace('"', "\"\"");
     let mut pragma_stmt = conn.prepare(&format!("PRAGMA table_info(\"{}\")", safe_name))?;
-    let columns: Vec<String> = pragma_stmt
-        .query_map([], |row| row.get::<_, String>(1))?
+    // PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+    let column_info: Vec<ColumnSchema> = pragma_stmt
+        .query_map([], |row| {
+            Ok(ColumnSchema {
+                name: row.get::<_, String>(1)?,
+                type_name: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                notnull: row.get::<_, i64>(3)? != 0,
+                default_value: row.get::<_, Option<String>>(4)?,
+                pk: row.get::<_, i64>(5)?,
+            })
+        })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
+    let columns: Vec<String> = column_info.iter().map(|c| c.name.clone()).collect();
+
+    // Discover indexes via PRAGMA index_list + PRAGMA index_info.
+    let mut indexes: Vec<IndexSchema> = Vec::new();
+    {
+        let mut idx_list_stmt = conn.prepare(&format!("PRAGMA index_list(\"{}\")", safe_name))?;
+        // index_list columns: seq, name, unique, origin, partial
+        let idx_rows: Vec<(String, bool)> = idx_list_stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(1)?, row.get::<_, i64>(2)? != 0))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        for (idx_name, unique) in idx_rows {
+            let safe_idx = idx_name.replace('"', "\"\"");
+            let mut info_stmt = conn.prepare(&format!("PRAGMA index_info(\"{}\")", safe_idx))?;
+            // index_info columns: seqno, cid, name
+            let cols: Vec<String> = info_stmt
+                .query_map([], |row| row.get::<_, Option<String>>(2))?
+                .filter_map(|r| r.ok().flatten())
+                .collect();
+            indexes.push(IndexSchema {
+                name: idx_name,
+                unique,
+                columns: cols,
+            });
+        }
+    }
 
     // Read all rows — build each row as an ordered Vec aligned to `columns`.
     let mut select_stmt = conn.prepare(&format!("SELECT * FROM \"{}\"", safe_name))?;
@@ -159,6 +228,8 @@ pub fn read_custom_table(db_path: &Path, table_name: &str) -> Result<CustomTable
         name: table_name.to_string(),
         columns,
         rows,
+        column_info,
+        indexes,
     })
 }
 
@@ -284,6 +355,51 @@ mod tests {
         let info = read_custom_table(&db_path, "nonexistent").unwrap();
         assert!(info.columns.is_empty());
         assert!(info.rows.is_empty());
+    }
+
+    #[test]
+    fn test_read_custom_table_includes_schema_and_indexes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("schema.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE items (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                qty REAL DEFAULT 1.0
+            );
+            CREATE UNIQUE INDEX idx_items_name ON items(name);
+            CREATE INDEX idx_items_qty ON items(qty);
+            ",
+        )
+        .unwrap();
+        drop(conn);
+
+        let info = read_custom_table(&db_path, "items").unwrap();
+        assert_eq!(info.column_info.len(), 3);
+        let id_col = info.column_info.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id_col.pk, 1);
+        assert_eq!(id_col.type_name, "INTEGER");
+        let name_col = info.column_info.iter().find(|c| c.name == "name").unwrap();
+        assert!(name_col.notnull);
+        assert_eq!(name_col.pk, 0);
+        let qty_col = info.column_info.iter().find(|c| c.name == "qty").unwrap();
+        assert_eq!(qty_col.default_value.as_deref(), Some("1.0"));
+        assert!(!qty_col.notnull);
+
+        let unique_idx = info
+            .indexes
+            .iter()
+            .find(|i| i.name == "idx_items_name")
+            .unwrap();
+        assert!(unique_idx.unique);
+        assert_eq!(unique_idx.columns, vec!["name".to_string()]);
+        let non_unique = info
+            .indexes
+            .iter()
+            .find(|i| i.name == "idx_items_qty")
+            .unwrap();
+        assert!(!non_unique.unique);
     }
 
     #[test]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -175,6 +175,8 @@ export type {
   CodeChanges,
   HealthFlag,
   ModelMetricDetail,
+  SessionDbColumn,
+  SessionDbIndex,
   SessionDbTable,
   SessionDetail,
   SessionFileEntry,

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -188,4 +188,29 @@ export interface SessionDbTable {
   columns: string[];
   /** Rows; each row is an ordered list of cell values aligned to `columns`. */
   rows: (string | number | null)[][];
+  /** Column schema metadata from `PRAGMA table_info`. */
+  columnInfo: SessionDbColumn[];
+  /** Indexes on the table, from `PRAGMA index_list` + `PRAGMA index_info`. */
+  indexes: SessionDbIndex[];
+}
+
+/** A single column's schema metadata. */
+export interface SessionDbColumn {
+  name: string;
+  /** Declared type (may be empty for typeless columns). */
+  typeName: string;
+  /** True when `NOT NULL` was declared. */
+  notnull: boolean;
+  /** Primary-key position (0 if not a PK column; 1-based for composite PKs). */
+  pk: number;
+  /** Declared default expression, if any. */
+  defaultValue: string | null;
+}
+
+/** Metadata for a single index on a table. */
+export interface SessionDbIndex {
+  name: string;
+  unique: boolean;
+  /** Column names the index covers, in index order. */
+  columns: string[];
 }

--- a/packages/ui/src/__tests__/SqliteTableView.test.ts
+++ b/packages/ui/src/__tests__/SqliteTableView.test.ts
@@ -51,15 +51,16 @@ describe("SqliteTableView", () => {
     expect(empty.text()).toContain("todo_deps");
   });
 
-  it("exposes Data and Schema tabs, Schema lists columns + indexes", async () => {
-    const wrapper = mount(SqliteTableView, { props: { table: emptyTable } });
+  it("respects the viewMode v-model to switch between Data and Schema", async () => {
+    const wrapper = mount(SqliteTableView, {
+      props: { table: emptyTable, viewMode: "data" },
+    });
 
-    const modes = wrapper.findAll(".stv__mode");
-    expect(modes.length).toBe(2);
-    expect(modes[0].text()).toContain("Data");
-    expect(modes[1].text()).toContain("Schema");
+    // Default: data wrap visible, no schema wrap.
+    expect(wrapper.find(".stv__data-wrap").exists()).toBe(true);
+    expect(wrapper.find(".stv__schema-wrap").exists()).toBe(false);
 
-    await modes[1].trigger("click");
+    await wrapper.setProps({ viewMode: "schema" });
     expect(wrapper.find(".stv__schema-wrap").exists()).toBe(true);
     // Column names in schema
     expect(wrapper.text()).toContain("todo_id");

--- a/packages/ui/src/__tests__/SqliteTableView.test.ts
+++ b/packages/ui/src/__tests__/SqliteTableView.test.ts
@@ -1,0 +1,113 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import SqliteTableView from "../components/SqliteTableView.vue";
+
+const emptyTable = {
+  name: "todo_deps",
+  columns: ["todo_id", "depends_on"],
+  rows: [],
+  columnInfo: [
+    { name: "todo_id", typeName: "TEXT", notnull: true, pk: 1, defaultValue: null },
+    { name: "depends_on", typeName: "TEXT", notnull: true, pk: 2, defaultValue: null },
+  ],
+  indexes: [
+    { name: "sqlite_autoindex_todo_deps_1", unique: true, columns: ["todo_id", "depends_on"] },
+  ],
+} as const;
+
+const populatedTable = {
+  name: "todos",
+  columns: ["id", "title", "status"],
+  rows: [
+    ["t1", "Fix bug", "done"],
+    [
+      "t2",
+      "Write docs with a very long description that will definitely overflow any reasonable column width and need expansion",
+      "pending",
+    ],
+  ],
+  columnInfo: [
+    { name: "id", typeName: "TEXT", notnull: true, pk: 1, defaultValue: null },
+    { name: "title", typeName: "TEXT", notnull: true, pk: 0, defaultValue: null },
+    { name: "status", typeName: "TEXT", notnull: false, pk: 0, defaultValue: "'pending'" },
+  ],
+  indexes: [],
+} as const;
+
+describe("SqliteTableView", () => {
+  it("renders column headers even for an empty table and shows empty-state row", () => {
+    const wrapper = mount(SqliteTableView, { props: { table: emptyTable } });
+
+    // Headers are present despite zero rows.
+    const ths = wrapper.findAll(".stv__th-label");
+    expect(ths.map((t) => t.text())).toEqual(["todo_id", "depends_on"]);
+
+    // Empty row is rendered as a single spanning cell.
+    const empty = wrapper.find(".stv__empty-row");
+    expect(empty.exists()).toBe(true);
+    expect(empty.attributes("colspan")).toBe("2");
+    expect(empty.text()).toContain("No rows in");
+    expect(empty.text()).toContain("todo_deps");
+  });
+
+  it("exposes Data and Schema tabs, Schema lists columns + indexes", async () => {
+    const wrapper = mount(SqliteTableView, { props: { table: emptyTable } });
+
+    const modes = wrapper.findAll(".stv__mode");
+    expect(modes.length).toBe(2);
+    expect(modes[0].text()).toContain("Data");
+    expect(modes[1].text()).toContain("Schema");
+
+    await modes[1].trigger("click");
+    expect(wrapper.find(".stv__schema-wrap").exists()).toBe(true);
+    // Column names in schema
+    expect(wrapper.text()).toContain("todo_id");
+    expect(wrapper.text()).toContain("NOT NULL");
+    // PK positions
+    expect(wrapper.text()).toContain("PK");
+    expect(wrapper.text()).toContain("PK2");
+    // Index listed
+    expect(wrapper.text()).toContain("sqlite_autoindex_todo_deps_1");
+  });
+
+  it("opens the cell-expand modal with the full value when a cell is clicked", async () => {
+    const wrapper = mount(SqliteTableView, {
+      props: { table: populatedTable },
+      attachTo: document.body,
+    });
+
+    const cells = wrapper.findAll(".stv__td");
+    // Second row, second cell contains the long title.
+    const longCell = cells.find((c) => c.text().startsWith("Write docs"));
+    expect(longCell).toBeTruthy();
+    await longCell!.trigger("click");
+
+    // Modal is teleported to body — query the document directly.
+    const modalValue = document.querySelector(".stv__cell-value");
+    expect(modalValue?.textContent).toContain("overflow any reasonable column width");
+    wrapper.unmount();
+  });
+
+  it("resizes a column width via the drag handle", async () => {
+    const wrapper = mount(SqliteTableView, {
+      props: { table: populatedTable },
+      attachTo: document.body,
+    });
+
+    const handles = wrapper.findAll(".stv__th-handle");
+    expect(handles.length).toBe(3);
+    // Initial width for column 0 should be the default 180px.
+    const colBefore = wrapper.find("col");
+    expect(colBefore.attributes("style")).toContain("180px");
+
+    await handles[0].trigger("mousedown", { clientX: 200 });
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 300 }));
+    document.dispatchEvent(new MouseEvent("mouseup"));
+    await wrapper.vm.$nextTick();
+
+    const colAfter = wrapper.find("col");
+    // Width should be default + 100 = 280px
+    expect(colAfter.attributes("style")).toContain("280px");
+    wrapper.unmount();
+  });
+});

--- a/packages/ui/src/__tests__/SqliteTableView.test.ts
+++ b/packages/ui/src/__tests__/SqliteTableView.test.ts
@@ -1,8 +1,9 @@
+import type { SessionDbTable } from "@tracepilot/types";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import SqliteTableView from "../components/SqliteTableView.vue";
 
-const emptyTable = {
+const emptyTable: SessionDbTable = {
   name: "todo_deps",
   columns: ["todo_id", "depends_on"],
   rows: [],
@@ -13,9 +14,9 @@ const emptyTable = {
   indexes: [
     { name: "sqlite_autoindex_todo_deps_1", unique: true, columns: ["todo_id", "depends_on"] },
   ],
-} as const;
+};
 
-const populatedTable = {
+const populatedTable: SessionDbTable = {
   name: "todos",
   columns: ["id", "title", "status"],
   rows: [
@@ -32,7 +33,7 @@ const populatedTable = {
     { name: "status", typeName: "TEXT", notnull: false, pk: 0, defaultValue: "'pending'" },
   ],
   indexes: [],
-} as const;
+};
 
 describe("SqliteTableView", () => {
   it("renders column headers even for an empty table and shows empty-state row", () => {

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -383,20 +383,20 @@ const iconTypeByPath = computed(() => {
    inset box-shadow so the list doesn't layout-shift when entries gain /
    lose the class. Uses --success-fg to read as "new content arrived". */
 .fb-tree__item--new {
-  animation: fb-tree-new-fade 1.1s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: fb-tree-new-fade 1.2s ease-out;
 }
 @keyframes fb-tree-new-fade {
   0% {
-    background: color-mix(in srgb, var(--success-fg) 28%, transparent);
-    box-shadow: inset 2px 0 0 var(--success-fg);
+    background: var(--success-muted);
+    box-shadow: inset 3px 0 0 var(--success-fg);
   }
-  60% {
-    background: color-mix(in srgb, var(--success-fg) 12%, transparent);
-    box-shadow: inset 2px 0 0 color-mix(in srgb, var(--success-fg) 65%, transparent);
+  70% {
+    background: var(--success-muted);
+    box-shadow: inset 3px 0 0 var(--success-fg);
   }
   100% {
     background: transparent;
-    box-shadow: inset 2px 0 0 transparent;
+    box-shadow: inset 3px 0 0 transparent;
   }
 }
 /* Note: when an item is both --selected and --new we still want the flash

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -378,17 +378,21 @@ const iconTypeByPath = computed(() => {
    so the list doesn't layout-shift when entries gain/lose the class.
    Uses accent colour (matches the selected-state pill) rather than raw
    green so the cue feels consistent with the rest of the app chrome. */
+/* Newly-appeared files (and content-updated ones) briefly flash green so
+   auto-refresh changes are visible at a glance. Kept to background +
+   inset box-shadow so the list doesn't layout-shift when entries gain /
+   lose the class. Uses --success-fg to read as "new content arrived". */
 .fb-tree__item--new {
   animation: fb-tree-new-fade 1.1s cubic-bezier(0.16, 1, 0.3, 1);
 }
 @keyframes fb-tree-new-fade {
   0% {
-    background: color-mix(in srgb, var(--accent-fg) 18%, transparent);
-    box-shadow: inset 2px 0 0 var(--accent-fg);
+    background: color-mix(in srgb, var(--success-fg) 28%, transparent);
+    box-shadow: inset 2px 0 0 var(--success-fg);
   }
   60% {
-    background: color-mix(in srgb, var(--accent-fg) 7%, transparent);
-    box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent-fg) 55%, transparent);
+    background: color-mix(in srgb, var(--success-fg) 12%, transparent);
+    box-shadow: inset 2px 0 0 color-mix(in srgb, var(--success-fg) 65%, transparent);
   }
   100% {
     background: transparent;

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -226,7 +226,11 @@ const iconTypeByPath = computed(() => {
 }
 
 .fb-tree__header {
-  padding: 10px 12px 8px;
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  min-height: 36px;
+  box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;
 }
@@ -370,15 +374,26 @@ const iconTypeByPath = computed(() => {
 }
 
 /* ── New-file highlight (auto-refresh) ──────────────────────────────── */
-/* Pure background fade — no size / border / margin change so the list
-   doesn't layout-shift when entries gain/lose the class. */
+/* Pure background + inset-shadow fade — no size / border / margin change
+   so the list doesn't layout-shift when entries gain/lose the class.
+   Uses accent colour (matches the selected-state pill) rather than raw
+   green so the cue feels consistent with the rest of the app chrome. */
 .fb-tree__item--new {
-  animation: fb-tree-new-fade 1.6s ease-out;
+  animation: fb-tree-new-fade 1.1s cubic-bezier(0.16, 1, 0.3, 1);
 }
 @keyframes fb-tree-new-fade {
-  0%   { background: color-mix(in srgb, var(--success-fg) 28%, transparent); }
-  60%  { background: color-mix(in srgb, var(--success-fg) 12%, transparent); }
-  100% { background: transparent; }
+  0% {
+    background: color-mix(in srgb, var(--accent-fg) 18%, transparent);
+    box-shadow: inset 2px 0 0 var(--accent-fg);
+  }
+  60% {
+    background: color-mix(in srgb, var(--accent-fg) 7%, transparent);
+    box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent-fg) 55%, transparent);
+  }
+  100% {
+    background: transparent;
+    box-shadow: inset 2px 0 0 transparent;
+  }
 }
 /* Selected takes precedence over the fade background */
 .fb-tree__item--selected.fb-tree__item--new {

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -335,6 +335,8 @@ const iconTypeByPath = computed(() => {
 
 /* ── File row ────────────────────────────────────────────── */
 .fb-tree__item {
+  position: relative;
+  isolation: isolate;
   display: flex;
   align-items: center;
   gap: 7px;
@@ -374,35 +376,37 @@ const iconTypeByPath = computed(() => {
 }
 
 /* ── New-file highlight (auto-refresh) ──────────────────────────────── */
-/* Pure background + inset-shadow fade — no size / border / margin change
-   so the list doesn't layout-shift when entries gain/lose the class.
-   Uses accent colour (matches the selected-state pill) rather than raw
-   green so the cue feels consistent with the rest of the app chrome. */
-/* Newly-appeared files (and content-updated ones) briefly flash green so
-   auto-refresh changes are visible at a glance. Kept to background +
-   inset box-shadow so the list doesn't layout-shift when entries gain /
-   lose the class. Uses --success-fg to read as "new content arrived". */
-.fb-tree__item--new {
-  animation: fb-tree-new-fade 1.2s ease-out;
+/* Newly-appeared and content-updated files flash green so auto-refresh
+   changes are visible at a glance.
+
+   Implementation: an absolutely-positioned ::before overlay inherits the
+   row's border-radius and animates ONLY its opacity. Animating the row's
+   own background/box-shadow produces sub-pixel rasterisation residue on
+   rounded corners (Chromium promotes the row to a compositor layer for
+   the shadow animation and can leave dithered green specks on tile
+   boundaries when the layer is discarded). An opacity-only animation on
+   a dedicated pseudo-element avoids touching the row's own paint region
+   entirely, so nothing can be left behind when the class is removed. */
+.fb-tree__item--new::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: var(--success-muted);
+  box-shadow: inset 3px 0 0 var(--success-fg);
+  pointer-events: none;
+  opacity: 1;
+  animation: fb-tree-new-fade 1.1s ease-out forwards;
 }
 @keyframes fb-tree-new-fade {
-  0% {
-    background: var(--success-muted);
-    box-shadow: inset 3px 0 0 var(--success-fg);
-  }
-  70% {
-    background: var(--success-muted);
-    box-shadow: inset 3px 0 0 var(--success-fg);
-  }
-  100% {
-    background: transparent;
-    box-shadow: inset 3px 0 0 transparent;
-  }
+  0%, 55% { opacity: 1; }
+  100%    { opacity: 0; }
 }
-/* Note: when an item is both --selected and --new we still want the flash
-   to play (content-updated open file). The animation transitions to
-   `background: transparent` at 100%, after which the --new class is
-   removed and the selected background takes over again. */
+/* When an item is both --selected and --new we still want the flash to
+   play. The overlay sits above the selected background (z-order of
+   ::before inside a positioned parent) and fades to opacity:0, leaving
+   the selected pill intact. */
 
 /* File-type icon accent colours */
 .fb-tree__file-icon--markdown { color: var(--accent-fg); opacity: 0.75; }

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -20,6 +20,13 @@ const props = defineProps<{
   title?: string;
   /** Folders with more entries than this will be auto-collapsed on load. Default: no limit. */
   autoCollapseThreshold?: number;
+  /**
+   * Paths to briefly highlight as newly-added (e.g. green fade-in) — used by
+   * the session explorer to indicate files that appeared on auto-refresh.
+   * The set is expected to be cleared by the parent after the animation
+   * duration; the class simply reflects current membership.
+   */
+  highlightedPaths?: ReadonlySet<string>;
 }>();
 
 const emit = defineEmits<{
@@ -77,7 +84,10 @@ const iconTypeByPath = computed(() => {
         v-for="entry in treeStructure.rootFiles"
         :key="entry.path"
         class="fb-tree__item"
-        :class="{ 'fb-tree__item--selected': selectedPath === entry.path }"
+        :class="{
+          'fb-tree__item--selected': selectedPath === entry.path,
+          'fb-tree__item--new': highlightedPaths?.has(entry.path),
+        }"
         role="button"
         tabindex="0"
         @click="emit('viewFile', entry.path)"
@@ -153,7 +163,10 @@ const iconTypeByPath = computed(() => {
             v-for="entry in folderEntries"
             :key="entry.path"
             class="fb-tree__item fb-tree__item--nested"
-            :class="{ 'fb-tree__item--selected': selectedPath === entry.path }"
+            :class="{
+              'fb-tree__item--selected': selectedPath === entry.path,
+              'fb-tree__item--new': highlightedPaths?.has(entry.path),
+            }"
             role="button"
             tabindex="0"
             @click="emit('viewFile', entry.path)"
@@ -354,6 +367,22 @@ const iconTypeByPath = computed(() => {
 
 .fb-tree__item--selected .fb-tree__file-icon {
   opacity: 0.9;
+}
+
+/* ── New-file highlight (auto-refresh) ──────────────────────────────── */
+/* Pure background fade — no size / border / margin change so the list
+   doesn't layout-shift when entries gain/lose the class. */
+.fb-tree__item--new {
+  animation: fb-tree-new-fade 1.6s ease-out;
+}
+@keyframes fb-tree-new-fade {
+  0%   { background: color-mix(in srgb, var(--success-fg) 28%, transparent); }
+  60%  { background: color-mix(in srgb, var(--success-fg) 12%, transparent); }
+  100% { background: transparent; }
+}
+/* Selected takes precedence over the fade background */
+.fb-tree__item--selected.fb-tree__item--new {
+  animation: none;
 }
 
 /* File-type icon accent colours */

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -229,7 +229,7 @@ const iconTypeByPath = computed(() => {
   display: flex;
   align-items: center;
   padding: 8px 12px;
-  min-height: 36px;
+  height: 36px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;

--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -399,10 +399,10 @@ const iconTypeByPath = computed(() => {
     box-shadow: inset 2px 0 0 transparent;
   }
 }
-/* Selected takes precedence over the fade background */
-.fb-tree__item--selected.fb-tree__item--new {
-  animation: none;
-}
+/* Note: when an item is both --selected and --new we still want the flash
+   to play (content-updated open file). The animation transitions to
+   `background: transparent` at 100%, after which the --new class is
+   removed and the selected background takes over again. */
 
 /* File-type icon accent colours */
 .fb-tree__file-icon--markdown { color: var(--accent-fg); opacity: 0.75; }

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -14,6 +14,7 @@ import { computed, ref, watch } from "vue";
 import { useClipboard } from "../composables/useClipboard";
 import MarkdownContent from "./MarkdownContent.vue";
 import CodeBlock from "./renderers/CodeBlock.vue";
+import SqliteTableView from "./SqliteTableView.vue";
 
 const props = defineProps<{
   /** Relative path within the session directory (for display + language detection). */
@@ -160,26 +161,7 @@ function copyTableAsJson() {
 
         <!-- Table content -->
         <div v-if="activeTable" class="fcv__db-content">
-          <div v-if="activeTable.rows.length === 0" class="fcv__db-empty">
-            No rows in <strong>{{ activeTable.name }}</strong>
-          </div>
-          <div v-else class="fcv__db-table-wrap">
-            <table class="fcv__db-table">
-              <thead>
-                <tr>
-                  <th v-for="col in activeTable.columns" :key="col" class="fcv__db-th">{{ col }}</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="(row, rIdx) in activeTable.rows" :key="rIdx" class="fcv__db-tr">
-                  <td v-for="(cell, cIdx) in row" :key="cIdx" class="fcv__db-td">
-                    <span v-if="cell === null" class="fcv__db-null">NULL</span>
-                    <span v-else>{{ cell }}</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <SqliteTableView :key="activeTable.name" :table="activeTable" />
         </div>
       </template>
 
@@ -523,8 +505,10 @@ function copyTableAsJson() {
 
 .fcv__db-content {
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .fcv__db-empty {

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -63,13 +63,40 @@ const fileName = computed(() => {
 const activeTableIndex = ref(0);
 const activeTable = computed(() => props.dbData?.[activeTableIndex.value] ?? null);
 
-// Reset active tab whenever the dataset changes (e.g., user switches SQLite files)
+/**
+ * Track the selected table by name so silent auto-refresh (which replaces
+ * `dbData` with a new array) doesn't reset the user back to index 0. When
+ * the dataset changes, re-locate the previously selected table in the new
+ * payload; fall back to index 0 only if it no longer exists.
+ */
+const activeTableName = ref<string | null>(null);
 watch(
   () => props.dbData,
-  () => {
-    activeTableIndex.value = 0;
+  (next, prev) => {
+    if (!next || next.length === 0) {
+      activeTableIndex.value = 0;
+      activeTableName.value = null;
+      return;
+    }
+    const prevName = activeTableName.value ?? prev?.[activeTableIndex.value]?.name ?? null;
+    const nextIdx = prevName ? next.findIndex((t) => t.name === prevName) : -1;
+    activeTableIndex.value = nextIdx >= 0 ? nextIdx : 0;
+    activeTableName.value = next[activeTableIndex.value]?.name ?? null;
   },
+  { immediate: true },
 );
+
+function selectTable(idx: number) {
+  activeTableIndex.value = idx;
+  activeTableName.value = props.dbData?.[idx]?.name ?? null;
+}
+
+// Data / Schema toggle — lifted out of SqliteTableView so the segmented
+// control can render inline with the table-tabs strip (one header row,
+// not two). Preserved across silent auto-refresh.
+type SqliteViewMode = "data" | "schema";
+const sqliteViewMode = ref<SqliteViewMode>("data");
+const activeTableHasSchema = computed(() => (activeTable.value?.columnInfo?.length ?? 0) > 0);
 
 // ── Copy to clipboard ──────────────────────────────────────────────────────
 const { copy: copyText, copied: textCopied } = useClipboard();
@@ -143,7 +170,7 @@ function copyTableAsJson() {
           </button>
         </div>
 
-        <!-- Table tabs -->
+        <!-- Table tabs (left) + Data/Schema toggle (right) -->
         <div class="fcv__db-tabs" role="tablist">
           <button
             v-for="(table, idx) in dbData"
@@ -152,16 +179,47 @@ function copyTableAsJson() {
             :class="{ 'fcv__db-tab--active': activeTableIndex === idx }"
             role="tab"
             :aria-selected="activeTableIndex === idx"
-            @click="activeTableIndex = idx"
+            @click="selectTable(idx)"
           >
             {{ table.name }}
             <span class="fcv__db-tab-count">{{ table.rows.length }}</span>
           </button>
+          <div class="fcv__db-tabs-spacer" />
+          <div
+            v-if="activeTable"
+            class="fcv__db-view-toggle"
+            role="radiogroup"
+            aria-label="Table view mode"
+          >
+            <button
+              class="fcv__db-view-btn"
+              :class="{ 'fcv__db-view-btn--active': sqliteViewMode === 'data' }"
+              role="radio"
+              :aria-checked="sqliteViewMode === 'data'"
+              @click="sqliteViewMode = 'data'"
+            >
+              Data
+            </button>
+            <button
+              v-if="activeTableHasSchema"
+              class="fcv__db-view-btn"
+              :class="{ 'fcv__db-view-btn--active': sqliteViewMode === 'schema' }"
+              role="radio"
+              :aria-checked="sqliteViewMode === 'schema'"
+              @click="sqliteViewMode = 'schema'"
+            >
+              Schema
+            </button>
+          </div>
         </div>
 
         <!-- Table content -->
         <div v-if="activeTable" class="fcv__db-content">
-          <SqliteTableView :key="activeTable.name" :table="activeTable" />
+          <SqliteTableView
+            :key="filePath"
+            v-model:view-mode="sqliteViewMode"
+            :table="activeTable"
+          />
         </div>
       </template>
 
@@ -381,6 +439,8 @@ function copyTableAsJson() {
   align-items: center;
   gap: 7px;
   padding: 8px 12px;
+  min-height: 36px;
+  box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   background: var(--canvas-subtle);
   flex-shrink: 0;
@@ -429,6 +489,8 @@ function copyTableAsJson() {
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
+  min-height: 36px;
+  box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   background: var(--canvas-subtle);
   flex-shrink: 0;
@@ -459,6 +521,7 @@ function copyTableAsJson() {
 
 .fcv__db-tabs {
   display: flex;
+  align-items: stretch;
   gap: 2px;
   padding: 4px 8px 0;
   border-bottom: 1px solid var(--border-default);
@@ -466,6 +529,46 @@ function copyTableAsJson() {
   flex-shrink: 0;
   overflow-x: auto;
   scrollbar-width: thin;
+}
+
+.fcv__db-tabs-spacer {
+  flex: 1 1 auto;
+  min-width: 8px;
+}
+
+.fcv__db-view-toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  margin: 2px 0 4px;
+  background: var(--surface-secondary, var(--canvas-subtle));
+  border: 1px solid var(--border-default);
+  border-radius: 999px;
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.fcv__db-view-btn {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.fcv__db-view-btn:hover:not(.fcv__db-view-btn--active) {
+  color: var(--text-primary);
+  background: var(--canvas-inset, var(--canvas-subtle));
+}
+
+.fcv__db-view-btn--active {
+  background: var(--accent-emphasis, var(--accent-fg));
+  color: var(--text-on-emphasis, #fff);
 }
 
 .fcv__db-tab {

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -79,8 +79,15 @@ watch(
       return;
     }
     const prevName = activeTableName.value ?? prev?.[activeTableIndex.value]?.name ?? null;
-    const nextIdx = prevName ? next.findIndex((t) => t.name === prevName) : -1;
-    activeTableIndex.value = nextIdx >= 0 ? nextIdx : 0;
+    let nextIdx = prevName ? next.findIndex((t) => t.name === prevName) : -1;
+    if (nextIdx < 0) {
+      // Prefer the `todos` table on first load when present — it's by far the
+      // most commonly inspected table in the session.db, and alphabetical
+      // ordering happens to put `todo_deps` ahead of `todos`.
+      const todosIdx = next.findIndex((t) => t.name === "todos");
+      nextIdx = todosIdx >= 0 ? todosIdx : 0;
+    }
+    activeTableIndex.value = nextIdx;
     activeTableName.value = next[activeTableIndex.value]?.name ?? null;
   },
   { immediate: true },

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -439,7 +439,7 @@ function copyTableAsJson() {
   align-items: center;
   gap: 7px;
   padding: 8px 12px;
-  min-height: 36px;
+  height: 36px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   background: var(--canvas-subtle);
@@ -489,7 +489,7 @@ function copyTableAsJson() {
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  min-height: 36px;
+  height: 36px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-default);
   background: var(--canvas-subtle);
@@ -608,7 +608,7 @@ function copyTableAsJson() {
 
 .fcv__db-content {
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
   min-height: 0;
   display: flex;
   flex-direction: column;

--- a/packages/ui/src/components/MarkdownContent.vue
+++ b/packages/ui/src/components/MarkdownContent.vue
@@ -151,13 +151,38 @@ function handleLinkClick(event: MouseEvent) {
 :deep(h3) { font-size: 1rem; }
 :deep(h4) { font-size: 0.875rem; }
 
+/*
+ * Lists: the global `* { padding: 0; margin: 0 }` reset in apps/desktop
+ * strips the default padding that browsers use to make room for list
+ * markers (which render at `list-style-position: outside` by default and
+ * would otherwise be clipped). We restore enough padding for markers and
+ * set `list-style` explicitly so any ancestor rule that sets
+ * `list-style: none` can't accidentally wipe out bullets/numbers.
+ */
 :deep(ul), :deep(ol) {
   margin: 0 0 0.75rem 0 !important;
-  padding-left: 1.25rem !important;
+  padding-left: 1.5rem !important;
+}
+
+:deep(ul) {
+  list-style: disc outside !important;
+}
+
+:deep(ol) {
+  list-style: decimal outside !important;
+}
+
+:deep(ul ul) {
+  list-style: circle outside !important;
+}
+
+:deep(ul ul ul) {
+  list-style: square outside !important;
 }
 
 :deep(li) {
   margin-bottom: 0.125rem !important;
+  display: list-item !important;
 }
 
 :deep(li p) {

--- a/packages/ui/src/components/SqliteTableView.vue
+++ b/packages/ui/src/components/SqliteTableView.vue
@@ -267,16 +267,17 @@ watch(
 .stv {
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 0;
-  overflow: hidden;
 }
 
 .stv__data-wrap,
 .stv__schema-wrap {
-  flex: 1;
-  overflow: auto;
-  min-height: 0;
+  /* Horizontal-only scroll so the scrollbar sits directly below the table
+     rows, not pinned to the bottom of the pane. Vertical scroll is owned
+     by the parent (.fcv__db-content), so tall tables still scroll. */
+  overflow-x: auto;
+  overflow-y: visible;
+  width: 100%;
 }
 
 .stv__schema-wrap {

--- a/packages/ui/src/components/SqliteTableView.vue
+++ b/packages/ui/src/components/SqliteTableView.vue
@@ -44,6 +44,8 @@ const widths = computed(() => {
   return props.table.columns.map(() => DEFAULT_WIDTH);
 });
 
+const totalWidth = computed(() => widths.value.reduce((sum, w) => sum + w, 0));
+
 watch(
   () => props.table.name,
   (name) => {
@@ -139,7 +141,7 @@ watch(
   <div class="stv">
     <!-- Data view -->
     <div v-if="viewMode === 'data'" class="stv__data-wrap">
-      <table class="stv__table">
+      <table class="stv__table" :style="{ width: `max(${totalWidth}px, 100%)` }">
         <colgroup>
           <col v-for="(_col, idx) in table.columns" :key="idx" :style="{ width: `${widths[idx]}px` }" />
         </colgroup>
@@ -298,12 +300,11 @@ watch(
 }
 
 .stv__table {
-  /* min-width: 100% lets empty / narrow tables fill the pane so the grid
-     doesn't collapse to a tiny block on the left. With `table-layout: fixed`
-     the browser distributes any surplus width across columns. When the sum
-     of column widths exceeds the container, horizontal scrolling on
-     .stv__data-wrap kicks in. */
-  min-width: 100%;
+  /* Table width is set inline to `max(totalWidthPx, 100%)` so the grid fills
+     the pane when columns are narrow but grows (and horizontally scrolls) when
+     the user resizes a column wider than the container. With `table-layout:
+     fixed`, `min-width: 100%` alone would cause the browser to redistribute
+     surplus width across columns and silently swallow resizes. */
   border-collapse: collapse;
   font-size: 0.75rem;
   font-family: var(--font-mono);
@@ -362,7 +363,11 @@ watch(
   background: var(--canvas-subtle);
 }
 
-.stv__tr:hover {
+/* Hover + click affordances only make sense in the data view, where rows are
+   real records and cells open the detail modal on click. The schema view uses
+   the same .stv__tr / .stv__td classes for consistent spacing but its cells
+   are read-only metadata, so scope these rules to .stv__data-wrap. */
+.stv__data-wrap .stv__tr:hover {
   background: var(--neutral-muted);
 }
 
@@ -374,14 +379,17 @@ watch(
   white-space: nowrap;
   vertical-align: top;
   color: var(--text-primary);
-  cursor: pointer;
 }
 
 .stv__td--name {
   font-weight: 500;
 }
 
-.stv__td:hover {
+.stv__data-wrap .stv__td {
+  cursor: pointer;
+}
+
+.stv__data-wrap .stv__td:hover {
   background: var(--accent-muted, var(--neutral-muted));
 }
 

--- a/packages/ui/src/components/SqliteTableView.vue
+++ b/packages/ui/src/components/SqliteTableView.vue
@@ -1,0 +1,494 @@
+<script setup lang="ts">
+/**
+ * SqliteTableView — renders a single SQLite table's data + schema.
+ *
+ * Features:
+ *  - Data / Schema tab toggle (column metadata + indexes).
+ *  - Always renders column headers so the table structure is visible even
+ *    when the table has zero rows (empty-state is a single spanning row).
+ *  - Resizable columns via a drag handle on each `<th>`'s right edge.
+ *    Widths are tracked per-column in memory and survive table switches
+ *    while the component is mounted.
+ *  - Click a truncated cell to open a modal showing the full value with a
+ *    "Copy" action.
+ */
+import type { SessionDbTable } from "@tracepilot/types";
+import { computed, ref, watch } from "vue";
+import { useClipboard } from "../composables/useClipboard";
+import ModalDialog from "./ModalDialog.vue";
+
+const props = defineProps<{
+  table: SessionDbTable;
+}>();
+
+type ViewMode = "data" | "schema";
+const viewMode = ref<ViewMode>("data");
+
+// ── Column widths ────────────────────────────────────────────────────
+// Per-table width map (pixel values). Kept across tab-switches via the
+// parent component's v-for key (table.name). localStorage persistence is
+// intentionally out of scope — in-memory is sufficient for the session.
+const DEFAULT_WIDTH = 180;
+const MIN_WIDTH = 48;
+const columnWidths = ref<Record<string, number[]>>({});
+
+const widths = computed(() => {
+  const existing = columnWidths.value[props.table.name];
+  if (existing && existing.length === props.table.columns.length) return existing;
+  return props.table.columns.map(() => DEFAULT_WIDTH);
+});
+
+watch(
+  () => props.table.name,
+  (name) => {
+    if (!columnWidths.value[name]) {
+      columnWidths.value[name] = props.table.columns.map(() => DEFAULT_WIDTH);
+    }
+  },
+  { immediate: true },
+);
+
+// ── Resize drag state ────────────────────────────────────────────────
+let dragIndex = -1;
+let dragStartX = 0;
+let dragStartWidth = 0;
+
+function onResizeStart(idx: number, e: MouseEvent) {
+  e.preventDefault();
+  e.stopPropagation();
+  dragIndex = idx;
+  dragStartX = e.clientX;
+  const name = props.table.name;
+  const current = columnWidths.value[name] ?? props.table.columns.map(() => DEFAULT_WIDTH);
+  dragStartWidth = current[idx] ?? DEFAULT_WIDTH;
+  // Mutate via a fresh array so Vue picks up the change.
+  if (!columnWidths.value[name] || columnWidths.value[name].length !== props.table.columns.length) {
+    columnWidths.value = {
+      ...columnWidths.value,
+      [name]: props.table.columns.map(() => DEFAULT_WIDTH),
+    };
+  }
+  document.addEventListener("mousemove", onResizeMove);
+  document.addEventListener("mouseup", onResizeEnd);
+  document.body.style.cursor = "col-resize";
+  document.body.style.userSelect = "none";
+}
+
+function onResizeMove(e: MouseEvent) {
+  if (dragIndex < 0) return;
+  const delta = e.clientX - dragStartX;
+  const next = Math.max(MIN_WIDTH, dragStartWidth + delta);
+  const name = props.table.name;
+  const arr = [...(columnWidths.value[name] ?? [])];
+  arr[dragIndex] = next;
+  columnWidths.value = { ...columnWidths.value, [name]: arr };
+}
+
+function onResizeEnd() {
+  dragIndex = -1;
+  document.removeEventListener("mousemove", onResizeMove);
+  document.removeEventListener("mouseup", onResizeEnd);
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
+}
+
+// ── Cell expand modal ────────────────────────────────────────────────
+const expandedCell = ref<{ column: string; value: string | number | null } | null>(null);
+const { copy: copyCell, copied: cellCopied } = useClipboard();
+
+function openCell(columnIdx: number, value: string | number | null) {
+  expandedCell.value = { column: props.table.columns[columnIdx] ?? "", value };
+}
+
+function closeCell() {
+  expandedCell.value = null;
+}
+
+const expandedValueText = computed(() => {
+  const v = expandedCell.value?.value;
+  if (v === null || v === undefined) return "NULL";
+  return typeof v === "string" ? v : String(v);
+});
+
+function copyExpanded() {
+  if (expandedCell.value) copyCell(expandedValueText.value);
+}
+
+// ── Schema derived values ────────────────────────────────────────────
+const hasSchema = computed(
+  () => props.table.columnInfo !== undefined && props.table.columnInfo.length > 0,
+);
+</script>
+
+<template>
+  <div class="stv">
+    <!-- View-mode toggle -->
+    <div class="stv__modes" role="tablist">
+      <button
+        class="stv__mode"
+        :class="{ 'stv__mode--active': viewMode === 'data' }"
+        role="tab"
+        :aria-selected="viewMode === 'data'"
+        @click="viewMode = 'data'"
+      >
+        Data
+        <span class="stv__mode-count">{{ table.rows.length }}</span>
+      </button>
+      <button
+        v-if="hasSchema"
+        class="stv__mode"
+        :class="{ 'stv__mode--active': viewMode === 'schema' }"
+        role="tab"
+        :aria-selected="viewMode === 'schema'"
+        @click="viewMode = 'schema'"
+      >
+        Schema
+      </button>
+    </div>
+
+    <!-- Data view -->
+    <div v-if="viewMode === 'data'" class="stv__data-wrap">
+      <table class="stv__table">
+        <colgroup>
+          <col v-for="(_col, idx) in table.columns" :key="idx" :style="{ width: `${widths[idx]}px` }" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th v-for="(col, idx) in table.columns" :key="col" class="stv__th">
+              <span class="stv__th-label">{{ col }}</span>
+              <span
+                class="stv__th-handle"
+                role="separator"
+                aria-orientation="vertical"
+                :aria-label="`Resize column ${col}`"
+                @mousedown="onResizeStart(idx, $event)"
+              />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="table.rows.length === 0">
+            <td :colspan="Math.max(1, table.columns.length)" class="stv__empty-row">
+              No rows in <strong>{{ table.name }}</strong>
+            </td>
+          </tr>
+          <tr
+            v-for="(row, rIdx) in table.rows"
+            v-else
+            :key="rIdx"
+            class="stv__tr"
+          >
+            <td
+              v-for="(cell, cIdx) in row"
+              :key="cIdx"
+              class="stv__td"
+              :title="cell === null ? 'NULL' : String(cell)"
+              @click="openCell(cIdx, cell)"
+            >
+              <span v-if="cell === null" class="stv__null">NULL</span>
+              <span v-else>{{ cell }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Schema view -->
+    <div v-else class="stv__schema-wrap">
+      <section class="stv__schema-section">
+        <h4 class="stv__schema-title">Columns</h4>
+        <table class="stv__schema-table">
+          <thead>
+            <tr>
+              <th class="stv__th">Name</th>
+              <th class="stv__th">Type</th>
+              <th class="stv__th">Nullable</th>
+              <th class="stv__th">PK</th>
+              <th class="stv__th">Default</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="!table.columnInfo || table.columnInfo.length === 0">
+              <td colspan="5" class="stv__empty-row">No column metadata available.</td>
+            </tr>
+            <tr v-for="col in table.columnInfo ?? []" v-else :key="col.name" class="stv__tr">
+              <td class="stv__td stv__td--name">{{ col.name }}</td>
+              <td class="stv__td">{{ col.typeName || "—" }}</td>
+              <td class="stv__td">{{ col.notnull ? "NOT NULL" : "NULL" }}</td>
+              <td class="stv__td">{{ col.pk > 0 ? (col.pk === 1 ? "PK" : `PK${col.pk}`) : "" }}</td>
+              <td class="stv__td">
+                <span v-if="col.defaultValue === null" class="stv__null">—</span>
+                <span v-else>{{ col.defaultValue }}</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="stv__schema-section">
+        <h4 class="stv__schema-title">Indexes</h4>
+        <table class="stv__schema-table">
+          <thead>
+            <tr>
+              <th class="stv__th">Name</th>
+              <th class="stv__th">Unique</th>
+              <th class="stv__th">Columns</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="!table.indexes || table.indexes.length === 0">
+              <td colspan="3" class="stv__empty-row">No indexes on this table.</td>
+            </tr>
+            <tr v-for="idx in table.indexes ?? []" v-else :key="idx.name" class="stv__tr">
+              <td class="stv__td stv__td--name">{{ idx.name }}</td>
+              <td class="stv__td">{{ idx.unique ? "Yes" : "No" }}</td>
+              <td class="stv__td">{{ idx.columns.join(", ") }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+
+    <!-- Cell value modal -->
+    <ModalDialog
+      :visible="expandedCell !== null"
+      :title="expandedCell?.column ?? ''"
+      @update:visible="(v) => !v && closeCell()"
+    >
+      <div class="stv__cell-body">
+        <pre class="stv__cell-value">{{ expandedValueText }}</pre>
+      </div>
+      <template #footer>
+        <button
+          class="stv__copy-btn"
+          :class="{ 'stv__copy-btn--copied': cellCopied }"
+          @click="copyExpanded"
+        >
+          {{ cellCopied ? "Copied!" : "Copy" }}
+        </button>
+        <button class="stv__close-btn" @click="closeCell">Close</button>
+      </template>
+    </ModalDialog>
+  </div>
+</template>
+
+<style scoped>
+.stv {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.stv__modes {
+  display: flex;
+  gap: 2px;
+  padding: 4px 8px 0;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--canvas-default);
+  flex-shrink: 0;
+}
+
+.stv__mode {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.stv__mode:hover {
+  color: var(--text-primary);
+  background: var(--canvas-subtle);
+}
+
+.stv__mode--active {
+  color: var(--accent-fg);
+  border-bottom-color: var(--accent-fg);
+  font-weight: 500;
+}
+
+.stv__mode-count {
+  font-size: 0.6875rem;
+  padding: 1px 5px;
+  border-radius: 99px;
+  background: var(--neutral-muted);
+  color: var(--text-secondary);
+}
+
+.stv__data-wrap,
+.stv__schema-wrap {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.stv__schema-wrap {
+  padding: 12px 16px 16px;
+}
+
+.stv__schema-section + .stv__schema-section {
+  margin-top: 16px;
+}
+
+.stv__schema-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  margin: 0 0 6px;
+}
+
+.stv__table {
+  border-collapse: collapse;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  table-layout: fixed;
+  /* width auto — follows <colgroup> sum so horizontal scroll reflects widths */
+}
+
+.stv__schema-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+}
+
+.stv__th {
+  position: sticky;
+  top: 0;
+  padding: 7px 10px;
+  text-align: left;
+  font-weight: 600;
+  background: var(--canvas-subtle);
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  z-index: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stv__th-label {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+.stv__th-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+.stv__th-handle:hover,
+.stv__th-handle:active {
+  background: var(--accent-fg);
+  opacity: 0.4;
+}
+
+.stv__tr:nth-child(even) {
+  background: var(--canvas-subtle);
+}
+
+.stv__tr:hover {
+  background: var(--neutral-muted);
+}
+
+.stv__td {
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--border-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: top;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.stv__td--name {
+  font-weight: 500;
+}
+
+.stv__td:hover {
+  background: var(--accent-muted, var(--neutral-muted));
+}
+
+.stv__null {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.stv__empty-row {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-sans, inherit);
+  cursor: default;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.stv__empty-row:hover {
+  background: transparent;
+}
+
+/* Cell expand modal */
+.stv__cell-body {
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.stv__cell-value {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--canvas-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+}
+
+.stv__copy-btn,
+.stv__close-btn {
+  padding: 6px 12px;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--canvas-default);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.stv__copy-btn:hover,
+.stv__close-btn:hover {
+  background: var(--neutral-muted);
+}
+
+.stv__copy-btn--copied {
+  color: var(--success-fg, #2da44e);
+  border-color: var(--success-fg, #2da44e);
+}
+</style>

--- a/packages/ui/src/components/SqliteTableView.vue
+++ b/packages/ui/src/components/SqliteTableView.vue
@@ -17,12 +17,18 @@ import { computed, ref, watch } from "vue";
 import { useClipboard } from "../composables/useClipboard";
 import ModalDialog from "./ModalDialog.vue";
 
+export type SqliteViewMode = "data" | "schema";
+
 const props = defineProps<{
   table: SessionDbTable;
 }>();
 
-type ViewMode = "data" | "schema";
-const viewMode = ref<ViewMode>("data");
+/**
+ * View mode (Data/Schema) is a v-model so the parent can render the
+ * segmented-control toggle alongside the table-tabs strip instead of
+ * duplicating a second header row inside this component.
+ */
+const viewMode = defineModel<SqliteViewMode>("viewMode", { default: "data" });
 
 // ── Column widths ────────────────────────────────────────────────────
 // Per-table width map (pixel values). Kept across tab-switches via the
@@ -118,34 +124,19 @@ function copyExpanded() {
 const hasSchema = computed(
   () => props.table.columnInfo !== undefined && props.table.columnInfo.length > 0,
 );
+
+// If the current view is "schema" but the newly-selected table has no schema
+// metadata (shouldn't normally happen, but be defensive), fall back to data.
+watch(
+  () => [hasSchema.value, viewMode.value] as const,
+  ([has, mode]) => {
+    if (!has && mode === "schema") viewMode.value = "data";
+  },
+);
 </script>
 
 <template>
   <div class="stv">
-    <!-- View-mode toggle -->
-    <div class="stv__modes" role="tablist">
-      <button
-        class="stv__mode"
-        :class="{ 'stv__mode--active': viewMode === 'data' }"
-        role="tab"
-        :aria-selected="viewMode === 'data'"
-        @click="viewMode = 'data'"
-      >
-        Data
-        <span class="stv__mode-count">{{ table.rows.length }}</span>
-      </button>
-      <button
-        v-if="hasSchema"
-        class="stv__mode"
-        :class="{ 'stv__mode--active': viewMode === 'schema' }"
-        role="tab"
-        :aria-selected="viewMode === 'schema'"
-        @click="viewMode = 'schema'"
-      >
-        Schema
-      </button>
-    </div>
-
     <!-- Data view -->
     <div v-if="viewMode === 'data'" class="stv__data-wrap">
       <table class="stv__table">
@@ -281,50 +272,6 @@ const hasSchema = computed(
   overflow: hidden;
 }
 
-.stv__modes {
-  display: flex;
-  gap: 2px;
-  padding: 4px 8px 0;
-  border-bottom: 1px solid var(--border-default);
-  background: var(--canvas-default);
-  flex-shrink: 0;
-}
-
-.stv__mode {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  background: none;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  white-space: nowrap;
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  transition: color var(--transition-fast), background var(--transition-fast);
-}
-
-.stv__mode:hover {
-  color: var(--text-primary);
-  background: var(--canvas-subtle);
-}
-
-.stv__mode--active {
-  color: var(--accent-fg);
-  border-bottom-color: var(--accent-fg);
-  font-weight: 500;
-}
-
-.stv__mode-count {
-  font-size: 0.6875rem;
-  padding: 1px 5px;
-  border-radius: 99px;
-  background: var(--neutral-muted);
-  color: var(--text-secondary);
-}
-
 .stv__data-wrap,
 .stv__schema-wrap {
   flex: 1;
@@ -350,11 +297,16 @@ const hasSchema = computed(
 }
 
 .stv__table {
+  /* min-width: 100% lets empty / narrow tables fill the pane so the grid
+     doesn't collapse to a tiny block on the left. With `table-layout: fixed`
+     the browser distributes any surplus width across columns. When the sum
+     of column widths exceeds the container, horizontal scrolling on
+     .stv__data-wrap kicks in. */
+  min-width: 100%;
   border-collapse: collapse;
   font-size: 0.75rem;
   font-family: var(--font-mono);
   table-layout: fixed;
-  /* width auto — follows <colgroup> sum so horizontal scroll reflects widths */
 }
 
 .stv__schema-table {

--- a/packages/ui/src/components/ToolCallItem.vue
+++ b/packages/ui/src/components/ToolCallItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { TurnToolCall } from "@tracepilot/types";
-import { computed } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { formatDuration } from "../utils/formatters";
 import { categoryColor, formatArgsSummary, toolCategory, toolIcon } from "../utils/toolCall";
 import ExpandChevron from "./ExpandChevron.vue";
@@ -31,10 +31,52 @@ const emit = defineEmits<{
 const summary = computed(
   () => props.argsSummary ?? formatArgsSummary(props.tc.arguments, props.tc.toolName),
 );
+
+// ── Keep expanded detail in view ───────────────────────────────────
+// When the user expands a tool-call detail, the newly-revealed content can
+// extend past the scroll container's viewport. If the header is currently
+// visible (user is looking at this row), nudge the container so the detail
+// fits. If the user is scrolled far away, do nothing — don't fight them.
+const rootEl = ref<HTMLElement | null>(null);
+
+function findScrollContainer(el: HTMLElement): HTMLElement | null {
+  let cur: HTMLElement | null = el.parentElement;
+  while (cur && cur !== document.body) {
+    const style = getComputedStyle(cur);
+    if (/auto|scroll|overlay/.test(style.overflowY)) {
+      if (cur.scrollHeight > cur.clientHeight) return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return null;
+}
+
+watch(
+  () => props.expanded,
+  (val, prev) => {
+    // Only on a genuine false → true transition (user-initiated expand).
+    if (!val || prev) return;
+    void nextTick(() => {
+      const root = rootEl.value;
+      if (!root) return;
+      const container = findScrollContainer(root);
+      if (!container) return;
+      const cRect = container.getBoundingClientRect();
+      const eRect = root.getBoundingClientRect();
+      // User is scrolled far away from this row — leave their scroll alone.
+      if (eRect.bottom < cRect.top || eRect.top > cRect.bottom) return;
+      // Expanded content doesn't extend past the bottom — nothing to do.
+      if (eRect.bottom <= cRect.bottom) return;
+      const overflow = eRect.bottom - cRect.bottom + 8;
+      container.scrollBy({ top: overflow, behavior: "smooth" });
+    });
+  },
+);
 </script>
 
 <template>
   <div
+    ref="rootEl"
     class="rounded-lg border overflow-hidden"
     :style="tc.success === false ? 'border-color: var(--danger-muted);' : 'border-color: var(--border-muted);'"
   >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -53,6 +53,7 @@ export { default as SegmentedControl } from "./components/SegmentedControl.vue";
 export { default as SessionCard } from "./components/SessionCard.vue";
 export { default as SessionList } from "./components/SessionList.vue";
 export { default as SkeletonLoader } from "./components/SkeletonLoader.vue";
+export { default as SqliteTableView } from "./components/SqliteTableView.vue";
 export { default as StatCard } from "./components/StatCard.vue";
 export { default as StatusIcon } from "./components/StatusIcon.vue";
 export type { TabNavItem } from "./components/TabNav.vue";


### PR DESCRIPTION
Wave of targeted bugfixes on top of `main`. Each numbered bug from the tracking list was investigated root-cause-first by a dedicated Opus 4.7 subagent, then a review pass caught and fixed follow-ups. Surgical changes throughout — no band-aids. Per-wave findings are in `files/bugfix-findings.md` on the session workspace (kept local).

### Bugs fixed

1. **Session File Explorer auto-refresh** — no more flash, no more scroll-snap-to-top; the open file is silently refetched in-place on agent-driven disk changes; new files briefly flash green (1.6s fade). Fixed in `useSessionFiles` by making `reload()` default to silent mode (keeps DOM mounted) and only swapping `fileContent` when bytes actually differ.
2. **New sessions missed by session-list auto-refresh** — `ensureIndex()` was throwing away BOTH the reindex and the list refresh inside its 2-min throttle. Split: throttle now only guards the expensive reindex; auto-refresh passes `{force:true}` and the list refresh always runs. A review-pass added a secondary 20s throttle to the force path so the 5s auto-refresh doesn't reindex every tick.
3. **Todos not auto-refreshed** — the cache-hit path in `useSessionDetail` explicitly nulled out `todos` and removed them from `loaded`, so `refreshAll` skipped the section. Added `todos` to the `CachedSession` snapshot and removed the ad-hoc reset.
4. **Agent Tree paginated/unified buttons squish after visiting Search/Workers; Subagent Panel chrome collapses** — three dynamically-imported per-feature stylesheets (`session-search.css`, `worktree-manager.css`, `waterfall.css`) had top-level rules on generic class names (`.view-mode-toggle`, `.view-mode-btn`, `.detail-panel`) that permanently attach to `<head>` on first visit. Rescoped all offending selectors under feature root classes; full audit of `<style>`-without-`scoped` + `:global` usage documented in findings.
5. **Tool-call expand cut off below viewport** — `ToolCallItem` now watches `expanded` and, after `nextTick`, nudges the nearest scrollable ancestor only when the row is currently visible AND the expanded content overflows the container bottom. Doesn't hijack scroll otherwise.
6. **SQLite renderer in Session File Explorer** — new `SqliteTableView` component: column headers always render (empty state is a spanning cell with proper padding), Data/Schema tab toggle (columns w/ Type/Nullable/PK/Default + Indexes), per-column drag-resize handles, click-cell modal for untruncated values with Copy button. Schema piggy-backs on the existing `session_read_sqlite` payload — no new Tauri command. PRAGMA calls use standard identifier quoting; all rendering is text-interpolated (no v-html).
7. **Markdown lists not rendering bullets** — `MarkdownContent.vue` was letting the global `* { padding: 0; margin: 0 }` reset swallow the markers. Explicit `list-style`, nested marker types, `display: list-item`, and adequate padding-left. Scoped via `:deep()` so no broader regression.
8. **Skills editor bottom cutoff** — classic `height: 100vh` trap inside a flex column with page chrome above it. Replaced with `flex: 1 1 auto; min-height: 0` and a flex-column wrapper matching the repo's pattern for full-height feature views.
9. **Search content-type filter not realtime** — `contentTypes` / `excludeContentTypes` are `shallowRef` arrays; three call sites were mutating them in place (`splice`/`push`) which shallowRef ignores. Switched to wholesale array replacement. Regression test added.

### Review-pass fixups (commit `67c6897a`)

- Fixed 4 `vue-tsc` errors in `SqliteTableView.test.ts` introduced by Wave D (`as const` readonly-tuple widening).
- Fixed a silent-refetch race in `useSessionFiles` that could leave loading flags stuck `true` if a user clicked a file mid auto-refresh (separate `silentSeq` counter + `selectedPath` guard).
- Added a 20s throttle to `ensureIndex({force:true})` so the session-list auto-refresh doesn't run a ~500ms reindex every 5s forever.

### Verification

- `vue-tsc` clean on `@tracepilot/desktop` and `@tracepilot/ui`.
- Desktop vitest 1666/1666; UI vitest 846/846+ (new regression tests for silent reload, new-path highlight, open-file silent refetch, `ensureIndex` force-throttle semantics, cache-hit todos refresh, SQLite viewer empty/schema/resize/modal, Search filter reactivity, MarkdownContent bullets).
- `cargo check --workspace` clean; `cargo test -p tracepilot-core parsing::session_db` 6/6 incl. new schema/index coverage.
- Desktop Vite build clean.

### Commits

- `78664c7e` auto-refresh trio (bugs 1, 2, 3)
- `84ab76c4` CSS scope audit (bug 4)
- `5d1c1051` tool-call auto-scroll + Skills editor (bugs 5, 8)
- `e2097bae` SQLite viewer overhaul (bug 6)
- `0bf380ea` MD bullets + Search filter reactivity (bugs 7, 9)
- `67c6897a` review fixups

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
