### PR TITLE
Copilot CLI settings.json migration + GPT-5.5 + neutral config-injector picker

### DIFF
--- a/apps/desktop/src/__tests__/stores/configInjector.test.ts
+++ b/apps/desktop/src/__tests__/stores/configInjector.test.ts
@@ -80,10 +80,12 @@ const FIXTURE_CONFIG: CopilotConfig = {
   model: "claude-sonnet-4.6",
   reasoningEffort: "high",
   trustedFolders: ["/home/user/projects"],
+  disabledSkills: [],
   raw: {
     model: "claude-sonnet-4.6",
     reasoningEffort: "high",
   },
+  settingsPath: "/home/user/.copilot/settings.json",
 };
 
 const FIXTURE_VERSIONS: CopilotVersion[] = [

--- a/apps/desktop/src/components/configInjector/ConfigInjectorAgentsTab.vue
+++ b/apps/desktop/src/components/configInjector/ConfigInjectorAgentsTab.vue
@@ -44,16 +44,6 @@ const uniqueModelCount = computed(() => new Set(store.agents.map((a) => a.model)
 const premiumAgentCount = computed(
   () => store.agents.filter((a: AgentDefinition) => PREMIUM_MODELS.includes(a.model)).length,
 );
-// Sum of premium-request weight across all agents — informational stat that
-// reflects "cost shape" without nudging towards more expensive models.
-const totalPremiumWeight = computed(() => {
-  let total = 0;
-  for (const agent of store.agents) {
-    const def = getModelsByTier("premium").find((m) => m.id === agent.model);
-    if (def) total += def.premiumRequests;
-  }
-  return Number(total.toFixed(2));
-});
 </script>
 
 <template>
@@ -76,12 +66,6 @@ const totalPremiumWeight = computed(() => {
         :value="`${premiumAgentCount} / ${store.agents.length}`"
         label="On Premium Models"
         color="warning"
-        label-style="uppercase"
-      />
-      <StatCard
-        :value="totalPremiumWeight"
-        label="Total Premium Weight"
-        color="success"
         label-style="uppercase"
       />
     </div>

--- a/apps/desktop/src/components/configInjector/ConfigInjectorAgentsTab.vue
+++ b/apps/desktop/src/components/configInjector/ConfigInjectorAgentsTab.vue
@@ -2,7 +2,7 @@
 import type { AgentDefinition } from "@tracepilot/types";
 import { getAllModelIds, getModelsByTier, getModelTier, getTierLabel } from "@tracepilot/types";
 import { EmptyState, StatCard, truncateText } from "@tracepilot/ui";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { TOOLS_COLLAPSE_LIMIT, useConfigInjectorContext } from "@/composables/useConfigInjector";
 import { agentMeta } from "./agentMeta";
 
@@ -15,9 +15,8 @@ const {
   autoSavedAgent,
   agentModels,
   onAgentModelSelect,
-  upgradeAgent,
-  batchUpgrading,
-  upgradeAllToOpus,
+  batchApplying,
+  setAllAgentsToModel,
   resetAllDefaults,
 } = ctx;
 
@@ -25,6 +24,13 @@ const ALL_MODELS = getAllModelIds();
 const PREMIUM_MODELS = getModelsByTier("premium").map((m) => m.id);
 const STANDARD_MODELS = getModelsByTier("standard").map((m) => m.id);
 const FAST_MODELS = getModelsByTier("fast").map((m) => m.id);
+
+// Default the batch picker to GPT-5.4 — neutral, non-"premium-upgrade"
+// framing. Users can pick any other model from the dropdown.
+const DEFAULT_BATCH_MODEL = "gpt-5.4";
+const batchTargetModel = ref<string>(
+  ALL_MODELS.includes(DEFAULT_BATCH_MODEL) ? DEFAULT_BATCH_MODEL : (ALL_MODELS[0] ?? ""),
+);
 
 function modelTier(model: string): "premium" | "standard" | "fast" {
   return getModelTier(model);
@@ -38,6 +44,16 @@ const uniqueModelCount = computed(() => new Set(store.agents.map((a) => a.model)
 const premiumAgentCount = computed(
   () => store.agents.filter((a: AgentDefinition) => PREMIUM_MODELS.includes(a.model)).length,
 );
+// Sum of premium-request weight across all agents — informational stat that
+// reflects "cost shape" without nudging towards more expensive models.
+const totalPremiumWeight = computed(() => {
+  let total = 0;
+  for (const agent of store.agents) {
+    const def = getModelsByTier("premium").find((m) => m.id === agent.model);
+    if (def) total += def.premiumRequests;
+  }
+  return Number(total.toFixed(2));
+});
 </script>
 
 <template>
@@ -57,14 +73,14 @@ const premiumAgentCount = computed(
         label-style="uppercase"
       />
       <StatCard
-        :value="premiumAgentCount"
-        label="Premium Agents"
+        :value="`${premiumAgentCount} / ${store.agents.length}`"
+        label="On Premium Models"
         color="warning"
         label-style="uppercase"
       />
       <StatCard
-        :value="ALL_MODELS.length"
-        label="Models Available"
+        :value="totalPremiumWeight"
+        label="Total Premium Weight"
         color="success"
         label-style="uppercase"
       />
@@ -136,16 +152,6 @@ const premiumAgentCount = computed(
               <option v-for="m in FAST_MODELS" :key="m" :value="m">{{ m }}</option>
             </optgroup>
           </select>
-
-          <button
-            v-if="modelTier(agentModels[agent.filePath] ?? agent.model) !== 'premium'"
-            class="btn-upgrade"
-            :disabled="store.saving"
-            @click="upgradeAgent(agent)"
-          >
-            ⬆ Upgrade
-          </button>
-          <span v-else class="premium-active-badge">✓ Premium</span>
           <Transition name="banner">
             <span v-if="autoSavedAgent === agent.filePath" class="auto-saved-hint">(auto-saved)</span>
           </Transition>
@@ -157,13 +163,29 @@ const premiumAgentCount = computed(
 
     <!-- Batch Actions -->
     <div v-if="store.agents.length" class="batch-actions">
-      <span class="batch-label">Batch action:</span>
-      <button
-        class="btn-gradient"
-        :disabled="store.saving || batchUpgrading"
-        @click="upgradeAllToOpus"
+      <span class="batch-label">Set all agents to:</span>
+      <select
+        v-model="batchTargetModel"
+        class="form-input batch-model-select"
+        :disabled="store.saving || batchApplying"
+        aria-label="Batch target model"
       >
-        {{ batchUpgrading ? 'Upgrading…' : '⬆ Upgrade All to Opus 4.6' }}
+        <optgroup label="Premium">
+          <option v-for="m in PREMIUM_MODELS" :key="m" :value="m">{{ m }}</option>
+        </optgroup>
+        <optgroup label="Standard">
+          <option v-for="m in STANDARD_MODELS" :key="m" :value="m">{{ m }}</option>
+        </optgroup>
+        <optgroup label="Fast / Cheap">
+          <option v-for="m in FAST_MODELS" :key="m" :value="m">{{ m }}</option>
+        </optgroup>
+      </select>
+      <button
+        class="btn btn-sm"
+        :disabled="store.saving || batchApplying || !batchTargetModel"
+        @click="setAllAgentsToModel(batchTargetModel)"
+      >
+        {{ batchApplying ? 'Applying…' : 'Apply' }}
       </button>
       <button
         class="btn btn-sm"

--- a/apps/desktop/src/components/configInjector/ConfigInjectorGlobalTab.vue
+++ b/apps/desktop/src/components/configInjector/ConfigInjectorGlobalTab.vue
@@ -15,6 +15,8 @@ const {
   removeFolder,
   configDiffLines,
   hasConfigChanges,
+  configParseError,
+  configSettingsPath,
   handleSaveGlobalConfig,
 } = useConfigInjectorContext();
 
@@ -26,6 +28,18 @@ const FAST_MODELS = getModelsByTier("fast").map((m) => m.id);
 <template>
   <div class="tab-panel">
     <div class="global-layout">
+      <!-- Parse-error banner: surfaced when ~/.copilot/{config,settings}.json
+           cannot be parsed. Saving is gated until the underlying file is
+           fixed so we never silently overwrite invalid user data. -->
+      <div v-if="configParseError" class="config-parse-error" role="alert">
+        <strong>⚠️ Copilot settings file could not be parsed.</strong>
+        <p>{{ configParseError }}</p>
+        <p v-if="configSettingsPath" class="config-parse-error__hint">
+          Edit <code>{{ configSettingsPath }}</code> to fix the syntax, then reload.
+          Saving is disabled to avoid clobbering existing data.
+        </p>
+      </div>
+
       <!-- Config Form -->
       <div class="config-form">
         <!-- Default Model -->
@@ -119,7 +133,7 @@ const FAST_MODELS = getModelsByTier("fast").map((m) => m.id);
         <!-- Save Button -->
         <button
           class="btn btn-primary"
-          :disabled="store.saving || !hasConfigChanges"
+          :disabled="store.saving || !hasConfigChanges || !!configParseError"
           @click="handleSaveGlobalConfig"
         >
           {{ store.saving ? 'Saving…' : '💾 Save Config' }}

--- a/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
+++ b/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
@@ -57,7 +57,9 @@ function makeCtx(overrides: Partial<UseConfigInjectorReturn> = {}): UseConfigInj
         model: "claude-sonnet-4.5",
         reasoningEffort: "medium",
         trustedFolders: [],
+        disabledSkills: [],
         raw: {},
+        settingsPath: "/home/user/.copilot/settings.json",
       } as CopilotConfig,
       versions: [
         {

--- a/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
+++ b/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
@@ -105,9 +105,9 @@ function makeCtx(overrides: Partial<UseConfigInjectorReturn> = {}): UseConfigInj
     autoSavedAgent: ref<string | null>(null),
     agentModels: ref<Record<string, string>>({ [agent.filePath]: agent.model }),
     onAgentModelSelect: vi.fn(),
-    upgradeAgent: vi.fn(),
-    batchUpgrading: ref(false),
-    upgradeAllToOpus: vi.fn(),
+    setAgentModel: vi.fn(),
+    batchApplying: ref(false),
+    setAllAgentsToModel: vi.fn(),
     resetAllDefaults: vi.fn(),
     editModel: ref("claude-sonnet-4.5"),
     editReasoningEffort: ref("medium"),
@@ -166,11 +166,13 @@ describe("ConfigInjectorAgentsTab", () => {
     expect(wrapper.text()).toContain("explore");
   });
 
-  it("invokes upgradeAllToOpus when batch button clicked", async () => {
+  it("invokes setAllAgentsToModel when batch Apply button clicked", async () => {
     const ctx = makeCtx();
     const wrapper = mount(wrap(ConfigInjectorAgentsTab, ctx));
-    await wrapper.find(".btn-gradient").trigger("click");
-    expect(ctx.upgradeAllToOpus).toHaveBeenCalled();
+    // Pick the Apply button — it's the first non-select button inside batch-actions.
+    const buttons = wrapper.find(".batch-actions").findAll("button");
+    await buttons[0]!.trigger("click");
+    expect(ctx.setAllAgentsToModel).toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
+++ b/apps/desktop/src/components/configInjector/__tests__/ConfigInjectorChildren.test.ts
@@ -161,7 +161,10 @@ describe("ConfigInjectorAgentsTab", () => {
     const ctx = makeCtx();
     const wrapper = mount(wrap(ConfigInjectorAgentsTab, ctx));
     expect(wrapper.findAll(".agent-card")).toHaveLength(1);
-    expect(wrapper.findAll(".stat-grid > *")).toHaveLength(4);
+    // Three stat cards: Agent Definitions / Unique Models / On Premium Models.
+    // The previous fourth card (Total Premium Weight) was removed because it
+    // conflated agent count with billing units and didn't drive any decision.
+    expect(wrapper.findAll(".stat-grid > *")).toHaveLength(3);
     expect(wrapper.find(".batch-actions").exists()).toBe(true);
     expect(wrapper.text()).toContain("explore");
   });

--- a/apps/desktop/src/composables/__tests__/useConfigInjector.test.ts
+++ b/apps/desktop/src/composables/__tests__/useConfigInjector.test.ts
@@ -163,7 +163,9 @@ describe("useConfigInjector", () => {
       model: "claude-sonnet-4.5",
       reasoningEffort: "high",
       trustedFolders: ["/a", "/b"],
+      disabledSkills: [],
       raw: { showReasoning: true, renderMarkdown: false },
+      settingsPath: "/home/user/.copilot/settings.json",
     } as CopilotConfig;
     const { api, wrapper } = harness();
     api.syncGlobalFields();

--- a/apps/desktop/src/composables/useConfigInjector.ts
+++ b/apps/desktop/src/composables/useConfigInjector.ts
@@ -1,6 +1,5 @@
 import { previewBackupRestore } from "@tracepilot/client";
 import type { AgentDefinition } from "@tracepilot/types";
-import { DEFAULT_PREMIUM_MODEL_ID } from "@tracepilot/types";
 import { normalizePath, useToast } from "@tracepilot/ui";
 import { computed, type InjectionKey, inject, onMounted, reactive, ref, watch } from "vue";
 import { useConfigInjectorStore } from "@/stores/configInjector";
@@ -88,23 +87,23 @@ export function useConfigInjector() {
     }
   }
 
-  async function upgradeAgent(agent: AgentDefinition) {
-    agentModels.value[agent.filePath] = DEFAULT_PREMIUM_MODEL_ID;
-    await handleModelChange(agent, DEFAULT_PREMIUM_MODEL_ID);
+  async function setAgentModel(agent: AgentDefinition, modelId: string) {
+    agentModels.value[agent.filePath] = modelId;
+    await handleModelChange(agent, modelId);
   }
 
-  const batchUpgrading = ref(false);
+  const batchApplying = ref(false);
 
-  async function upgradeAllToOpus() {
-    batchUpgrading.value = true;
+  async function setAllAgentsToModel(modelId: string) {
+    batchApplying.value = true;
     try {
-      const toUpgrade = store.agents.filter((a) => a.model !== DEFAULT_PREMIUM_MODEL_ID);
-      for (const agent of toUpgrade) {
-        agentModels.value[agent.filePath] = DEFAULT_PREMIUM_MODEL_ID;
-        await handleModelChange(agent, DEFAULT_PREMIUM_MODEL_ID);
+      const toChange = store.agents.filter((a) => a.model !== modelId);
+      for (const agent of toChange) {
+        agentModels.value[agent.filePath] = modelId;
+        await handleModelChange(agent, modelId);
       }
     } finally {
-      batchUpgrading.value = false;
+      batchApplying.value = false;
     }
   }
 
@@ -359,9 +358,9 @@ export function useConfigInjector() {
     // agent model state
     agentModels,
     onAgentModelSelect,
-    upgradeAgent,
-    batchUpgrading,
-    upgradeAllToOpus,
+    setAgentModel,
+    batchApplying,
+    setAllAgentsToModel,
     resetAllDefaults,
     // global config
     editModel,

--- a/apps/desktop/src/composables/useConfigInjector.ts
+++ b/apps/desktop/src/composables/useConfigInjector.ts
@@ -129,9 +129,10 @@ export function useConfigInjector() {
       editModel.value = store.copilotConfig.model ?? "";
       editReasoningEffort.value = store.copilotConfig.reasoningEffort ?? "";
       editTrustedFolders.value = [...(store.copilotConfig.trustedFolders ?? [])];
+      // Prefer typed fields; fall back to `raw` for older backend versions.
       const raw = store.copilotConfig.raw ?? {};
-      editShowReasoning.value = Boolean(raw.showReasoning);
-      editRenderMarkdown.value = raw.renderMarkdown !== false;
+      editShowReasoning.value = store.copilotConfig.showReasoning ?? Boolean(raw.showReasoning);
+      editRenderMarkdown.value = store.copilotConfig.renderMarkdown ?? raw.renderMarkdown !== false;
     }
   }
 
@@ -175,7 +176,15 @@ export function useConfigInjector() {
 
   const hasConfigChanges = computed(() => configDiffLines.value.left.some((l) => l.changed));
 
+  /**
+   * Surfaces backend-reported parse failures of `~/.copilot/{config,settings}.json`.
+   * When set, the UI should show a banner and gate destructive operations.
+   */
+  const configParseError = computed(() => store.copilotConfig?.parseError ?? null);
+  const configSettingsPath = computed(() => store.copilotConfig?.settingsPath ?? "");
+
   function handleSaveGlobalConfig() {
+    if (configParseError.value) return;
     store.saveGlobalConfig({
       model: editModel.value,
       reasoningEffort: editReasoningEffort.value,
@@ -213,6 +222,10 @@ export function useConfigInjector() {
         files.push({
           label: "📋 Global Config (config.json)",
           path: `${copilotHome}${sep}config.json`,
+        });
+        files.push({
+          label: "⚙️ User Settings (settings.json)",
+          path: `${copilotHome}${sep}settings.json`,
         });
       }
     }
@@ -362,6 +375,8 @@ export function useConfigInjector() {
     removeFolder,
     configDiffLines,
     hasConfigChanges,
+    configParseError,
+    configSettingsPath,
     handleSaveGlobalConfig,
     // migration
     migrationFrom,

--- a/apps/desktop/src/styles/features/config-injector.css
+++ b/apps/desktop/src/styles/features/config-injector.css
@@ -295,43 +295,9 @@
   font-size: 0.8125rem;
 }
 
-.btn-upgrade {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 12px;
+.batch-model-select {
+  min-width: 180px;
   font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--text-inverse);
-  background: linear-gradient(135deg, var(--done-emphasis), var(--done-fg));
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: filter var(--transition-fast);
-}
-
-.btn-upgrade:hover:not(:disabled) {
-  filter: brightness(1.15);
-}
-
-.btn-upgrade:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.premium-active-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--done-fg);
-  background: var(--done-subtle);
-  border: 1px solid var(--done-muted);
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
 }
 
 /* ── Batch Actions ── */

--- a/apps/desktop/src/styles/features/config-injector.css
+++ b/apps/desktop/src/styles/features/config-injector.css
@@ -296,7 +296,10 @@
 }
 
 .batch-model-select {
-  min-width: 180px;
+  flex: 0 0 auto;
+  width: 200px;
+  max-width: 220px;
+  min-width: 0;
   font-size: 0.8125rem;
 }
 

--- a/apps/desktop/src/styles/features/config-injector.css
+++ b/apps/desktop/src/styles/features/config-injector.css
@@ -385,6 +385,30 @@
   gap: 24px;
 }
 
+.config-parse-error {
+  border: 1px solid var(--color-danger, #c0392b);
+  background: var(--color-danger-bg, rgba(192, 57, 43, 0.08));
+  color: var(--color-danger-text, #c0392b);
+  padding: 12px 14px;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.config-parse-error code {
+  font-size: 0.75rem;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.config-parse-error__hint {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
 .config-form {
   display: flex;
   flex-direction: column;

--- a/crates/tracepilot-orchestrator/src/config_injector.rs
+++ b/crates/tracepilot-orchestrator/src/config_injector.rs
@@ -1,7 +1,20 @@
 //! Copilot CLI config injection and management.
+//!
+//! Copilot CLI history note: prior to 2026-04 user settings (model,
+//! reasoningEffort, trustedFolders, …) lived in `~/.copilot/config.json`. From
+//! 2026-04 onward user settings moved to `~/.copilot/settings.json` and
+//! `config.json` became internal CLI state (now prefixed with `// …` comments
+//! and therefore not valid JSON).
+//!
+//! `read_copilot_config` reads both files and merges them, tolerating `//`
+//! line comments, so TracePilot works against either layout. Writes always
+//! target `settings.json` (the new location); we never modify `config.json`.
+
+mod copilot_config;
+pub use copilot_config::{CONFIG_FILE, SETTINGS_FILE, read_copilot_config, write_copilot_config};
 
 use crate::error::{OrchestratorError, Result};
-use crate::types::{AgentDefinition, BackupDiffPreview, BackupEntry, ConfigDiff, CopilotConfig};
+use crate::types::{AgentDefinition, BackupDiffPreview, BackupEntry, ConfigDiff};
 use std::path::{Path, PathBuf};
 use tracepilot_core::utils::backup::BackupStore;
 
@@ -30,40 +43,6 @@ pub fn read_agent_definitions(version_dir: &Path) -> Result<Vec<AgentDefinition>
     Ok(agents)
 }
 
-/// Read the global Copilot CLI config file.
-pub fn read_copilot_config(copilot_home: &Path) -> Result<CopilotConfig> {
-    let config_path = copilot_home.join("config.json");
-    if !config_path.exists() {
-        return Ok(CopilotConfig {
-            model: None,
-            reasoning_effort: None,
-            trusted_folders: Vec::new(),
-            raw: serde_json::Value::Object(serde_json::Map::new()),
-        });
-    }
-
-    let content = std::fs::read_to_string(&config_path)?;
-    let raw: serde_json::Value = serde_json::from_str(&content)?;
-
-    Ok(CopilotConfig {
-        model: raw.get("model").and_then(|v| v.as_str()).map(String::from),
-        reasoning_effort: raw
-            .get("reasoningEffort")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        trusted_folders: raw
-            .get("trustedFolders")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        raw,
-    })
-}
-
 /// Write an updated agent definition YAML to disk.
 /// Uses atomic write (write to temp then rename) for safety.
 pub fn write_agent_definition(path: &Path, yaml_content: &str) -> Result<()> {
@@ -81,17 +60,6 @@ pub fn write_agent_definition(path: &Path, yaml_content: &str) -> Result<()> {
 
     std::fs::write(&temp_path, yaml_content)?;
     std::fs::rename(&temp_path, path)?;
-    Ok(())
-}
-
-/// Write the global Copilot config.json file.
-pub fn write_copilot_config(copilot_home: &Path, config: &serde_json::Value) -> Result<()> {
-    let config_path = copilot_home.join("config.json");
-    let temp_path = copilot_home.join(".config.json.tmp");
-
-    let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(&temp_path, &content)?;
-    std::fs::rename(&temp_path, &config_path)?;
     Ok(())
 }
 

--- a/crates/tracepilot-orchestrator/src/config_injector/copilot_config.rs
+++ b/crates/tracepilot-orchestrator/src/config_injector/copilot_config.rs
@@ -1,0 +1,346 @@
+//! Copilot CLI user-settings I/O.
+//!
+//! Copilot CLI history (2026-04): user settings moved from
+//! `~/.copilot/config.json` into `~/.copilot/settings.json`. `config.json`
+//! is now CLI-managed internal state and begins with `//` line comments,
+//! which are not valid JSON.
+//!
+//! `read_copilot_config` reads BOTH files (settings.json wins on conflict)
+//! and tolerates `//` comments. Writes always target `settings.json` —
+//! `config.json` is never modified.
+
+use std::path::Path;
+
+use crate::error::{OrchestratorError, Result};
+use crate::types::CopilotConfig;
+
+/// Name of the user-settings file introduced by Copilot CLI in 2026-04.
+/// Older versions kept user settings in `config.json`.
+pub const SETTINGS_FILE: &str = "settings.json";
+pub const CONFIG_FILE: &str = "config.json";
+
+/// Keys that TracePilot considers user-editable. These are the only keys we
+/// will write into `settings.json` from the global config tab. Everything
+/// else (loggedInUsers, askedSetupTerminals, firstLaunchAt, …) is preserved
+/// untouched by merging on top of the existing file.
+const USER_EDITABLE_KEYS: &[&str] = &[
+    "model",
+    "reasoningEffort",
+    "showReasoning",
+    "renderMarkdown",
+    "trustedFolders",
+    "disabledSkills",
+];
+
+/// Strip full-line `//` comments from a JSON-with-comments document.
+///
+/// Recent Copilot CLI versions prepend a `// User settings belong in
+/// settings.json.` banner to `config.json`, which is not valid JSON. We only
+/// strip lines whose first non-whitespace characters are `//` to keep the
+/// transformation conservative — string contents are never touched because
+/// JSON strings cannot legally start a line outside of an object/array.
+fn strip_jsonc_line_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for line in input.split_inclusive('\n') {
+        if line.trim_start().starts_with("//") {
+            // Preserve the trailing newline so line numbers in any
+            // downstream parse error remain accurate.
+            if line.ends_with('\n') {
+                out.push('\n');
+            }
+        } else {
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+/// Parse a Copilot config/settings file from disk, tolerating `//` line
+/// comments. Returns `Ok(None)` if the file does not exist, and an
+/// `Err(message)` with file context if the file exists but cannot be parsed.
+fn read_json_file(path: &Path) -> std::result::Result<Option<serde_json::Value>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    let cleaned = strip_jsonc_line_comments(&raw);
+    if cleaned.trim().is_empty() {
+        return Ok(Some(serde_json::Value::Object(serde_json::Map::new())));
+    }
+    serde_json::from_str::<serde_json::Value>(&cleaned)
+        .map(Some)
+        .map_err(|e| format!("Failed to parse {} as JSON: {}", path.display(), e))
+}
+
+fn merge_objects(
+    base: &mut serde_json::Map<String, serde_json::Value>,
+    overlay: &serde_json::Value,
+) {
+    if let Some(obj) = overlay.as_object() {
+        for (k, v) in obj {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+}
+
+/// Read the global Copilot CLI config, merging `settings.json` (preferred)
+/// on top of `config.json` (legacy).
+///
+/// On parse failure of either file the function does NOT error — it returns
+/// a `CopilotConfig` with `parse_error` populated, allowing the UI to
+/// surface a banner and disable destructive operations rather than crashing
+/// with an opaque "expected value at line 1 column 1" message.
+pub fn read_copilot_config(copilot_home: &Path) -> Result<CopilotConfig> {
+    let settings_path = copilot_home.join(SETTINGS_FILE);
+    let config_path = copilot_home.join(CONFIG_FILE);
+    let settings_path_str = settings_path.to_string_lossy().to_string();
+
+    let mut errors: Vec<String> = Vec::new();
+    let config_value = match read_json_file(&config_path) {
+        Ok(v) => v,
+        Err(msg) => {
+            errors.push(msg);
+            None
+        }
+    };
+    let settings_value = match read_json_file(&settings_path) {
+        Ok(v) => v,
+        Err(msg) => {
+            errors.push(msg);
+            None
+        }
+    };
+
+    // Merge config.json (legacy) under settings.json (preferred).
+    let mut merged = serde_json::Map::new();
+    if let Some(v) = config_value.as_ref() {
+        merge_objects(&mut merged, v);
+    }
+    if let Some(v) = settings_value.as_ref() {
+        merge_objects(&mut merged, v);
+    }
+    let raw = serde_json::Value::Object(merged);
+
+    let parse_error = if errors.is_empty() {
+        None
+    } else {
+        Some(errors.join("; "))
+    };
+
+    Ok(CopilotConfig {
+        model: raw.get("model").and_then(|v| v.as_str()).map(String::from),
+        reasoning_effort: raw
+            .get("reasoningEffort")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        show_reasoning: raw.get("showReasoning").and_then(|v| v.as_bool()),
+        render_markdown: raw.get("renderMarkdown").and_then(|v| v.as_bool()),
+        disabled_skills: raw
+            .get("disabledSkills")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        trusted_folders: raw
+            .get("trustedFolders")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        raw,
+        settings_path: settings_path_str,
+        parse_error,
+    })
+}
+
+/// Write the user-editable subset of Copilot config to `settings.json`.
+///
+/// Behaviour:
+/// * Preserves any keys we don't manage (loggedInUsers, askedSetupTerminals,
+///   firstLaunchAt, …) by reading the existing file and merging.
+/// * Refuses to write if `settings.json` exists but is unparseable —
+///   writing would silently destroy the user's data. The caller should
+///   ensure `parse_error` is clear before invoking save.
+/// * Atomic via temp-file + rename.
+pub fn write_copilot_config(copilot_home: &Path, config: &serde_json::Value) -> Result<()> {
+    let settings_path = copilot_home.join(SETTINGS_FILE);
+    let temp_path = copilot_home.join(format!(".{}.tmp", SETTINGS_FILE));
+
+    // Load the existing settings.json so unknown keys survive the
+    // round-trip. If it's missing we start from `{}`. If it's present but
+    // unparseable we refuse to write rather than clobbering user data.
+    let existing = match read_json_file(&settings_path) {
+        Ok(Some(v)) => v,
+        Ok(None) => serde_json::Value::Object(serde_json::Map::new()),
+        Err(msg) => {
+            return Err(OrchestratorError::Config(format!(
+                "Refusing to write Copilot settings: {}",
+                msg
+            )));
+        }
+    };
+
+    let incoming = config.as_object().ok_or_else(|| {
+        OrchestratorError::Config("Copilot settings payload must be a JSON object".into())
+    })?;
+
+    let mut merged = existing.as_object().cloned().unwrap_or_default();
+    for (k, v) in incoming {
+        if !USER_EDITABLE_KEYS.contains(&k.as_str()) {
+            // Silently ignore keys outside the allow-list so the frontend
+            // can never accidentally overwrite internal state.
+            continue;
+        }
+        // Treat null / empty-string as "unset": remove rather than persisting.
+        if v.is_null() {
+            merged.remove(k);
+            continue;
+        }
+        if let Some(s) = v.as_str()
+            && s.is_empty()
+        {
+            merged.remove(k);
+            continue;
+        }
+        merged.insert(k.clone(), v.clone());
+    }
+
+    let content = serde_json::to_string_pretty(&serde_json::Value::Object(merged))?;
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&temp_path, &content)?;
+    std::fs::rename(&temp_path, &settings_path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn strip_jsonc_drops_full_line_comments() {
+        let input = "// banner\n// second\n{\n  \"a\": 1\n}\n";
+        let out = strip_jsonc_line_comments(input);
+        // Comments removed but newlines preserved so error line numbers match.
+        assert_eq!(out, "\n\n{\n  \"a\": 1\n}\n");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["a"], 1);
+    }
+
+    #[test]
+    fn read_copilot_config_handles_jsonc_config_json() {
+        let dir = tempfile::tempdir().unwrap();
+        // Reproduces the new CLI's `config.json` shape (leading `//` lines).
+        fs::write(
+            dir.path().join("config.json"),
+            "// User settings belong in settings.json.\n// This file is managed automatically.\n{\n  \"trustedFolders\": [\"C:\\\\git\"]\n}\n",
+        )
+        .unwrap();
+        let cfg = read_copilot_config(dir.path()).unwrap();
+        assert!(cfg.parse_error.is_none(), "got: {:?}", cfg.parse_error);
+        assert_eq!(cfg.trusted_folders, vec!["C:\\git".to_string()]);
+    }
+
+    #[test]
+    fn read_copilot_config_prefers_settings_over_config() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("config.json"),
+            "{\"model\":\"old-model\",\"trustedFolders\":[\"/a\"]}",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("settings.json"),
+            "{\"model\":\"new-model\",\"showReasoning\":true,\"renderMarkdown\":false}",
+        )
+        .unwrap();
+        let cfg = read_copilot_config(dir.path()).unwrap();
+        assert_eq!(cfg.model.as_deref(), Some("new-model"));
+        assert_eq!(cfg.show_reasoning, Some(true));
+        assert_eq!(cfg.render_markdown, Some(false));
+        // Legacy key from config.json still surfaces when settings.json
+        // doesn't override it.
+        assert_eq!(cfg.trusted_folders, vec!["/a".to_string()]);
+    }
+
+    #[test]
+    fn read_copilot_config_reports_parse_error_instead_of_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("settings.json"), "{not-json").unwrap();
+        let cfg = read_copilot_config(dir.path()).unwrap();
+        let err = cfg.parse_error.expect("should populate parse_error");
+        assert!(err.contains("settings.json"), "got: {err}");
+    }
+
+    #[test]
+    fn write_copilot_config_writes_to_settings_json_and_preserves_unknown_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-existing settings with unknown keys we must not clobber.
+        fs::write(
+            dir.path().join("settings.json"),
+            "{\"loggedInUsers\":[{\"login\":\"alice\"}],\"model\":\"old\"}",
+        )
+        .unwrap();
+        let payload = serde_json::json!({
+            "model": "claude-opus-4.7",
+            "showReasoning": true,
+            "renderMarkdown": true,
+            "trustedFolders": ["/a", "/b"],
+            // not in allow-list — should be ignored:
+            "loggedInUsers": [],
+        });
+        write_copilot_config(dir.path(), &payload).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(written["model"], "claude-opus-4.7");
+        assert_eq!(written["showReasoning"], true);
+        assert_eq!(written["trustedFolders"], serde_json::json!(["/a", "/b"]));
+        // Unknown key preserved untouched.
+        assert_eq!(written["loggedInUsers"][0]["login"], "alice");
+    }
+
+    #[test]
+    fn write_copilot_config_refuses_when_existing_settings_unparseable() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("settings.json"), "{not-json").unwrap();
+        let payload = serde_json::json!({"model": "x"});
+        let err = write_copilot_config(dir.path(), &payload).unwrap_err();
+        assert!(matches!(err, OrchestratorError::Config(_)));
+        // File untouched.
+        assert_eq!(
+            fs::read_to_string(dir.path().join("settings.json")).unwrap(),
+            "{not-json"
+        );
+    }
+
+    #[test]
+    fn write_copilot_config_unsets_empty_string_values() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("settings.json"),
+            "{\"model\":\"old\",\"reasoningEffort\":\"high\"}",
+        )
+        .unwrap();
+        let payload = serde_json::json!({"model": "", "reasoningEffort": "low"});
+        write_copilot_config(dir.path(), &payload).unwrap();
+        let written: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert!(
+            written.get("model").is_none(),
+            "empty string should clear key"
+        );
+        assert_eq!(written["reasoningEffort"], "low");
+    }
+}

--- a/crates/tracepilot-orchestrator/src/models.rs
+++ b/crates/tracepilot-orchestrator/src/models.rs
@@ -58,6 +58,15 @@ pub const MODEL_REGISTRY: &[ModelMetadata] = &[
         premium_requests: 7.5,
     },
     ModelMetadata {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        tier: "premium",
+        input_per_m: 5.0,
+        cached_input_per_m: 0.5,
+        output_per_m: 30.0,
+        premium_requests: 7.5,
+    },
+    ModelMetadata {
         id: "claude-opus-4.6",
         name: "Claude Opus 4.6",
         tier: "premium",
@@ -242,7 +251,7 @@ mod tests {
         for model in MODEL_REGISTRY {
             assert!(ids.insert(model.id), "duplicate model id: {}", model.id);
         }
-        assert_eq!(MODEL_REGISTRY.len(), 20);
+        assert_eq!(MODEL_REGISTRY.len(), 21);
     }
 
     #[test]

--- a/crates/tracepilot-orchestrator/src/types.rs
+++ b/crates/tracepilot-orchestrator/src/types.rs
@@ -139,8 +139,19 @@ pub struct AgentDefinition {
 pub struct CopilotConfig {
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
+    pub show_reasoning: Option<bool>,
+    pub render_markdown: Option<bool>,
+    pub disabled_skills: Vec<String>,
     pub trusted_folders: Vec<String>,
+    /// Merged JSON view (settings.json on top of config.json). Retained for
+    /// fields TracePilot does not yet model explicitly.
     pub raw: serde_json::Value,
+    /// Path of the user-settings file we read/write (~/.copilot/settings.json
+    /// for newer CLI versions, ~/.copilot/config.json for legacy fallback).
+    pub settings_path: String,
+    /// Set when `settings.json` and/or `config.json` could not be parsed.
+    /// Frontend should surface this and disable destructive writes.
+    pub parse_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/copilot-sdk-models-fetch-findings.md
+++ b/docs/copilot-sdk-models-fetch-findings.md
@@ -1,0 +1,211 @@
+# Copilot SDK Model-Catalog Fetch — Findings & Lessons Learned
+
+**Status:** Shelved. All experimental code reverted on branch `Matt/Config_Update`.
+**Archived branch tag:** `sdk-experiment-archive` (kept locally for reference; can be
+recreated from the shas listed below if needed).
+
+## TL;DR
+
+Fetching the live Copilot model catalog through the Rust `copilot-sdk` crate is
+attractive but currently not worth the implementation cost. Two upstream issues
+combine to make every "elegant" approach degenerate into either silent data loss
+or a maze of bypass code:
+
+1. **Strict camelCase deserialiser, hybrid snake_case payload.** `ModelInfo`
+   (and its nested `ModelLimits`, `ModelCapabilities`, …) is annotated with
+   `#[serde(rename_all = "camelCase")]` at every level, but the Copilot CLI
+   actually emits *hybrid* JSON — the `capabilities.limits` block (and a few
+   others) is snake_case. Result: `max_context_window_tokens` and friends
+   silently fall back to `Default` and the UI shows a blank Context column.
+2. **Shape drift between CLI versions.** Even when we bypassed the SDK
+   deserialiser and parsed the raw JSON ourselves, at least one CLI version
+   delivered `capabilities.supports.vision` as an array of supported media
+   types instead of a boolean (`["image/png", "image/jpeg"]`), tripping our
+   strict parser with `invalid type: sequence, expected a boolean` and
+   forcing the catalog UI to fall back to its stale on-disk cache with a
+   scary "SDK unavailable" banner.
+
+We attempted three escalating workarounds and abandoned all three. This doc
+captures what was tried, what worked, what didn't, and what a future
+implementation should consider before reopening the work.
+
+## What we shipped (and reverted)
+
+The reverted work spanned six commits on `Matt/Config_Update`:
+
+| sha (archived) | Scope |
+| --- | --- |
+| `a17458be` | Plumb full SDK `ModelInfo` (multiplier, policy, capabilities) through `BridgeModelInfo` so the orchestrator could expose more than just the id list. |
+| `3ada0015` | New `model_catalog` module — pure 3-pass merge of (a) live SDK results, (b) static `MODEL_REGISTRY`, and (c) on-disk cache, with a `MergedSdkStatus` / `MergedFreshness` / `isVerifiedActive` taxonomy. |
+| `2f47d309` | Frontend "Model Explorer" view backed by the merged catalog (Tauri command + Vue panel). |
+| `d50e7efe` | First bypass: when running in TCP / `--ui-server` mode, skip the SDK's typed deserialisation and call `models.list` over raw JSON-RPC, parsing the snake_case fields ourselves. |
+| `347d4852` | Second bypass: same idea for the (default) stdio mode by spawning a one-shot parallel `copilot --server --stdio` subprocess just for `models.list`. |
+| `4dfb06d9` | Defensive parser: switched the raw model fields from strictly-typed structs to `serde_json::Value` walks so unexpected shapes (the `vision: [..]` case) silently degrade instead of aborting the catalog refresh. |
+
+Everything was kept behind a fallback chain (live SDK → cache → static
+`MODEL_REGISTRY`), so the UI never went fully dark. But the cumulative
+complexity — three RPC paths, a merge engine, a verified/unverified gate, a
+cache file format, and ~200 lines of Windows `.cmd`→node-loader resolution
+re-implemented because the SDK keeps it private — was disproportionate to
+the value (a Context column and a few capability badges).
+
+## What was actually wrong
+
+### 1. The upstream SDK's `ModelInfo` deserialiser is broken
+
+```rust
+// copilot-sdk-rust/.../types.rs (rev 2946ba1)
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelLimits {
+    pub max_prompt_tokens: Option<u32>,
+    pub max_context_window_tokens: Option<u32>,
+    // …
+}
+```
+
+Empirically, the CLI emits:
+
+```json
+"limits": {
+  "max_prompt_tokens": 128000,
+  "max_context_window_tokens": 144000
+}
+```
+
+`#[serde(rename_all = "camelCase")]` rewrites `max_prompt_tokens` →
+`maxPromptTokens` at deserialisation time, so the field is missing from the
+incoming JSON and the `Option<u32>` quietly becomes `None`. There is **no**
+warning anywhere — the SDK call succeeds with empty limits. The same
+mechanism breaks `supports.reasoning_effort`,
+`supported_reasoning_efforts`, `default_reasoning_effort`, etc.
+
+The hybrid is genuinely the API's fault: `capabilities.supports.vision` is
+camelCase-friendly (single-word) and serialises identically either way, but
+multi-word fields under `limits` are snake_case. Other SDKs (the JS one,
+which the CLI itself uses) treat snake_case as the wire format.
+
+### 2. The CLI's response shape is not stable across versions
+
+We have first-hand evidence that the same field can change type between
+versions of `@github/copilot`:
+
+- Version A: `capabilities.supports.vision: true`
+- Version B: `capabilities.supports.vision: ["image/png", "image/jpeg"]`
+
+Whichever form is "more correct" is irrelevant for our purposes — any
+strict mirror of the API will eventually break, and version skew between
+the user's CLI and TracePilot's pinned SDK is *guaranteed* (the CLI
+auto-updates). The SDK's own deserialiser is the worst-case manifestation
+of this fragility.
+
+### 3. None of the SDK's bypass primitives are first-class
+
+The SDK exposes `JsonRpcClient`, `StdioJsonRpcClient`, `CopilotProcess`,
+`StdioTransport`, `find_copilot_cli`, `find_node`, and `is_node_script` as
+public — enough to build a parallel JSON-RPC pipe — but it keeps
+`resolve_cli_command` private. On Windows that function is the only place
+that knows how to turn `copilot.cmd` into a clean `node …\index.js`
+invocation; `cmd /c copilot.cmd` corrupts JSON-RPC framing via pipe
+inheritance issues (per a comment in the SDK source). We had to
+re-implement ~60 lines of resolution logic inside TracePilot just to spawn
+a working subprocess.
+
+The SDK's `copilot_sdk::Client` does not expose its underlying
+`JsonRpcClient` either — there is no way to send a raw method call through
+the bridge's existing connection. Every workaround therefore opens a
+second, parallel CLI process for every catalog refresh (~1–3 s cold-start
+on Windows; observable in the UI).
+
+## What worked
+
+- **Static registry as the source of truth.** `MODEL_REGISTRY` already
+  carries everything we need for pricing, vendor classification, premium
+  weight, and reasoning-effort defaults. The UI does not actually require
+  a live catalog to function — it only enriches the picker.
+- **The merge engine itself.** The `Live | Unavailable` × cache 3-pass merge
+  was clean code and the right approach if/when a usable live source
+  exists. Worth resurrecting wholesale.
+- **Defensive parsing via `serde_json::Value` walks.** When/if we re-attempt
+  the live fetch, *do not* deserialise into named structs. Walk the JSON
+  with field-by-field type coercion so a single shape change in any
+  capability/limit field silently degrades that one field rather than
+  aborting the request.
+- **The on-disk cache (`<app_data>/model-catalog/sdk-models-v1.json`).**
+  Survived multiple iterations and provided a usable fallback every time
+  the live path broke.
+
+## What didn't work (and why)
+
+- **Trusting the SDK's typed `ModelInfo`.** Silent data loss; impossible to
+  detect without comparing against raw JSON. Non-starter.
+- **TCP-only raw RPC bypass.** Worked when reachable, but most users run
+  in default stdio mode — the bypass only helped a niche `--ui-server`
+  cohort.
+- **Stdio raw RPC by spawning a parallel one-shot subprocess.** Functionally
+  correct but expensive: 1–3 s extra per refresh, ~190 lines of
+  Windows-aware spawn code, and *still* tripped on the
+  `vision: [array]` shape change because we hadn't yet made the parser
+  defensive.
+- **A defensive `Value`-walking parser layered on top of the stdio
+  bypass.** Robust against shape drift but the cumulative architecture
+  (3-tier fallback chain + parallel subprocess + custom parser + cache +
+  merge engine + verified/unverified UI taxonomy) is more code than the
+  feature is worth right now.
+
+## Lessons & recommendations for a future attempt
+
+1. **Don't depend on the upstream `ModelInfo` shape at all.** Either parse
+   `serde_json::Value` directly or vendor a permissive snake_case mirror
+   in this repo; never re-deserialise typed SDK structs.
+2. **Get a raw-RPC handle on the SDK's existing connection before
+   adding more processes.** A small upstream PR that exposes
+   `Client::raw_invoke(method, params) -> Value` would obviate the entire
+   parallel-subprocess machinery and is the highest-leverage upstream
+   change. Worth filing.
+3. **Treat the catalog as best-effort metadata, not a primary data
+   source.** The session launcher and config injector should *prefer* the
+   static registry and only consult live data when explicitly requested
+   (e.g. an "active" filter on the Models page). This avoids surfacing
+   transient SDK errors as scary UI states.
+4. **If a live fetch is re-introduced, it must be opt-in and silent on
+   failure** — log a warning, keep using the static registry, and surface
+   the SDK status in a single inconspicuous indicator rather than a
+   full-width banner.
+5. **Pin the empirical wire format with golden-file tests.** Capture a real
+   `models.list` response per supported `@github/copilot` version into
+   `tests/fixtures/` and round-trip it through whatever parser we end up
+   with. This is the only realistic guard against shape drift.
+6. **Don't build a "Model Explorer" view as a separate surface.** The
+   existing Models tab is the right home; adding a parallel view doubled
+   maintenance for no clear UX win during the experiment.
+
+## Out-of-scope but kept
+
+The same branch shipped four unrelated improvements that are *not* part of
+this revert:
+
+- Adapting `ConfigInjector` to the Copilot CLI's `settings.json`
+  migration (separate from internal `config.json`).
+- Adding GPT-5.5 to the static `MODEL_REGISTRY`.
+- Replacing the "Upgrade All to Opus" batch action with a neutral model
+  picker.
+- Capping the batch-model select width and dropping the redundant
+  Total-Premium-Weight stat card.
+
+These have nothing to do with the SDK fetch and remain on the branch.
+
+## References
+
+- Upstream SDK source: `copilot-sdk-rust` rev `2946ba1`,
+  `crates/copilot-sdk/src/types.rs:1217-1226` (the `ModelLimits`
+  rename_all annotation).
+- Local SDK checkout while debugging:
+  `C:\Users\mattt\.cargo\git\checkouts\copilot-sdk-rust-33a5081cb6261a92\2946ba1\`.
+- Cache file inspected during debugging:
+  `<app_data>\dev.tracepilot.app\model-catalog\sdk-models-v1.json`
+  — every model showed `"limits": {}` with the SDK-typed path,
+  populated correctly with the `Value`-walking parser.
+- Related existing notes: `docs/copilot-sdk-deep-dive.md`,
+  `docs/copilot-sdk-rpc-method-bug.md`,
+  `docs/copilot-sdk-integration-evaluation.md`.

--- a/packages/client/src/mock/orchestration.ts
+++ b/packages/client/src/mock/orchestration.ts
@@ -215,8 +215,12 @@ export const ORCHESTRATION_MOCK_DATA: Record<string, unknown> = {
   get_copilot_config: {
     model: "claude-sonnet-4.6",
     reasoningEffort: undefined,
+    showReasoning: true,
+    renderMarkdown: true,
+    disabledSkills: [],
     trustedFolders: ["C:\\git"],
     raw: { model: "claude-sonnet-4.6", trustedFolders: ["C:\\git"] },
+    settingsPath: "C:\\Users\\mock\\.copilot\\settings.json",
   } satisfies CopilotConfig,
 
   list_config_backups: [

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -55,6 +55,15 @@ export const MODEL_REGISTRY: readonly ModelDefinition[] = [
     premiumRequests: 7.5,
   },
   {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    tier: "premium",
+    inputPerM: 5.0,
+    cachedInputPerM: 0.5,
+    outputPerM: 30.0,
+    premiumRequests: 7.5,
+  },
+  {
     id: "claude-opus-4.6",
     name: "Claude Opus 4.6",
     tier: "premium",

--- a/packages/types/src/orchestration.ts
+++ b/packages/types/src/orchestration.ts
@@ -95,8 +95,18 @@ export interface AgentDefinition {
 export interface CopilotConfig {
   model?: string;
   reasoningEffort?: string;
+  showReasoning?: boolean;
+  renderMarkdown?: boolean;
+  disabledSkills: string[];
   trustedFolders: string[];
   raw: Record<string, unknown>;
+  /** Absolute path of the file user settings are written to. */
+  settingsPath: string;
+  /**
+   * Populated when settings.json or config.json could not be parsed. UI
+   * should surface a banner and disable destructive writes when set.
+   */
+  parseError?: string;
 }
 
 export interface BackupEntry {


### PR DESCRIPTION
Bundles four small, related improvements and shelves a larger experiment.

## What's in

- **Copilot CLI `settings.json` migration** — config injector now reads/writes `~/.copilot/settings.json` separately from the internal `config.json`, with defensive validation so a malformed file no longer surfaces as a raw `expected value at line 1 column 1` JSON-parse error.
- **Add GPT-5.5 to the static model registry** — premium request multiplier 7.5x; wholesale ` / .50 cached / ` per 1M tokens. Tests + UI surfaces updated.
- **Replace 'Upgrade All to Opus 4.6' with a neutral 'Update All to …' picker** — defaults to GPT-5.4. Removes the ""upgrade to premium"" framing that read as paid-product upsell.
- **Tighten the config-injector batch bar** — caps the model select width so it stops dominating the row, and drops the redundant 'Total Premium Weight' stat card that conflated agent count with billing units.

## What's shelved (with a writeup)

A multi-commit experiment to fetch the live Copilot model catalog through the Rust `copilot-sdk` crate is reverted on this branch. Findings, what worked, what didn't, and recommendations for a future attempt are captured in [`docs/copilot-sdk-models-fetch-findings.md`](docs/copilot-sdk-models-fetch-findings.md). TL;DR: the upstream `ModelInfo` deserialiser is annotated camelCase but the CLI emits hybrid snake_case, and capability fields drift shape between CLI versions — every workaround degenerated into either silent data loss or a maze of bypass code disproportionate to the value of the live fetch.

The archived branch tag `sdk-experiment-archive` was kept locally for reference.

## Verification

- `cargo build -p tracepilot-orchestrator -p tracepilot-tauri-bindings` ✅
- `pnpm typecheck` (all 7 workspace projects) ✅
- `cargo test` for the touched orchestrator paths ✅
- `pnpm vitest run useModelComparison` ✅