### PR TITLE
🎨 Palette: Add aria-label to FileBrowserTree folder toggle

### DIFF
--- a/packages/ui/src/components/FileBrowserTree.vue
+++ b/packages/ui/src/components/FileBrowserTree.vue
@@ -146,6 +146,7 @@ const iconTypeByPath = computed(() => {
         <button
           class="fb-tree__folder"
           :aria-expanded="!collapsedFolders.has(String(folder))"
+          :aria-label="(!collapsedFolders.has(String(folder)) ? 'Collapse folder ' : 'Expand folder ') + folder"
           @click="toggleFolder(String(folder))"
         >
           <span class="fb-tree__chevron">


### PR DESCRIPTION
💡 **What:** Added a dynamic `aria-label` to the folder toggle button in `FileBrowserTree.vue`.
🎯 **Why:** To improve accessibility for screen reader users by providing clear, descriptive feedback about the button's action and target (e.g., "Expand folder src" or "Collapse folder src").
📸 **Before/After:** N/A (Non-visual change)
♿ **Accessibility:** The `aria-label` dynamically updates based on the expanded/collapsed state, pairing well with the existing `aria-expanded` attribute.

---
*PR created automatically by Jules for task [4162502332720261905](https://jules.google.com/task/4162502332720261905) started by @MattShelton04*