### PR TITLE
⚡ Bolt: [performance improvement] optimize batch insert statement compilation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-26 - [Optimize Batch Insert Compilation]
+**Learning:** In `rusqlite` batched inserts chunking large inputs, compiling the exact same SQL placeholder string inside the chunk loop causes measurable overhead because `stmt.execute(...)` does not preserve the cached prepared statement between chunks when dynamically reconstructed via string concatenation, polluting the cache.
+**Action:** Always pre-allocate and cache the prepared `rusqlite::Statement` instance (`conn.prepare()`) outside or lazily inside the loop for full-sized chunks. Fallback to dynamic compilation only for the very last fractional chunk.

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -83,30 +83,30 @@ where
         return Ok(());
     }
 
-    // All full-sized chunks share the same SQL shape — build it lazily on first
-    // use so sessions with < BATCH_CHUNK_SIZE rows (most analytics tables) pay
-    // zero allocation for the full-chunk string they never use.
-    let mut full_sql: Option<String> = None;
+    // Cache the prepared statement for full-sized chunks to avoid recompiling
+    // the statement on every loop iteration. The final smaller chunk uses
+    // a dynamic prepare() to avoid polluting the SQLite statement cache.
+    let mut full_stmt = None;
 
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let partial;
-        let sql: &str = if chunk.len() == BATCH_CHUNK_SIZE {
-            full_sql.get_or_insert_with(|| {
-                build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row)
-            })
-        } else {
-            partial = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
-            &partial
-        };
-
-        let mut stmt = conn.prepare(sql)?;
-
         let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
         for item in chunk {
             to_params(item, &mut params);
         }
 
-        stmt.execute(rusqlite::params_from_iter(params))?;
+        if chunk.len() == BATCH_CHUNK_SIZE {
+            if full_stmt.is_none() {
+                let sql = build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row);
+                full_stmt = Some(conn.prepare(&sql)?);
+            }
+            if let Some(stmt) = full_stmt.as_mut() {
+                stmt.execute(rusqlite::params_from_iter(params))?;
+            }
+        } else {
+            let sql = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
+            let mut stmt = conn.prepare(&sql)?;
+            stmt.execute(rusqlite::params_from_iter(params))?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
💡 What: This PR optimizes the `batched_insert` function in `tracepilot-indexer`. It caches the `rusqlite::Statement` instance rather than the raw SQL string for full-sized chunks during batch inserts. The fallback path for the final chunk still correctly recompiles the statement dynamically based on its variable size to avoid polluting the SQLite cache.

🎯 Why: During `batched_insert`, the inner loop dynamically constructed the SQL string (based on chunk size) and then `conn.prepare(sql)` compiled it. While `full_sql` was cached, `conn.prepare` was repeatedly executed on the same exact SQL string for every full-sized chunk.

📊 Impact: Reduces CPU overhead associated with preparing the identical statement repeatedly, improving throughput during the indexing of large scale session metrics like `search_content`.

🔬 Measurement: Verifiable by executing the benchmark `cargo bench -p tracepilot-bench --bench batch_size`, which measures insert throughput.

---
*PR created automatically by Jules for task [718200125953908024](https://jules.google.com/task/718200125953908024) started by @MattShelton04*