### PR TITLE
🎨 Palette: [Add aria-labels to worktree icon buttons]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - Icon-only Button Accessibility
+**Learning:** Icon-only buttons used in lists and detail panels (like those using `.icon-btn` classes for worktree actions) frequently lack explicit `aria-label` attributes, relying solely on `title` tooltips which can result in poor screen reader experiences.
+**Action:** Always verify that components with `title` attributes (or `.icon-btn` classes) also possess an explicit `aria-label` for proper keyboard/screen reader accessibility. Ensure the labels dynamically update if the button's state changes (e.g. dynamic titles like "Lock Worktree" vs "Unlock Worktree").

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
             locked
           </span>
         </div>
-        <button class="icon-btn" @click="emit('close')">
+        <button class="icon-btn" aria-label="Close" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>

--- a/apps/desktop/src/components/worktree/WorktreeList.vue
+++ b/apps/desktop/src/components/worktree/WorktreeList.vue
@@ -149,18 +149,19 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
 
       <!-- Actions -->
       <div class="wt-row-actions" @click.stop>
-        <button class="icon-btn" title="Open Folder" @click="emit('open-explorer', wt.path)">
+        <button class="icon-btn" title="Open Folder" aria-label="Open Folder" @click="emit('open-explorer', wt.path)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
         </button>
-        <button class="icon-btn" title="Open Terminal" @click="emit('open-terminal', wt.path)">
+        <button class="icon-btn" title="Open Terminal" aria-label="Open Terminal" @click="emit('open-terminal', wt.path)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>
         </button>
-        <button class="icon-btn" title="Launch Session Here" @click="emit('navigate-launcher', wt)">
+        <button class="icon-btn" title="Launch Session Here" aria-label="Launch Session Here" @click="emit('navigate-launcher', wt)">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3" /></svg>
         </button>
         <button
           class="icon-btn"
           :title="wt.isMainWorktree ? 'Cannot lock main worktree' : wt.isLocked ? 'Unlock Worktree' : 'Lock Worktree'"
+          :aria-label="wt.isMainWorktree ? 'Cannot lock main worktree' : wt.isLocked ? 'Unlock Worktree' : 'Lock Worktree'"
           :disabled="wt.isMainWorktree"
           @click="wt.isLocked ? emit('unlock', wt) : emit('lock', wt)"
         >
@@ -170,6 +171,7 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
         <button
           class="icon-btn icon-btn--danger"
           :title="wt.isMainWorktree ? 'Cannot remove main worktree' : wt.isLocked ? 'Unlock to remove' : 'Remove'"
+          :aria-label="wt.isMainWorktree ? 'Cannot remove main worktree' : wt.isLocked ? 'Unlock to remove' : 'Remove'"
           :disabled="wt.isMainWorktree || wt.isLocked"
           @click="emit('delete', wt)"
         >


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only action buttons in the `WorktreeList.vue` and `WorktreeDetailPanel.vue` components, mapping them to match their corresponding visible `title` tooltips.
🎯 **Why:** Icon-only buttons relying purely on `title` tooltips lack sufficient context for users relying on screen readers or keyboard navigation. Adding specific `aria-label`s ensures accessibility across the application. 
📸 **Before/After:** Visuals remain completely unchanged; structural HTML is enhanced for screen reader usage. 
♿ **Accessibility:** Screen readers will now explicitly announce the purpose of each button (e.g., "Open Folder", "Launch Session Here", "Lock Worktree") instead of potentially ignoring them or reading generic states. Also dynamically binds the lock and remove aria-labels to respond to the worktree's specific state (e.g. disabled main branches, locked status) to maintain parity with the visible tooltip structure.

---
*PR created automatically by Jules for task [8918032747911473515](https://jules.google.com/task/8918032747911473515) started by @MattShelton04*