### PR TITLE
⚡ Bolt: [performance improvement] optimize rusqlite batch insert caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-05-18 - Optimized sqlite batch insertion
+**Learning:** In the `tracepilot-indexer` crate, batch insertion into SQLite with rusqlite recompiled the prepared statement inside a loop. This caused a performance bottleneck when inserting thousands of rows.
+**Action:** When performing `rusqlite` batch operations with chunked data arrays in Rust, explicitly cache the prepared `rusqlite::Statement` object (rather than just the SQL string) for full-sized chunks to avoid the overhead of recompiling the statement inside a loop.

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -83,30 +83,30 @@ where
         return Ok(());
     }
 
-    // All full-sized chunks share the same SQL shape — build it lazily on first
-    // use so sessions with < BATCH_CHUNK_SIZE rows (most analytics tables) pay
-    // zero allocation for the full-chunk string they never use.
-    let mut full_sql: Option<String> = None;
+    // Cache the prepared statement for full-sized chunks to avoid the overhead of
+    // recompiling the statement inside a loop.
+    let mut full_stmt = None;
 
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let partial;
-        let sql: &str = if chunk.len() == BATCH_CHUNK_SIZE {
-            full_sql.get_or_insert_with(|| {
-                build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row)
-            })
-        } else {
-            partial = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
-            &partial
-        };
-
-        let mut stmt = conn.prepare(sql)?;
-
         let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
         for item in chunk {
             to_params(item, &mut params);
         }
 
-        stmt.execute(rusqlite::params_from_iter(params))?;
+        if chunk.len() == BATCH_CHUNK_SIZE {
+            let stmt = if let Some(ref mut s) = full_stmt {
+                s
+            } else {
+                let sql = build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row);
+                full_stmt = Some(conn.prepare(&sql)?);
+                full_stmt.as_mut().unwrap()
+            };
+            stmt.execute(rusqlite::params_from_iter(params))?;
+        } else {
+            let sql = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
+            let mut stmt = conn.prepare(&sql)?;
+            stmt.execute(rusqlite::params_from_iter(params))?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
### 💡 What
Cached the prepared `rusqlite::Statement` directly within the batch loop in `batched_insert` (crates/tracepilot-indexer/src/index_db/batch_insert.rs) instead of just generating the raw SQL string inside the loop body.

### 🎯 Why
When dealing with bulk insert logic across multiple rows, re-preparing the statement using `conn.prepare(sql)` inside a loop requires SQLite to re-compile the query plan for every chunk. By explicitly caching the Statement and directly executing it for fully populated chunks, we amortize this overhead completely, particularly vital since there can be tens of thousands of inserts going on.

### 📊 Impact
Measurable time saved during large scale session writes. This should directly speed up the overall indexing process by removing constant setup overhead for statement plans per batch chunk (~100 items). Benchmarks using `cargo bench -p tracepilot-bench --bench batch_size` and `cargo bench -p tracepilot-bench --bench indexer` confirmed improved iteration stability. 

### 🔬 Measurement
To verify the performance enhancement locally:
```bash
cargo bench -p tracepilot-bench --bench batch_size
cargo bench -p tracepilot-bench --bench indexer
```

---
*PR created automatically by Jules for task [8909838936114751167](https://jules.google.com/task/8909838936114751167) started by @MattShelton04*