### PR TITLE
🎨 Palette: [a11y improve decorative characters]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-04-26 - [Decorative Characters require ARIA treatment]
+**Learning:** Purely decorative characters (like raw unicode symbols "✕" or decorative SVGs) inside interactive elements (like buttons) must be wrapped with `<span aria-hidden="true">` or `<svg aria-hidden="true">`. This prevents screen readers from announcing them confusingly, even when the parent element has an explicit `aria-label`.
+**Action:** When working on buttons and other interactive elements, ensure any visual icon, svg, or unicode character is marked with `aria-hidden="true"` to provide a clean screen reader experience.

--- a/apps/desktop/src/components/SearchPalette.vue
+++ b/apps/desktop/src/components/SearchPalette.vue
@@ -200,7 +200,7 @@ onUnmounted(() => {
               aria-label="Clear search"
               @click="query = ''"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
             <kbd class="kbd">ESC</kbd>
           </div>

--- a/packages/ui/src/components/ErrorAlert.vue
+++ b/packages/ui/src/components/ErrorAlert.vue
@@ -59,7 +59,7 @@ defineEmits<{
         aria-label="Dismiss"
         @click="$emit('dismiss')"
       >
-        ✕
+        <span aria-hidden="true">✕</span>
       </button>
     </span>
   </div>

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -40,7 +40,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           <slot name="header">
             <h3>{{ title }}</h3>
           </slot>
-          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close">✕</button>
+          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close"><span aria-hidden="true">✕</span></button>
         </div>
         <div class="modal-body">
           <slot />

--- a/packages/ui/src/components/ToastContainer.vue
+++ b/packages/ui/src/components/ToastContainer.vue
@@ -57,7 +57,7 @@ function onAction(action: { label: string; onClick: () => void }, id: string) {
           </button>
         </div>
 
-        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)">✕</button>
+        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)"><span aria-hidden="true">✕</span></button>
 
         <div
           v-if="t.duration > 0"


### PR DESCRIPTION
💡 What: Wrapped bare "✕" characters with `<span aria-hidden="true">` in close, clear, and dismiss buttons across `ModalDialog`, `ToastContainer`, `ErrorAlert`, and `SearchPalette`.
🎯 Why: Screen readers often read out raw unicode characters even when an `aria-label` is present on the parent button. This fix ensures the screen reader relies exclusively on the provided `aria-label` for clear and predictable narration.
📸 Before/After: Visual appearance remains exactly the same.
♿ Accessibility: Improves screen reader announcement clarity for core interactive close/dismiss patterns across the UI.

---
*PR created automatically by Jules for task [10504111680640587820](https://jules.google.com/task/10504111680640587820) started by @MattShelton04*