### PR TITLE
fix(sdk): repair live-stream deltas, surface tool partial output, fix popout auto-scroll

### DIFF
--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -160,6 +160,26 @@ const {
 
 const { findToolCallIndex, getArgsSummary } = useConversationSections(() => turns.value);
 
+// Auto-expand in-progress tool calls so users can watch live progress
+// without an extra click. Once added, the key stays in the set across
+// completion (so the panel stays open until the user manually collapses).
+watch(
+  turns,
+  (currentTurns) => {
+    for (const turn of currentTurns) {
+      const calls = turn.toolCalls ?? [];
+      for (const tc of calls) {
+        if (tc.isComplete !== false) continue;
+        const idx = findToolCallIndex(turn, tc);
+        if (idx < 0) continue;
+        const key = `${turn.turnIndex}-${idx}`;
+        if (!expandedToolDetails.has(key)) expandedToolDetails.add(key);
+      }
+    }
+  },
+  { immediate: true, deep: false },
+);
+
 // ─── Scroll ───────────────────────────────────────────────────────
 
 const scrollEl = ref<HTMLElement | null>(null);

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -54,16 +54,19 @@ const liveConversationTurn = computed<ConversationTurn | null>(() => {
   // dedup: we don't depend on bridge ids matching session.jsonl turn ids,
   // and it's evaluated synchronously inside the computed so there's no
   // post-render race when auto-refresh and streaming overlap.
-  if (liveText) {
-    const last = persistedTurns.value[persistedTurns.value.length - 1];
-    const persisted = (last?.assistantMessages ?? [])
-      .map((m) => m.content)
-      .join("")
-      .trim();
-    if (persisted?.startsWith(liveText)) return null;
-  }
-
   const last = persistedTurns.value[persistedTurns.value.length - 1];
+  const persistedAssistant = (last?.assistantMessages ?? [])
+    .map((m) => m.content)
+    .join("")
+    .trim();
+  const persistedReasoning = (last?.reasoningTexts ?? [])
+    .map((r) => r.content)
+    .join("")
+    .trim();
+  const assistantSuperseded = liveText ? persistedAssistant.startsWith(liveText) : true;
+  const reasoningSuperseded = liveReasoning ? persistedReasoning.startsWith(liveReasoning) : true;
+  if (assistantSuperseded && reasoningSuperseded) return null;
+
   return {
     turnIndex: (last?.turnIndex ?? 0) + 1,
     turnId: live.turnId ?? undefined,

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import type { ConversationTurn } from "@tracepilot/types";
-import { useConversationSections, useToggleSet } from "@tracepilot/ui";
-import { computed, nextTick, ref, watch } from "vue";
+import {
+  LIVE_TOOL_PARTIAL_OUTPUT_KEY,
+  useConversationSections,
+  useToggleSet,
+} from "@tracepilot/ui";
+import { computed, nextTick, provide, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import GapIndicator from "@/components/conversation/chat/GapIndicator.vue";
 import TurnBlock from "@/components/conversation/chat/TurnBlock.vue";
@@ -86,6 +90,35 @@ watch(
   },
 );
 const renderMd = computed(() => preferences.isFeatureEnabled("renderMarkdown"));
+
+// Live partial output (streaming stdout from in-flight tool calls), keyed
+// by toolCallId. Sourced from the SDK live-state reducer's per-session
+// `ToolProgressSummary[]`. Provided into the tool-detail tree via injection
+// so it surfaces inline on the persisted tool call without prop-drilling.
+const liveToolPartialOutputs = computed<Map<string, string>>(() => {
+  const sessionId = store.sessionId;
+  const map = new Map<string, string>();
+  if (!sessionId) return map;
+  const state = sdk.sessionStatesById[sessionId];
+  if (!state) return map;
+  for (const tool of state.tools ?? []) {
+    if (!tool.toolCallId || tool.partialResult == null) continue;
+    const text =
+      typeof tool.partialResult === "string"
+        ? tool.partialResult
+        : (() => {
+            try {
+              return JSON.stringify(tool.partialResult, null, 2);
+            } catch {
+              return String(tool.partialResult);
+            }
+          })();
+    if (text.length > 0) map.set(tool.toolCallId, text);
+  }
+  return map;
+});
+provide(LIVE_TOOL_PARTIAL_OUTPUT_KEY, liveToolPartialOutputs);
+
 const emit = defineEmits<{
   messageSent: [prompt: string];
 }>();

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -137,6 +137,12 @@ const expandedReasoning = useToggleSet<string>();
 const expandedGroups = useToggleSet<string>();
 const expandedToolDetails = useToggleSet<string>();
 
+const isSdkSteered = computed<boolean>(() => {
+  const sid = store.sessionId;
+  if (!sid) return false;
+  return sdk.sessionStatesById[sid] != null || sdk.liveTurnsBySessionId[sid] != null;
+});
+
 // ─── Tool result loader ───────────────────────────────────────────
 
 const {
@@ -195,6 +201,28 @@ const turnRenderData = computed(() => {
 function renderDataFor(turn: ConversationTurn): TurnRenderData {
   return turnRenderData.value.get(turn.turnIndex) ?? { reasoning: [], messages: [], segments: [] };
 }
+
+// Auto-expand reasoning blocks once per turn for SDK-steered sessions so
+// streaming "thinking" content is visible without an extra click and stays
+// expanded after the turn finalizes (same turnIndex carries the toggle).
+// We track which keys we've auto-seeded so a user-initiated collapse isn't
+// re-opened on the next render.
+const autoExpandedReasoningKeys = new Set<string>();
+watch(
+  [turnRenderData, isSdkSteered],
+  ([renderMap, steered]) => {
+    if (!steered) return;
+    for (const [turnIndex, data] of renderMap) {
+      for (let rIdx = 0; rIdx < data.reasoning.length; rIdx++) {
+        const key = `${turnIndex}-main-${rIdx}`;
+        if (autoExpandedReasoningKeys.has(key)) continue;
+        autoExpandedReasoningKeys.add(key);
+        if (!expandedReasoning.has(key)) expandedReasoning.toggle(key);
+      }
+    }
+  },
+  { immediate: true },
+);
 
 // ─── toolCallId → turnIndex index (O(1) lookups) ─────────────────
 

--- a/apps/desktop/src/components/conversation/sdkSteering/SdkSteeringLiveState.vue
+++ b/apps/desktop/src/components/conversation/sdkSteering/SdkSteeringLiveState.vue
@@ -120,6 +120,13 @@ function formatPreview(value: unknown): string {
   return `${rendered.slice(0, 1200)}…`;
 }
 
+// Streaming tool stdout (e.g. shell/powershell) is truncated server-side
+// (`MAX_PARTIAL_RESULT_CHARS` in the live-state reducer). Don't add another
+// frontend-side cap that would chop it again.
+function formatToolPartial(value: unknown): string {
+  return formatObjectResult(value).replace(/\s+$/u, "");
+}
+
 function formatUsageRows(usage: unknown): Array<{ key: string; value: string }> {
   if (!usage || typeof usage !== "object" || Array.isArray(usage)) {
     return usage == null ? [] : [{ key: "usage", value: formatPreview(usage) }];
@@ -231,7 +238,7 @@ function isScalarUsageValue(value: unknown): boolean {
         <div v-if="progressLabel(tool.progress)" class="cb-live-progress" :aria-label="`Tool progress ${progressLabel(tool.progress)}`">
           <span :style="progressStyle(tool.progress)" />
         </div>
-        <pre v-if="tool.partialResult != null" class="cb-live-tool-output">{{ formatPreview(tool.partialResult) }}</pre>
+        <pre v-if="tool.partialResult != null" class="cb-live-tool-output">{{ formatToolPartial(tool.partialResult) }}</pre>
       </article>
     </div>
 

--- a/apps/desktop/src/composables/__tests__/useAutoScroll.popout.test.ts
+++ b/apps/desktop/src/composables/__tests__/useAutoScroll.popout.test.ts
@@ -1,0 +1,168 @@
+// Regression tests for the popout-window auto-scroll lock bug.
+// See `useAutoScroll.test.ts` for the broader behavioural coverage; this file
+// isolates the instant-scroll programmatic-guard regression so the parent
+// suite stays under the file-size guard-rail.
+import { flushPromises } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, ref } from "vue";
+import { useAutoScroll } from "../useAutoScroll";
+
+function withSetup<T>(fn: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const app = createApp({
+    setup() {
+      result = fn();
+      return {};
+    },
+    render: () => null as never,
+  });
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  app.mount(root);
+  return {
+    result,
+    unmount: () => {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+function makeScrollEl(
+  opts: { scrollHeight?: number; clientHeight?: number; scrollTop?: number } = {},
+) {
+  const el = document.createElement("div");
+  let _scrollHeight = opts.scrollHeight ?? 1000;
+  const _clientHeight = opts.clientHeight ?? 500;
+  let _scrollTop = opts.scrollTop ?? 0;
+
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => _scrollHeight });
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => _clientHeight });
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => _scrollTop,
+    set: (v: number) => {
+      _scrollTop = v;
+    },
+  });
+
+  const scrollSpy = vi.fn((scrollOpts: ScrollToOptions) => {
+    if (scrollOpts?.top !== undefined) _scrollTop = scrollOpts.top;
+  });
+  Object.defineProperty(el, "scrollTo", { configurable: true, writable: true, value: scrollSpy });
+
+  return {
+    el,
+    setScrollHeight: (v: number) => {
+      _scrollHeight = v;
+    },
+    setScrollTop: (v: number) => {
+      _scrollTop = v;
+    },
+    scrollSpy,
+  };
+}
+
+let rafQueue: Array<FrameRequestCallback> = [];
+function flushRaf() {
+  const pending = rafQueue.splice(0);
+  for (const cb of pending) cb(0);
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useAutoScroll instant-scroll programmatic guard (popout streaming)", () => {
+  it("does not disengage lock when streaming content outpaces the post-scroll handler", async () => {
+    // Reproduces the popout-window auto-scroll bug:
+    // - User is at the bottom (locked organically, no FAB click).
+    // - SDK streaming text grows scrollHeight rapidly.
+    // - Data-watcher fires instant `scrollTo({behavior:"auto"})`.
+    // - Between scrollTo landing and the resulting `scroll` event,
+    //   `scrollHeight` grew further (popout webview timing).
+    // - Without an instant-scroll guard, the post-scroll handler sees
+    //   `distFromBottom > disengageThreshold` and erroneously flips lock off.
+    const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+    const containerRef = ref<HTMLElement | null>(state.el);
+    const watchSrc = ref(0);
+
+    const { result, unmount } = withSetup(() =>
+      useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+    );
+
+    // First-data tick (no scroll), then engage organically.
+    watchSrc.value = 1;
+    await flushPromises();
+    result.isLockedToBottom.value = true;
+
+    // Streaming content grows; data watcher fires.
+    state.setScrollHeight(1500);
+    watchSrc.value = 2;
+    await flushPromises();
+
+    // Webview lag: scroll event lands while scrollHeight has grown again,
+    // putting us 300px from the new bottom (well past the 80px disengage).
+    state.setScrollHeight(2000);
+    state.setScrollTop(1200);
+    state.el.dispatchEvent(new Event("scroll"));
+    flushRaf();
+
+    expect(result.isLockedToBottom.value).toBe(true);
+    unmount();
+  });
+
+  it("re-arms the instant guard for each subsequent maintainLock-style scroll", async () => {
+    const state = makeScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+    const containerRef = ref<HTMLElement | null>(state.el);
+    const watchSrc = ref(0);
+
+    const { result, unmount } = withSetup(() =>
+      useAutoScroll({ containerRef, watchSource: () => watchSrc.value }),
+    );
+    watchSrc.value = 1;
+    await flushPromises();
+    result.isLockedToBottom.value = true;
+
+    state.setScrollHeight(1500);
+    watchSrc.value = 2;
+    await flushPromises();
+
+    state.setScrollTop(900); // distFromBottom = 100 > 80
+    state.el.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(result.isLockedToBottom.value).toBe(true);
+
+    // Advance past the previous safety timeout: only re-arming keeps us safe.
+    vi.advanceTimersByTime(1000);
+
+    state.setScrollHeight(2000);
+    watchSrc.value = 3;
+    await flushPromises();
+
+    state.setScrollTop(1300); // distFromBottom = 200 > 80
+    state.el.dispatchEvent(new Event("scroll"));
+    flushRaf();
+    expect(result.isLockedToBottom.value).toBe(true);
+    unmount();
+  });
+});

--- a/apps/desktop/src/composables/useAutoScroll.ts
+++ b/apps/desktop/src/composables/useAutoScroll.ts
@@ -37,8 +37,18 @@ export function useAutoScroll(options: AutoScrollOptions) {
   const hasOverflow = ref(false);
 
   let rafId: number | null = null;
-  // Guard flag: prevents scroll handler from disengaging lock during programmatic smooth scrolls
+  // Guard flag: prevents scroll handler from disengaging lock during
+  // *any* programmatic scroll (smooth OR instant). Without guarding instant
+  // scrolls, fast-streaming content can grow `scrollHeight` between our
+  // `scrollTo` landing and the resulting `scroll` event reaching us — at
+  // which point the post-scroll position may be >disengageThreshold from
+  // the new bottom and the lock would erroneously flip off. This was the
+  // root cause of popout-window auto-scroll dropping its lock during SDK
+  // live streaming.
   let isProgrammaticScroll = false;
+  // Programmatic-scroll safety-clear timer. Cleared early when the position
+  // check confirms we landed at the target.
+  let programmaticScrollClearTimer: ReturnType<typeof setTimeout> | null = null;
   // Skip auto-scroll on the first data change (initial load should not snap to bottom)
   let hasReceivedFirstData = false;
 
@@ -77,23 +87,24 @@ export function useAutoScroll(options: AutoScrollOptions) {
     }
   }
 
+  function armProgrammaticScrollGuard(safetyMs = 1500) {
+    isProgrammaticScroll = true;
+    if (programmaticScrollClearTimer) clearTimeout(programmaticScrollClearTimer);
+    programmaticScrollClearTimer = setTimeout(() => {
+      isProgrammaticScroll = false;
+      programmaticScrollClearTimer = null;
+    }, safetyMs);
+  }
+
   function scrollToBottom(animated = true) {
     const el = containerRef.value;
     if (!el) return;
     const useSmooth = animated && !prefersReducedMotion.matches;
     el.scrollTo({ top: el.scrollHeight, behavior: useSmooth ? "smooth" : "auto" });
     isLockedToBottom.value = true;
-    if (useSmooth) {
-      // Guard: suppress handleScroll's lock/unlock logic during smooth animation.
-      // Cleared position-based in handleScroll once the element reaches the bottom.
-      // Using scrollend is intentionally avoided here — an instant scroll fired by the
-      // data watcher (new message arriving mid-animation) would cancel the smooth scroll
-      // and trigger scrollend early, clearing the guard before we arrive at the bottom.
-      isProgrammaticScroll = true;
-      setTimeout(() => {
-        isProgrammaticScroll = false;
-      }, 2000); // safety fallback only
-    }
+    // Guard for both smooth (animation runs) and instant (resulting scroll
+    // event may land after content grew further during streaming).
+    armProgrammaticScrollGuard(useSmooth ? 2000 : 250);
   }
 
   function scrollToTop(animated = true) {
@@ -102,12 +113,7 @@ export function useAutoScroll(options: AutoScrollOptions) {
     const useSmooth = animated && !prefersReducedMotion.matches;
     el.scrollTo({ top: 0, behavior: useSmooth ? "smooth" : "auto" });
     isLockedToBottom.value = false;
-    if (useSmooth) {
-      isProgrammaticScroll = true;
-      setTimeout(() => {
-        isProgrammaticScroll = false;
-      }, 2000);
-    }
+    armProgrammaticScrollGuard(useSmooth ? 2000 : 250);
   }
 
   function handleScroll() {
@@ -129,7 +135,13 @@ export function useAutoScroll(options: AutoScrollOptions) {
         const atTarget = isLockedToBottom.value
           ? isNearBottom(el, engageThreshold)
           : el.scrollTop <= engageThreshold;
-        if (atTarget) isProgrammaticScroll = false;
+        if (atTarget) {
+          isProgrammaticScroll = false;
+          if (programmaticScrollClearTimer) {
+            clearTimeout(programmaticScrollClearTimer);
+            programmaticScrollClearTimer = null;
+          }
+        }
         return;
       }
 
@@ -162,6 +174,7 @@ export function useAutoScroll(options: AutoScrollOptions) {
       nextTick(() => {
         const el = containerRef.value;
         if (!el) return;
+        armProgrammaticScrollGuard(250);
         el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
       });
     }
@@ -184,6 +197,7 @@ export function useAutoScroll(options: AutoScrollOptions) {
     if (hasActiveTextSelection()) return;
     const el = containerRef.value;
     if (!el) return;
+    armProgrammaticScrollGuard(250);
     el.scrollTo({ top: el.scrollHeight, behavior: "auto" });
   }
   function attachResizeObserver(el: HTMLElement) {
@@ -226,6 +240,10 @@ export function useAutoScroll(options: AutoScrollOptions) {
     if (rafId !== null) {
       cancelAnimationFrame(rafId);
       rafId = null;
+    }
+    if (programmaticScrollClearTimer) {
+      clearTimeout(programmaticScrollClearTimer);
+      programmaticScrollClearTimer = null;
     }
   });
 

--- a/apps/desktop/src/composables/useSdkSteering.ts
+++ b/apps/desktop/src/composables/useSdkSteering.ts
@@ -301,6 +301,10 @@ export function useSdkSteering(options: UseSdkSteeringOptions) {
   async function handleSend() {
     const text = prompt.value.trim();
     if (!text || !sessionIdRef.value || !isLinked.value) return;
+    // Avoid creating an optimistic "sending" row that would otherwise be
+    // orphaned when the messaging slice's idempotency guard drops a duplicate
+    // call (e.g. Send double-tap or Ctrl+Enter racing a click).
+    if (sdk.isSending(effectiveSessionId.value)) return;
 
     sessionError.value = null;
 

--- a/apps/desktop/src/stores/sdk/__tests__/liveTurns.reorder.test.ts
+++ b/apps/desktop/src/stores/sdk/__tests__/liveTurns.reorder.test.ts
@@ -1,0 +1,104 @@
+import type { BridgeEvent, BridgeSessionInfo } from "@tracepilot/types";
+import { describe, expect, it, vi } from "vitest";
+import { ref, shallowRef } from "vue";
+
+vi.mock("@tracepilot/tauri-bridge", () => ({
+  sdkSendMessage: vi.fn(),
+  sdkResume: vi.fn(),
+  sdkUnlinkSession: vi.fn(),
+  sdkDestroySession: vi.fn(),
+}));
+
+import { createMessagingSlice } from "../messaging";
+
+function makeSlice() {
+  const sessions = ref<BridgeSessionInfo[]>([]);
+  const activeSessions = ref(0);
+  const lastError = ref<string | null>(null);
+  const recentEvents = shallowRef([]);
+  return createMessagingSlice({ sessions, activeSessions, lastError, recentEvents });
+}
+
+function at(
+  sessionId: string,
+  eventType: string,
+  timestamp: string,
+  data: Record<string, unknown> = {},
+): BridgeEvent {
+  return {
+    sessionId,
+    eventType,
+    timestamp,
+    id: null,
+    parentId: null,
+    ephemeral: false,
+    data,
+  };
+}
+
+describe("liveTurns reorder buffer", () => {
+  it("reorders out-of-order deltas using event timestamp", () => {
+    // Repro for the SDK race: pinned Copilot Rust SDK `tokio::spawn`s a fresh
+    // task per `session.event` notification, so adjacent deltas can race into
+    // `event_tx.send` in non-source order. The reducer must sort by
+    // `event.timestamp` so the live preview reflects source order.
+    const slice = makeSlice();
+    slice.applyBridgeEvent(at("sdk-A", "assistant.turn_start", "2026-04-27T00:00:00.000Z"));
+    // Source-order deltas would be: "hell", "ow", " world".
+    // Wire arrives reordered: "hell", " world", "ow".
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.001Z", { deltaContent: "hell" }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.003Z", {
+        deltaContent: " world",
+      }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.002Z", { deltaContent: "ow" }),
+    );
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("hellow world");
+  });
+
+  it("snap-replaces the visible text on assistant.message when reordered tail is garbled", () => {
+    // Even if the reorder window failed to recover (e.g. >WINDOW deltas
+    // arrived out of order), the final `assistant.message` carries the full
+    // canonical content and snap-replaces if it's longer than what we have.
+    const slice = makeSlice();
+    slice.applyBridgeEvent(at("sdk-A", "assistant.turn_start", "2026-04-27T00:00:00.000Z"));
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.002Z", {
+        deltaContent: "world",
+      }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.001Z", {
+        deltaContent: "hello ",
+      }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message", "2026-04-27T00:00:00.010Z", {
+        content: "hello world (final)",
+      }),
+    );
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("hello world (final)");
+  });
+
+  it("reorders reasoning_delta events identically", () => {
+    const slice = makeSlice();
+    slice.applyBridgeEvent(at("sdk-A", "assistant.turn_start", "2026-04-27T00:00:00.000Z"));
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.reasoning_delta", "2026-04-27T00:00:00.002Z", {
+        deltaContent: "B",
+      }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.reasoning_delta", "2026-04-27T00:00:00.001Z", {
+        deltaContent: "A",
+      }),
+    );
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.reasoningText).toBe("AB");
+  });
+});

--- a/apps/desktop/src/stores/sdk/__tests__/liveTurns.reorder.test.ts
+++ b/apps/desktop/src/stores/sdk/__tests__/liveTurns.reorder.test.ts
@@ -36,6 +36,24 @@ function at(
   };
 }
 
+function atP(
+  sessionId: string,
+  eventType: string,
+  timestamp: string,
+  parentId: string,
+  data: Record<string, unknown> = {},
+): BridgeEvent {
+  return {
+    sessionId,
+    eventType,
+    timestamp,
+    id: null,
+    parentId,
+    ephemeral: false,
+    data,
+  };
+}
+
 describe("liveTurns reorder buffer", () => {
   it("reorders out-of-order deltas using event timestamp", () => {
     // Repro for the SDK race: pinned Copilot Rust SDK `tokio::spawn`s a fresh
@@ -100,5 +118,70 @@ describe("liveTurns reorder buffer", () => {
       }),
     );
     expect(slice.liveTurnsBySessionId.value["sdk-A"]?.reasoningText).toBe("AB");
+  });
+
+  it("ignores delta events that arrive after assistant.message finalizes the stream", () => {
+    // Late delta after canonical text would re-corrupt it (e.g. the same
+    // SDK race could deliver one straggler post-final). Once finalized, the
+    // reducer must drop subsequent deltas for that turn.
+    const slice = makeSlice();
+    slice.applyBridgeEvent(at("sdk-A", "assistant.turn_start", "2026-04-27T00:00:00.000Z"));
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.001Z", {
+        deltaContent: "hello ",
+      }),
+    );
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message", "2026-04-27T00:00:00.010Z", {
+        content: "hello world",
+      }),
+    );
+    // Straggler delta arriving AFTER the final event:
+    slice.applyBridgeEvent(
+      at("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.002Z", {
+        deltaContent: "world",
+      }),
+    );
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("hello world");
+  });
+
+  it("drops deltas whose parentId disagrees with the active turn", () => {
+    // Cross-turn contamination repro: a previous-turn delta arrives after the
+    // next assistant.turn_start. With only sessionId-based routing it would
+    // be applied to the new turn's buffer; the parentId guard prevents that.
+    const slice = makeSlice();
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.turn_start", "2026-04-27T00:00:00.000Z", "turn-1", {
+        turnId: "turn-1",
+      }),
+    );
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.001Z", "turn-1", {
+        deltaContent: "first ",
+      }),
+    );
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.message", "2026-04-27T00:00:00.010Z", "turn-1", {
+        content: "first turn",
+      }),
+    );
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.turn_start", "2026-04-27T00:00:01.000Z", "turn-2", {
+        turnId: "turn-2",
+      }),
+    );
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.message_delta", "2026-04-27T00:00:01.001Z", "turn-2", {
+        deltaContent: "second",
+      }),
+    );
+    // Late straggler from the PREVIOUS turn arriving after rotation:
+    slice.applyBridgeEvent(
+      atP("sdk-A", "assistant.message_delta", "2026-04-27T00:00:00.002Z", "turn-1", {
+        deltaContent: "STRAGGLER",
+      }),
+    );
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("second");
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.turnId).toBe("turn-2");
   });
 });

--- a/apps/desktop/src/stores/sdk/__tests__/messaging.idempotency.test.ts
+++ b/apps/desktop/src/stores/sdk/__tests__/messaging.idempotency.test.ts
@@ -1,0 +1,139 @@
+import type { BridgeSessionInfo } from "@tracepilot/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref, shallowRef } from "vue";
+
+const clientMocks = vi.hoisted(() => ({
+  sdkAbortSession: vi.fn(async () => {}),
+  sdkCreateSession: vi.fn(),
+  sdkDestroySession: vi.fn(async () => {}),
+  sdkGetForegroundSession: vi.fn(async () => null),
+  sdkResumeSession: vi.fn(
+    async (sessionId: string): Promise<BridgeSessionInfo> => ({
+      sessionId,
+      model: null,
+      workingDirectory: null,
+      mode: null,
+      isActive: true,
+      resumeError: null,
+      isRemote: false,
+    }),
+  ),
+  sdkSendMessage: vi.fn(async () => "turn-1"),
+  sdkSetForegroundSession: vi.fn(async () => {}),
+  sdkSetSessionMode: vi.fn(async () => {}),
+  sdkSetSessionModel: vi.fn(async () => {}),
+  sdkUnlinkSession: vi.fn(async () => {}),
+}));
+
+vi.mock("@tracepilot/client", () => clientMocks);
+
+import { createMessagingSlice } from "../messaging";
+
+function makeSession(sessionId: string, isActive: boolean): BridgeSessionInfo {
+  return {
+    sessionId,
+    model: null,
+    workingDirectory: null,
+    mode: null,
+    isActive,
+    resumeError: null,
+    isRemote: false,
+  };
+}
+
+function makeSlice() {
+  const sessions = ref<BridgeSessionInfo[]>([]);
+  const activeSessions = ref(0);
+  const lastError = ref<string | null>(null);
+  const recentEvents = shallowRef([]);
+  const slice = createMessagingSlice({ sessions, activeSessions, lastError, recentEvents });
+  return { slice };
+}
+
+describe("createMessagingSlice idempotency guards", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(clientMocks)) fn.mockClear();
+  });
+
+  it("sendMessage drops a duplicate call while one is already in flight for the same session", async () => {
+    // Repro for double-send bug: a fast double-tap of the Send button (or
+    // Ctrl+Enter racing a click) used to fire two SDK sends because the
+    // caller's prompt-clear only ran AFTER the first send resolved.
+    let resolveFirst: ((v: string) => void) | undefined;
+    clientMocks.sdkSendMessage.mockImplementationOnce(
+      () =>
+        new Promise<string>((res) => {
+          resolveFirst = res;
+        }),
+    );
+    const { slice } = makeSlice();
+
+    const first = slice.sendMessage("sdk-A", { prompt: "hi" });
+    expect(slice.isSending("sdk-A")).toBe(true);
+
+    const second = await slice.sendMessage("sdk-A", { prompt: "hi" });
+    expect(second).toBeNull();
+    expect(clientMocks.sdkSendMessage).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.("turn-1");
+    expect(await first).toBe("turn-1");
+
+    const third = await slice.sendMessage("sdk-A", { prompt: "next" });
+    expect(third).toBe("turn-1");
+    expect(clientMocks.sdkSendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("sendMessage allows concurrent sends for *different* sessions", async () => {
+    let resolveA: ((v: string) => void) | undefined;
+    clientMocks.sdkSendMessage.mockImplementationOnce(
+      () =>
+        new Promise<string>((res) => {
+          resolveA = res;
+        }),
+    );
+    clientMocks.sdkSendMessage.mockResolvedValueOnce("turn-B");
+    const { slice } = makeSlice();
+
+    const aPending = slice.sendMessage("sdk-A", { prompt: "a" });
+    const b = await slice.sendMessage("sdk-B", { prompt: "b" });
+
+    expect(b).toBe("turn-B");
+    resolveA?.("turn-A");
+    expect(await aPending).toBe("turn-A");
+  });
+
+  it("resumeSession coalesces concurrent calls for the same sessionId onto one SDK call", async () => {
+    // Repro for duplicate-resume bug: two callers (e.g. linkSession from a
+    // re-render race, or a popout window mounting just as the main one
+    // resumes) used to each invoke the SDK, producing two `session.resume`
+    // events on disk.
+    let resolve: ((v: BridgeSessionInfo) => void) | undefined;
+    clientMocks.sdkResumeSession.mockImplementationOnce(
+      () =>
+        new Promise<BridgeSessionInfo>((res) => {
+          resolve = res;
+        }),
+    );
+    const { slice } = makeSlice();
+
+    const p1 = slice.resumeSession("sdk-A");
+    const p2 = slice.resumeSession("sdk-A");
+
+    expect(clientMocks.sdkResumeSession).toHaveBeenCalledTimes(1);
+
+    resolve?.(makeSession("sdk-A", true));
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1?.sessionId).toBe("sdk-A");
+    expect(r2?.sessionId).toBe("sdk-A");
+    expect(r1).toBe(r2);
+  });
+
+  it("resumeSession allows a fresh call once the previous in-flight resume completes", async () => {
+    const { slice } = makeSlice();
+
+    await slice.resumeSession("sdk-A");
+    await slice.resumeSession("sdk-A");
+
+    expect(clientMocks.sdkResumeSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/stores/sdk/__tests__/messaging.test.ts
+++ b/apps/desktop/src/stores/sdk/__tests__/messaging.test.ts
@@ -204,4 +204,76 @@ describe("createMessagingSlice session cache isolation", () => {
     slice.clearLiveTurn("sdk-A");
     expect(slice.liveTurnsBySessionId.value["sdk-A"]).toBeUndefined();
   });
+
+  it("does not duplicate text when a final assistant.message arrives after deltas", () => {
+    const { slice } = makeSlice();
+
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.turn_start", { turnId: "turn-A" }));
+    slice.applyBridgeEvent(
+      makeEvent("sdk-A", "assistant.message_delta", { deltaContent: "hello " }),
+    );
+    slice.applyBridgeEvent(
+      makeEvent("sdk-A", "assistant.message_delta", { deltaContent: "world" }),
+    );
+    // Final event with the FULL content — must NOT be appended on top.
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message", { content: "hello world" }));
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("hello world");
+  });
+
+  it("does not duplicate reasoning when a final assistant.reasoning arrives after deltas", () => {
+    const { slice } = makeSlice();
+
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.turn_start", { turnId: "turn-A" }));
+    slice.applyBridgeEvent(
+      makeEvent("sdk-A", "assistant.reasoning_delta", { deltaContent: "thinking " }),
+    );
+    slice.applyBridgeEvent(
+      makeEvent("sdk-A", "assistant.reasoning_delta", { deltaContent: "deeply" }),
+    );
+    slice.applyBridgeEvent(
+      makeEvent("sdk-A", "assistant.reasoning", { content: "thinking deeply" }),
+    );
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.reasoningText).toBe("thinking deeply");
+  });
+
+  it("ignores stray `content` field on delta events", () => {
+    const { slice } = makeSlice();
+
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.turn_start", { turnId: "turn-A" }));
+    // A misbehaving server might attach `content` to a delta event. We must
+    // ignore it — only deltaContent counts.
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message_delta", { content: "STRAY" }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message_delta", { deltaContent: "ok" }));
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("ok");
+  });
+
+  it("populates assistant.message even when no deltas arrived first", () => {
+    const { slice } = makeSlice();
+
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.turn_start", { turnId: "turn-A" }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message", { content: "complete answer" }));
+
+    expect(slice.liveTurnsBySessionId.value["sdk-A"]?.assistantText).toBe("complete answer");
+  });
+
+  it("accepts the `delta` field alias on message and reasoning delta events", () => {
+    // Some SDK servers emit `{ delta: "..." }` rather than `{ deltaContent }`.
+    // The Rust reducer accepts this alias; the frontend live-turn accumulator
+    // must too, otherwise the chat live preview never updates until a final
+    // `assistant.message` arrives.
+    const { slice } = makeSlice();
+
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.turn_start", { turnId: "turn-A" }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message_delta", { delta: "hello " }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.message_delta", { delta: "world" }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.reasoning_delta", { delta: "think " }));
+    slice.applyBridgeEvent(makeEvent("sdk-A", "assistant.reasoning_delta", { delta: "more" }));
+
+    const live = slice.liveTurnsBySessionId.value["sdk-A"];
+    expect(live?.assistantText).toBe("hello world");
+    expect(live?.reasoningText).toBe("think more");
+  });
 });

--- a/apps/desktop/src/stores/sdk/liveTurns.ts
+++ b/apps/desktop/src/stores/sdk/liveTurns.ts
@@ -29,6 +29,10 @@ export interface SdkLiveTurn {
   /** Internal: pending deltas, sorted ascending by timestamp. */
   assistantPending: PendingDelta[];
   reasoningPending: PendingDelta[];
+  /** Set once `assistant.message` / `assistant.reasoning` lands; late deltas
+   * arriving after the canonical text are dropped to avoid re-corrupting it. */
+  assistantFinalized: boolean;
+  reasoningFinalized: boolean;
   updatedAt: string;
 }
 
@@ -95,6 +99,8 @@ export function createLiveTurnAccumulator() {
       reasoningCommitted: "",
       assistantPending: [],
       reasoningPending: [],
+      assistantFinalized: false,
+      reasoningFinalized: false,
       updatedAt: event.timestamp,
     };
   }
@@ -117,6 +123,14 @@ export function createLiveTurnAccumulator() {
     liveTurnsBySessionId.value = next;
   }
 
+  /** Drop late events whose parentId disagrees with the active turn (so a
+   * straggler delta from a previous turn cannot contaminate the next one). */
+  function isStaleEvent(turn: SdkLiveTurn, event: BridgeEvent): boolean {
+    if (!turn.turnId) return false;
+    if (!event.parentId) return false;
+    return turn.turnId !== event.parentId;
+  }
+
   function applyBridgeEvent(event: BridgeEvent) {
     if (event.eventType === "assistant.turn_start") {
       const turnId = stringField(event.data, ["turnId", "turn_id"]) ?? event.id;
@@ -137,6 +151,8 @@ export function createLiveTurnAccumulator() {
       ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
+      if (turn.assistantFinalized) return;
+      if (isStaleEvent(turn, event)) return;
       const applied = applyDeltaWithReorder(turn.assistantCommitted, turn.assistantPending, {
         delta,
         timestamp: event.timestamp,
@@ -162,6 +178,8 @@ export function createLiveTurnAccumulator() {
       ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
+      if (turn.reasoningFinalized) return;
+      if (isStaleEvent(turn, event)) return;
       const applied = applyDeltaWithReorder(turn.reasoningCommitted, turn.reasoningPending, {
         delta,
         timestamp: event.timestamp,
@@ -181,6 +199,7 @@ export function createLiveTurnAccumulator() {
       const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
       if (!content) return;
       const turn = currentLiveTurn(event);
+      if (isStaleEvent(turn, event)) return;
       // Snap-replace: drain pending into committed; keep whichever is longer
       // (the final `content` typically equals concat of deltas, but acts as a
       // self-heal when the tail of the reorder buffer is still garbled).
@@ -192,6 +211,7 @@ export function createLiveTurnAccumulator() {
         assistantCommitted: next,
         assistantPending: [],
         assistantText: next,
+        assistantFinalized: true,
         updatedAt: event.timestamp,
       });
       return;
@@ -203,6 +223,7 @@ export function createLiveTurnAccumulator() {
       const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
       if (!content) return;
       const turn = currentLiveTurn(event);
+      if (isStaleEvent(turn, event)) return;
       const drained = turn.reasoningCommitted + joinPending(turn.reasoningPending);
       const next = content.length > drained.length ? content : drained;
       upsertLiveTurn({
@@ -211,6 +232,7 @@ export function createLiveTurnAccumulator() {
         reasoningCommitted: next,
         reasoningPending: [],
         reasoningText: next,
+        reasoningFinalized: true,
         updatedAt: event.timestamp,
       });
     }

--- a/apps/desktop/src/stores/sdk/liveTurns.ts
+++ b/apps/desktop/src/stores/sdk/liveTurns.ts
@@ -61,7 +61,16 @@ export function createLiveTurnAccumulator() {
     }
 
     if (event.eventType === "assistant.message_delta") {
-      const delta = stringField(event.data, ["deltaContent", "delta_content", "content"]);
+      // IMPORTANT: do NOT fall back to `content` for delta events. The SDK
+      // emits a separate `assistant.message` event with the FULL content;
+      // accepting `content` as a delta produces duplicated streamed text.
+      const delta = stringField(event.data, [
+        "deltaContent",
+        "delta_content",
+        "chunkContent",
+        "chunk_content",
+        "delta",
+      ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
       upsertLiveTurn({
@@ -74,7 +83,13 @@ export function createLiveTurnAccumulator() {
     }
 
     if (event.eventType === "assistant.reasoning_delta") {
-      const delta = stringField(event.data, ["deltaContent", "delta_content", "content"]);
+      const delta = stringField(event.data, [
+        "deltaContent",
+        "delta_content",
+        "chunkContent",
+        "chunk_content",
+        "delta",
+      ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
       upsertLiveTurn({
@@ -90,10 +105,32 @@ export function createLiveTurnAccumulator() {
       const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
       if (!content) return;
       const turn = currentLiveTurn(event);
+      // Replace only when the final content is longer than the accumulated
+      // delta text. Otherwise the deltas already produced the final text and
+      // overwriting with the same payload would still be a no-op, but skipping
+      // avoids a wasted render and protects against any out-of-order replays
+      // where a partial `content` could shrink the visible text.
+      const next = content.length > turn.assistantText.length ? content : turn.assistantText;
       upsertLiveTurn({
         ...turn,
         turnId: turn.turnId ?? event.parentId,
-        assistantText: content,
+        assistantText: next,
+        updatedAt: event.timestamp,
+      });
+      return;
+    }
+
+    if (event.eventType === "assistant.reasoning") {
+      // Final reasoning event carries the full content. Same dedup strategy
+      // as `assistant.message` above.
+      const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
+      if (!content) return;
+      const turn = currentLiveTurn(event);
+      const next = content.length > turn.reasoningText.length ? content : turn.reasoningText;
+      upsertLiveTurn({
+        ...turn,
+        turnId: turn.turnId ?? event.parentId,
+        reasoningText: next,
         updatedAt: event.timestamp,
       });
     }

--- a/apps/desktop/src/stores/sdk/liveTurns.ts
+++ b/apps/desktop/src/stores/sdk/liveTurns.ts
@@ -1,11 +1,34 @@
 import type { BridgeEvent } from "@tracepilot/types";
 import { shallowRef } from "vue";
 
+// Reorder window for delta events. The pinned Copilot SDK
+// (`client.rs::setup_handlers`) `tokio::spawn`s a fresh task per
+// `session.event` notification, so adjacent deltas can race into
+// `event_tx.send` in non-source order. We hold the most recent N
+// deltas in a buffer sorted by their source-side `event.timestamp`;
+// once a newer delta pushes one out of the window it's committed.
+// The visible `assistantText` is committed + sorted-pending, so the
+// UI sees ordered text but with up to N deltas of "shifting tail".
+// The final `assistant.message` event drains+snaps the tail.
+const DELTA_REORDER_WINDOW = 4;
+
+interface PendingDelta {
+  delta: string;
+  timestamp: string;
+}
+
 export interface SdkLiveTurn {
   sessionId: string;
   turnId: string | null;
+  /** Visible text (committed prefix + pending sorted by timestamp). */
   assistantText: string;
   reasoningText: string;
+  /** Internal: text that has been drained out of the reorder buffer. */
+  assistantCommitted: string;
+  reasoningCommitted: string;
+  /** Internal: pending deltas, sorted ascending by timestamp. */
+  assistantPending: PendingDelta[];
+  reasoningPending: PendingDelta[];
   updatedAt: string;
 }
 
@@ -19,19 +42,65 @@ function stringField(data: unknown, keys: string[]): string | null {
   return null;
 }
 
+function joinPending(pending: PendingDelta[]): string {
+  let out = "";
+  for (const p of pending) out += p.delta;
+  return out;
+}
+
+/**
+ * Insert `incoming` into pending in ascending-timestamp order and drain front
+ * entries beyond the reorder window into `committed`. Returns updated state
+ * plus the new visible text (`committed + pending`).
+ */
+function applyDeltaWithReorder(
+  committed: string,
+  pending: PendingDelta[],
+  incoming: PendingDelta,
+): { committed: string; pending: PendingDelta[]; visible: string } {
+  let insertAt = pending.length;
+  for (let i = 0; i < pending.length; i += 1) {
+    if (incoming.timestamp < pending[i].timestamp) {
+      insertAt = i;
+      break;
+    }
+  }
+  let nextPending: PendingDelta[] = [
+    ...pending.slice(0, insertAt),
+    incoming,
+    ...pending.slice(insertAt),
+  ];
+  let nextCommitted = committed;
+  while (nextPending.length > DELTA_REORDER_WINDOW) {
+    nextCommitted = nextCommitted + nextPending[0].delta;
+    nextPending = nextPending.slice(1);
+  }
+  return {
+    committed: nextCommitted,
+    pending: nextPending,
+    visible: nextCommitted + joinPending(nextPending),
+  };
+}
+
 export function createLiveTurnAccumulator() {
   const liveTurnsBySessionId = shallowRef<Record<string, SdkLiveTurn>>({});
 
+  function emptyTurn(event: BridgeEvent, turnId: string | null): SdkLiveTurn {
+    return {
+      sessionId: event.sessionId,
+      turnId,
+      assistantText: "",
+      reasoningText: "",
+      assistantCommitted: "",
+      reasoningCommitted: "",
+      assistantPending: [],
+      reasoningPending: [],
+      updatedAt: event.timestamp,
+    };
+  }
+
   function currentLiveTurn(event: BridgeEvent): SdkLiveTurn {
-    return (
-      liveTurnsBySessionId.value[event.sessionId] ?? {
-        sessionId: event.sessionId,
-        turnId: null,
-        assistantText: "",
-        reasoningText: "",
-        updatedAt: event.timestamp,
-      }
-    );
+    return liveTurnsBySessionId.value[event.sessionId] ?? emptyTurn(event, null);
   }
 
   function upsertLiveTurn(turn: SdkLiveTurn) {
@@ -50,13 +119,8 @@ export function createLiveTurnAccumulator() {
 
   function applyBridgeEvent(event: BridgeEvent) {
     if (event.eventType === "assistant.turn_start") {
-      upsertLiveTurn({
-        sessionId: event.sessionId,
-        turnId: stringField(event.data, ["turnId", "turn_id"]) ?? event.id,
-        assistantText: "",
-        reasoningText: "",
-        updatedAt: event.timestamp,
-      });
+      const turnId = stringField(event.data, ["turnId", "turn_id"]) ?? event.id;
+      upsertLiveTurn(emptyTurn(event, turnId));
       return;
     }
 
@@ -73,10 +137,16 @@ export function createLiveTurnAccumulator() {
       ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
+      const applied = applyDeltaWithReorder(turn.assistantCommitted, turn.assistantPending, {
+        delta,
+        timestamp: event.timestamp,
+      });
       upsertLiveTurn({
         ...turn,
         turnId: turn.turnId ?? event.parentId,
-        assistantText: `${turn.assistantText}${delta}`,
+        assistantCommitted: applied.committed,
+        assistantPending: applied.pending,
+        assistantText: applied.visible,
         updatedAt: event.timestamp,
       });
       return;
@@ -92,10 +162,16 @@ export function createLiveTurnAccumulator() {
       ]);
       if (!delta) return;
       const turn = currentLiveTurn(event);
+      const applied = applyDeltaWithReorder(turn.reasoningCommitted, turn.reasoningPending, {
+        delta,
+        timestamp: event.timestamp,
+      });
       upsertLiveTurn({
         ...turn,
         turnId: turn.turnId ?? event.parentId,
-        reasoningText: `${turn.reasoningText}${delta}`,
+        reasoningCommitted: applied.committed,
+        reasoningPending: applied.pending,
+        reasoningText: applied.visible,
         updatedAt: event.timestamp,
       });
       return;
@@ -105,15 +181,16 @@ export function createLiveTurnAccumulator() {
       const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
       if (!content) return;
       const turn = currentLiveTurn(event);
-      // Replace only when the final content is longer than the accumulated
-      // delta text. Otherwise the deltas already produced the final text and
-      // overwriting with the same payload would still be a no-op, but skipping
-      // avoids a wasted render and protects against any out-of-order replays
-      // where a partial `content` could shrink the visible text.
-      const next = content.length > turn.assistantText.length ? content : turn.assistantText;
+      // Snap-replace: drain pending into committed; keep whichever is longer
+      // (the final `content` typically equals concat of deltas, but acts as a
+      // self-heal when the tail of the reorder buffer is still garbled).
+      const drained = turn.assistantCommitted + joinPending(turn.assistantPending);
+      const next = content.length > drained.length ? content : drained;
       upsertLiveTurn({
         ...turn,
         turnId: turn.turnId ?? event.parentId,
+        assistantCommitted: next,
+        assistantPending: [],
         assistantText: next,
         updatedAt: event.timestamp,
       });
@@ -126,10 +203,13 @@ export function createLiveTurnAccumulator() {
       const content = stringField(event.data, ["content", "chunkContent", "chunk_content"]);
       if (!content) return;
       const turn = currentLiveTurn(event);
-      const next = content.length > turn.reasoningText.length ? content : turn.reasoningText;
+      const drained = turn.reasoningCommitted + joinPending(turn.reasoningPending);
+      const next = content.length > drained.length ? content : drained;
       upsertLiveTurn({
         ...turn,
         turnId: turn.turnId ?? event.parentId,
+        reasoningCommitted: next,
+        reasoningPending: [],
         reasoningText: next,
         updatedAt: event.timestamp,
       });

--- a/apps/desktop/src/stores/sdk/liveTurns.ts
+++ b/apps/desktop/src/stores/sdk/liveTurns.ts
@@ -49,6 +49,28 @@ export function createLiveTurnAccumulator() {
   }
 
   function applyBridgeEvent(event: BridgeEvent) {
+    // TEMPORARY diagnostic logging — see PR #536 follow-up. Logs every
+    // assistant.* / session.* / tool.execution_* event the frontend live-turn
+    // accumulator sees, so we can diff against the bridge-side `[sdk-diag]`
+    // log to spot duplicates / out-of-order delivery.
+    const et = event.eventType;
+    if (
+      et.startsWith("assistant.") ||
+      et.startsWith("session.") ||
+      et.startsWith("tool.execution_")
+    ) {
+      const d = (event.data ?? {}) as Record<string, unknown>;
+      const preview = (k: string): string => {
+        const v = d[k];
+        if (typeof v !== "string") return "-";
+        return JSON.stringify(v.length > 80 ? `${v.slice(0, 80)}…` : v);
+      };
+      // eslint-disable-next-line no-console
+      console.info(
+        `[sdk-diag] frontend event session=${event.sessionId} type=${et} id=${event.id ?? "-"} parent=${event.parentId ?? "-"} msgId=${(d.messageId as string) ?? "-"} reasoningId=${(d.reasoningId as string) ?? "-"} delta=${preview("deltaContent")} content=${preview("content")} chunk=${preview("chunkContent")}`,
+      );
+    }
+
     if (event.eventType === "assistant.turn_start") {
       upsertLiveTurn({
         sessionId: event.sessionId,

--- a/apps/desktop/src/stores/sdk/liveTurns.ts
+++ b/apps/desktop/src/stores/sdk/liveTurns.ts
@@ -49,28 +49,6 @@ export function createLiveTurnAccumulator() {
   }
 
   function applyBridgeEvent(event: BridgeEvent) {
-    // TEMPORARY diagnostic logging — see PR #536 follow-up. Logs every
-    // assistant.* / session.* / tool.execution_* event the frontend live-turn
-    // accumulator sees, so we can diff against the bridge-side `[sdk-diag]`
-    // log to spot duplicates / out-of-order delivery.
-    const et = event.eventType;
-    if (
-      et.startsWith("assistant.") ||
-      et.startsWith("session.") ||
-      et.startsWith("tool.execution_")
-    ) {
-      const d = (event.data ?? {}) as Record<string, unknown>;
-      const preview = (k: string): string => {
-        const v = d[k];
-        if (typeof v !== "string") return "-";
-        return JSON.stringify(v.length > 80 ? `${v.slice(0, 80)}…` : v);
-      };
-      // eslint-disable-next-line no-console
-      console.info(
-        `[sdk-diag] frontend event session=${event.sessionId} type=${et} id=${event.id ?? "-"} parent=${event.parentId ?? "-"} msgId=${(d.messageId as string) ?? "-"} reasoningId=${(d.reasoningId as string) ?? "-"} delta=${preview("deltaContent")} content=${preview("content")} chunk=${preview("chunkContent")}`,
-      );
-    }
-
     if (event.eventType === "assistant.turn_start") {
       upsertLiveTurn({
         sessionId: event.sessionId,

--- a/apps/desktop/src/stores/sdk/messaging.ts
+++ b/apps/desktop/src/stores/sdk/messaging.ts
@@ -104,25 +104,25 @@ export function createMessagingSlice(deps: MessagingDeps) {
     });
   }
 
+  /**
+   * Per-session in-flight resume tracking. Multiple rapid `resumeSession()`
+   * invocations for the same `sessionId` (e.g. linkSession fired twice from
+   * a re-render or a popout window's mount race) are coalesced onto the
+   * same underlying SDK promise, preventing duplicate `session.resume`
+   * subprocess calls.
+   */
+  const resumeInFlight = new Map<string, Promise<BridgeSessionInfo | null>>();
+
   async function resumeSession(
     sessionId: string,
     workingDirectory?: string,
     model?: string,
   ): Promise<BridgeSessionInfo | null> {
-    // TEMPORARY diagnostic — capture stack to identify which caller resumes
-    // a session that's already active (PR #536 follow-up).
-    const existing = sessions.value.find((s) => s.sessionId === sessionId);
-    const stack = new Error("sdk-diag-stack").stack ?? "(no stack)";
-    logInfo(
-      "[sdk-diag] resumeSession call session=",
-      sessionId,
-      "alreadyTracked=",
-      Boolean(existing),
-      "alreadyActive=",
-      Boolean(existing?.isActive),
-      "\n  stack:",
-      stack,
-    );
+    const pending = resumeInFlight.get(sessionId);
+    if (pending) {
+      logInfo("[sdk] resumeSession already in flight for", sessionId, "— reusing promise");
+      return pending;
+    }
     logInfo(
       "[sdk] Resuming session:",
       sessionId,
@@ -131,16 +131,24 @@ export function createMessagingSlice(deps: MessagingDeps) {
       "model:",
       model ?? "(none)",
     );
+    const promise = (async () => {
+      try {
+        const session = await sdkResumeSession(sessionId, workingDirectory, model);
+        logInfo("[sdk] Resume result:", session);
+        lastError.value = null;
+        upsertSession(session);
+        return session;
+      } catch (e) {
+        lastError.value = toErrorMessage(e);
+        logWarn("[sdk] Resume failed:", e);
+        return null;
+      }
+    })();
+    resumeInFlight.set(sessionId, promise);
     try {
-      const session = await sdkResumeSession(sessionId, workingDirectory, model);
-      logInfo("[sdk] Resume result:", session);
-      lastError.value = null;
-      upsertSession(session);
-      return session;
-    } catch (e) {
-      lastError.value = toErrorMessage(e);
-      logWarn("[sdk] Resume failed:", e);
-      return null;
+      return await promise;
+    } finally {
+      resumeInFlight.delete(sessionId);
     }
   }
 
@@ -148,20 +156,15 @@ export function createMessagingSlice(deps: MessagingDeps) {
     sessionId: string,
     payload: BridgeMessagePayload,
   ): Promise<string | null> {
+    // Idempotency guard: if a send is already in flight for this session,
+    // drop the duplicate. Without this, double-clicks / Ctrl+Enter races /
+    // an Enter handler firing alongside a click can produce two SDK sends
+    // for the same prompt before `prompt.value = ""` clears in the caller.
+    if (sendingByIds.value.has(sessionId)) {
+      logWarn("[sdk] sendMessage dropped — already sending for", sessionId);
+      return null;
+    }
     markSending(sessionId, true);
-    // TEMPORARY diagnostic — capture the JS call stack so we can identify
-    // any duplicate sendMessage calls (PR #536 follow-up).
-    const stack = new Error("sdk-diag-stack").stack ?? "(no stack)";
-    logInfo(
-      "[sdk-diag] sendMessage call session=",
-      sessionId,
-      "prompt_len=",
-      payload.prompt?.length ?? 0,
-      "preview=",
-      payload.prompt?.slice(0, 60),
-      "\n  stack:",
-      stack,
-    );
     logInfo(
       "[sdk] Sending message to session:",
       sessionId,
@@ -170,7 +173,6 @@ export function createMessagingSlice(deps: MessagingDeps) {
     );
     try {
       const turnId = await sdkSendMessage(sessionId, payload);
-      logInfo("[sdk-diag] sendMessage result session=", sessionId, "turnId=", turnId);
       logInfo("[sdk] Message sent, turnId:", turnId);
       lastError.value = null;
       return turnId;

--- a/apps/desktop/src/stores/sdk/messaging.ts
+++ b/apps/desktop/src/stores/sdk/messaging.ts
@@ -109,6 +109,20 @@ export function createMessagingSlice(deps: MessagingDeps) {
     workingDirectory?: string,
     model?: string,
   ): Promise<BridgeSessionInfo | null> {
+    // TEMPORARY diagnostic — capture stack to identify which caller resumes
+    // a session that's already active (PR #536 follow-up).
+    const existing = sessions.value.find((s) => s.sessionId === sessionId);
+    const stack = new Error("sdk-diag-stack").stack ?? "(no stack)";
+    logInfo(
+      "[sdk-diag] resumeSession call session=",
+      sessionId,
+      "alreadyTracked=",
+      Boolean(existing),
+      "alreadyActive=",
+      Boolean(existing?.isActive),
+      "\n  stack:",
+      stack,
+    );
     logInfo(
       "[sdk] Resuming session:",
       sessionId,
@@ -135,6 +149,19 @@ export function createMessagingSlice(deps: MessagingDeps) {
     payload: BridgeMessagePayload,
   ): Promise<string | null> {
     markSending(sessionId, true);
+    // TEMPORARY diagnostic — capture the JS call stack so we can identify
+    // any duplicate sendMessage calls (PR #536 follow-up).
+    const stack = new Error("sdk-diag-stack").stack ?? "(no stack)";
+    logInfo(
+      "[sdk-diag] sendMessage call session=",
+      sessionId,
+      "prompt_len=",
+      payload.prompt?.length ?? 0,
+      "preview=",
+      payload.prompt?.slice(0, 60),
+      "\n  stack:",
+      stack,
+    );
     logInfo(
       "[sdk] Sending message to session:",
       sessionId,
@@ -143,6 +170,7 @@ export function createMessagingSlice(deps: MessagingDeps) {
     );
     try {
       const turnId = await sdkSendMessage(sessionId, payload);
+      logInfo("[sdk-diag] sendMessage result session=", sessionId, "turnId=", turnId);
       logInfo("[sdk] Message sent, turnId:", turnId);
       lastError.value = null;
       return turnId;

--- a/apps/desktop/src/stores/sdk/messaging.ts
+++ b/apps/desktop/src/stores/sdk/messaging.ts
@@ -119,22 +119,10 @@ export function createMessagingSlice(deps: MessagingDeps) {
     model?: string,
   ): Promise<BridgeSessionInfo | null> {
     const pending = resumeInFlight.get(sessionId);
-    if (pending) {
-      logInfo("[sdk] resumeSession already in flight for", sessionId, "— reusing promise");
-      return pending;
-    }
-    logInfo(
-      "[sdk] Resuming session:",
-      sessionId,
-      "cwd:",
-      workingDirectory ?? "(none)",
-      "model:",
-      model ?? "(none)",
-    );
+    if (pending) return pending;
     const promise = (async () => {
       try {
         const session = await sdkResumeSession(sessionId, workingDirectory, model);
-        logInfo("[sdk] Resume result:", session);
         lastError.value = null;
         upsertSession(session);
         return session;
@@ -160,10 +148,7 @@ export function createMessagingSlice(deps: MessagingDeps) {
     // drop the duplicate. Without this, double-clicks / Ctrl+Enter races /
     // an Enter handler firing alongside a click can produce two SDK sends
     // for the same prompt before `prompt.value = ""` clears in the caller.
-    if (sendingByIds.value.has(sessionId)) {
-      logWarn("[sdk] sendMessage dropped — already sending for", sessionId);
-      return null;
-    }
+    if (sendingByIds.value.has(sessionId)) return null;
     markSending(sessionId, true);
     logInfo(
       "[sdk] Sending message to session:",

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/mod.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/mod.rs
@@ -75,6 +75,13 @@ pub struct SessionLiveState {
     pub(super) assistant_pending: Vec<PendingDelta>,
     #[serde(skip)]
     pub(super) reasoning_pending: Vec<PendingDelta>,
+    /// Set once `assistant.message` / `assistant.reasoning` has been applied
+    /// for the active turn. Late deltas after finalization are dropped to
+    /// avoid re-corrupting the canonical text. Cleared by `assistant.turn_start`.
+    #[serde(skip)]
+    pub(super) assistant_finalized: bool,
+    #[serde(skip)]
+    pub(super) reasoning_finalized: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -104,6 +111,8 @@ impl SessionLiveState {
             reasoning_committed: String::new(),
             assistant_pending: Vec::new(),
             reasoning_pending: Vec::new(),
+            assistant_finalized: false,
+            reasoning_finalized: false,
         }
     }
 }

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/mod.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/mod.rs
@@ -61,6 +61,26 @@ pub struct SessionLiveState {
     pub last_event_timestamp: Option<String>,
     pub last_error: Option<String>,
     pub reducer_warnings: Vec<String>,
+    /// Drained-out-of-buffer prefix of `assistant_text`. Internal bookkeeping
+    /// for the timestamp-based reorder buffer; not serialized over the wire.
+    #[serde(skip)]
+    pub(super) assistant_committed: String,
+    #[serde(skip)]
+    pub(super) reasoning_committed: String,
+    /// Pending message deltas, sorted ascending by `event.timestamp`. Pinned
+    /// Copilot SDK `tokio::spawn`s a fresh task per `session.event` notification
+    /// so adjacent deltas can race; we hold the most recent few here and sort
+    /// before committing.
+    #[serde(skip)]
+    pub(super) assistant_pending: Vec<PendingDelta>,
+    #[serde(skip)]
+    pub(super) reasoning_pending: Vec<PendingDelta>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct PendingDelta {
+    pub delta: String,
+    pub timestamp: String,
 }
 
 impl SessionLiveState {
@@ -80,9 +100,15 @@ impl SessionLiveState {
             last_event_timestamp: None,
             last_error: None,
             reducer_warnings: Vec::new(),
+            assistant_committed: String::new(),
+            reasoning_committed: String::new(),
+            assistant_pending: Vec::new(),
+            reasoning_pending: Vec::new(),
         }
     }
 }
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_reorder;

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
@@ -4,7 +4,10 @@ use serde_json::{Value, json};
 
 const MAX_TEXT_PREVIEW_CHARS: usize = 16 * 1024;
 const MAX_TOOLS: usize = 32;
-const MAX_PARTIAL_RESULT_CHARS: usize = 2048;
+// 64 KiB lets us stream meaningfully long shell/powershell stdout into the live
+// preview without losing earlier chunks; once the SDK emits
+// `tool.execution_complete` the persisted result takes over from disk.
+pub(super) const MAX_PARTIAL_RESULT_CHARS: usize = 64 * 1024;
 const MAX_REDUCER_WARNINGS: usize = 8;
 
 pub fn apply_event(state: &mut SessionLiveState, event: &BridgeEvent) {
@@ -18,12 +21,10 @@ pub fn apply_event(state: &mut SessionLiveState, event: &BridgeEvent) {
     match event.event_type.as_str() {
         "assistant.turn_start" => start_turn(state),
         "user.message" => state.status = SessionRuntimeStatus::Running,
-        "assistant.message" | "assistant.message_delta" => {
-            append_text(state, event, TextKind::Assistant)
-        }
-        "assistant.reasoning" | "assistant.reasoning_delta" => {
-            append_text(state, event, TextKind::Reasoning)
-        }
+        "assistant.message_delta" => append_delta(state, event, TextKind::Assistant),
+        "assistant.reasoning_delta" => append_delta(state, event, TextKind::Reasoning),
+        "assistant.message" => apply_full_text(state, event, TextKind::Assistant),
+        "assistant.reasoning" => apply_full_text(state, event, TextKind::Reasoning),
         "assistant.usage" | "session.usage_info" => state.usage = Some(event.data.clone()),
         "session.idle" | "assistant.turn_end" => state.status = SessionRuntimeStatus::Idle,
         "session.shutdown" => state.status = SessionRuntimeStatus::Shutdown,
@@ -57,9 +58,14 @@ enum TextKind {
     Reasoning,
 }
 
-fn append_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
+/// Apply an `assistant.message_delta` / `assistant.reasoning_delta` event by
+/// appending only the incremental delta payload. The SDK emits `deltaContent`
+/// (camelCase of `delta_content`); we accept a few aliases used by alternative
+/// servers but never read `content` here — that field is the FULL message and
+/// belongs to the non-delta event.
+fn append_delta(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
     state.status = SessionRuntimeStatus::Running;
-    match event_text_field(
+    if let Some(delta) = event_text_field(
         &event.data,
         &[
             "deltaContent",
@@ -67,17 +73,46 @@ fn append_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind
             "chunkContent",
             "chunk_content",
             "delta",
-            "text",
+        ],
+    ) {
+        match kind {
+            TextKind::Assistant => append_capped(&mut state.assistant_text, &delta),
+            TextKind::Reasoning => append_capped(&mut state.reasoning_text, &delta),
+        }
+    }
+}
+
+/// Apply a final `assistant.message` / `assistant.reasoning` event. Carries the
+/// full `content`. Many sessions stream deltas first and then send the final
+/// event with `content == accumulated deltas`; appending it would duplicate the
+/// text. We REPLACE only when the final content is strictly longer than what we
+/// already accumulated (i.e. the deltas did not cover the whole message — for
+/// example when delta streaming was suppressed). Otherwise we keep the
+/// streamed text.
+fn apply_full_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
+    state.status = SessionRuntimeStatus::Running;
+    let Some(content) = event_text_field(
+        &event.data,
+        &[
             "content",
+            "chunkContent",
+            "chunk_content",
+            "text",
             "message",
             "value",
         ],
-    ) {
-        Some(delta) => match kind {
-            TextKind::Assistant => append_capped(&mut state.assistant_text, &delta),
-            TextKind::Reasoning => append_capped(&mut state.reasoning_text, &delta),
-        },
-        None => {}
+    ) else {
+        return;
+    };
+    let target = match kind {
+        TextKind::Assistant => &mut state.assistant_text,
+        TextKind::Reasoning => &mut state.reasoning_text,
+    };
+    // Replace only if the final content is longer than the accumulated text;
+    // otherwise the deltas already produced the final text.
+    if content.chars().count() > target.chars().count() {
+        target.clear();
+        append_capped(target, &content);
     }
 }
 
@@ -120,21 +155,24 @@ fn upsert_tool(state: &mut SessionLiveState, event: &BridgeEvent, fallback_statu
         ],
     );
     let progress = number_field(&event.data, &["percent", "progress", "percentage"]);
-    let partial_result = event
+    // Treat the final-completion `result` separately from in-flight
+    // `partial_output`: completion replaces the live preview, but partials are
+    // merged so we don't lose earlier streamed output if a server emits
+    // incremental chunks (some do, some send cumulative snapshots).
+    let partial_payload = event
         .data
         .get("partialResult")
         .or_else(|| event.data.get("partialOutput"))
         .or_else(|| event.data.get("partial_result"))
-        .or_else(|| event.data.get("partial_output"))
-        .or_else(|| event.data.get("result"))
-        .map(compact_partial_result);
+        .or_else(|| event.data.get("partial_output"));
+    let final_result = event.data.get("result");
     let summary = ToolProgressSummary {
         tool_call_id: tool_call_id.clone(),
         tool_name,
         status,
         message,
         progress,
-        partial_result,
+        partial_result: None, // Filled in by the merge step below.
         updated_at: event.timestamp.clone(),
     };
     if let Some(id) = tool_call_id
@@ -147,17 +185,68 @@ fn upsert_tool(state: &mut SessionLiveState, event: &BridgeEvent, fallback_statu
         existing.status = summary.status;
         existing.message = summary.message.or_else(|| existing.message.clone());
         existing.progress = summary.progress.or(existing.progress);
-        existing.partial_result = summary
-            .partial_result
-            .or_else(|| existing.partial_result.clone());
+        if let Some(result) = final_result {
+            existing.partial_result = Some(compact_partial_result(result));
+        } else if let Some(incoming) = partial_payload {
+            existing.partial_result = Some(merge_partial_result(
+                existing.partial_result.as_ref(),
+                incoming,
+            ));
+        }
         existing.updated_at = summary.updated_at;
         return;
+    }
+    let mut summary = summary;
+    if let Some(result) = final_result {
+        summary.partial_result = Some(compact_partial_result(result));
+    } else if let Some(incoming) = partial_payload {
+        summary.partial_result = Some(merge_partial_result(None, incoming));
     }
     state.tools.push(summary);
     if state.tools.len() > MAX_TOOLS {
         let overflow = state.tools.len() - MAX_TOOLS;
         state.tools.drain(0..overflow);
     }
+}
+
+/// Merge a streamed partial-output payload into the previous one.
+///
+/// SDK servers vary: some emit `partial_output` as the *cumulative* snapshot,
+/// others as *incremental* deltas. We don't want to lose history in the
+/// incremental case (the previous behaviour, which always replaced, dropped
+/// earlier stdout) or to produce duplicate suffixes in the cumulative case.
+///
+/// Strategy when both old and new are strings:
+/// * If `new.starts_with(old)` — new is a cumulative snapshot that extends old; keep `new`.
+/// * If `old.starts_with(new)` — new is a re-send of an earlier prefix; keep `old`.
+/// * Otherwise — treat new as an incremental chunk and append.
+///
+/// For non-string payloads (objects/arrays produced by structured tools) we
+/// keep the latest snapshot — those are typically replacement payloads.
+fn merge_partial_result(existing: Option<&Value>, incoming: &Value) -> Value {
+    let incoming_compacted = compact_partial_result(incoming);
+    let Some(existing) = existing else {
+        return incoming_compacted;
+    };
+    // The existing payload may already be a compacted `{truncated, preview}`
+    // object from a prior over-cap merge. Treat its `preview` as the
+    // accumulated string so further incremental chunks keep extending it
+    // instead of clobbering the preview with the new chunk alone.
+    let old_str = existing.as_str().or_else(|| compacted_preview(existing));
+    let (Some(old_str), Some(new_str)) = (old_str, incoming.as_str()) else {
+        return incoming_compacted;
+    };
+    let merged = if new_str.starts_with(old_str) {
+        new_str.to_string()
+    } else if old_str.starts_with(new_str) {
+        old_str.to_string()
+    } else {
+        let mut s = String::with_capacity(old_str.len() + new_str.len());
+        s.push_str(old_str);
+        s.push_str(new_str);
+        s
+    };
+    compact_partial_result(&Value::String(merged))
 }
 
 fn request_summary(event: &BridgeEvent, kind: &str) -> PendingRequestSummary {
@@ -264,17 +353,29 @@ fn compact_partial_result(value: &Value) -> Value {
     }
 }
 
+/// Extract the `preview` string from a compacted `{truncated: true, preview}`
+/// object so cap-crossing incremental merges keep extending the accumulated
+/// stdout rather than replacing it with only the latest chunk.
+fn compacted_preview(value: &Value) -> Option<&str> {
+    let obj = value.as_object()?;
+    if obj.get("truncated").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    obj.get("preview").and_then(Value::as_str)
+}
+
+/// Keep only the trailing `max_len` characters of `value`. For streaming
+/// stdout/tool output the tail is what the user is actively watching, so we
+/// drop the *oldest* bytes when over the cap rather than the latest ones.
 fn truncate_string(value: &str, max_len: usize) -> String {
     if value.len() <= max_len {
         return value.to_string();
     }
-    let end = value
-        .char_indices()
-        .map(|(idx, _)| idx)
-        .take_while(|idx| *idx <= max_len)
-        .last()
-        .unwrap_or(0);
-    format!("{}…", &value[..end])
+    let mut start = value.len().saturating_sub(max_len);
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("…{}", &value[start..])
 }
 
 fn warn(state: &mut SessionLiveState, event: &BridgeEvent, warning: &str) {

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
@@ -1,4 +1,7 @@
-use super::{PendingRequestSummary, SessionLiveState, SessionRuntimeStatus, ToolProgressSummary};
+use super::{
+    PendingDelta, PendingRequestSummary, SessionLiveState, SessionRuntimeStatus,
+    ToolProgressSummary,
+};
 use crate::bridge::BridgeEvent;
 use serde_json::{Value, json};
 
@@ -9,6 +12,10 @@ const MAX_TOOLS: usize = 32;
 // `tool.execution_complete` the persisted result takes over from disk.
 pub(super) const MAX_PARTIAL_RESULT_CHARS: usize = 64 * 1024;
 const MAX_REDUCER_WARNINGS: usize = 8;
+// Reorder window for delta events. Pinned Copilot SDK `tokio::spawn`s a fresh
+// task per notification so adjacent deltas can race into `event_tx.send` in
+// non-source order. Mirror the frontend `DELTA_REORDER_WINDOW`.
+const DELTA_REORDER_WINDOW: usize = 4;
 
 pub fn apply_event(state: &mut SessionLiveState, event: &BridgeEvent) {
     state.last_event_id = event.id.clone();
@@ -59,13 +66,12 @@ enum TextKind {
 }
 
 /// Apply an `assistant.message_delta` / `assistant.reasoning_delta` event by
-/// appending only the incremental delta payload. The SDK emits `deltaContent`
-/// (camelCase of `delta_content`); we accept a few aliases used by alternative
-/// servers but never read `content` here — that field is the FULL message and
-/// belongs to the non-delta event.
+/// inserting its delta payload into a small reorder buffer keyed by
+/// `event.timestamp`, then committing entries that drop out of the window.
+/// The visible `*_text` is recomputed as `committed + pending sorted joined`.
 fn append_delta(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
     state.status = SessionRuntimeStatus::Running;
-    if let Some(delta) = event_text_field(
+    let Some(delta) = event_text_field(
         &event.data,
         &[
             "deltaContent",
@@ -74,21 +80,60 @@ fn append_delta(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKin
             "chunk_content",
             "delta",
         ],
-    ) {
-        match kind {
-            TextKind::Assistant => append_capped(&mut state.assistant_text, &delta),
-            TextKind::Reasoning => append_capped(&mut state.reasoning_text, &delta),
+    ) else {
+        return;
+    };
+    let incoming = PendingDelta {
+        delta,
+        timestamp: event.timestamp.clone(),
+    };
+    let (committed, pending, visible) = match kind {
+        TextKind::Assistant => (
+            &mut state.assistant_committed,
+            &mut state.assistant_pending,
+            &mut state.assistant_text,
+        ),
+        TextKind::Reasoning => (
+            &mut state.reasoning_committed,
+            &mut state.reasoning_pending,
+            &mut state.reasoning_text,
+        ),
+    };
+    insert_pending_sorted(pending, incoming);
+    while pending.len() > DELTA_REORDER_WINDOW {
+        let drained = pending.remove(0);
+        append_capped(committed, &drained.delta);
+    }
+    rebuild_visible(committed, pending, visible);
+}
+
+fn insert_pending_sorted(pending: &mut Vec<PendingDelta>, incoming: PendingDelta) {
+    // Stable insertion in ascending timestamp order.
+    let pos = pending
+        .iter()
+        .position(|p| incoming.timestamp < p.timestamp)
+        .unwrap_or(pending.len());
+    pending.insert(pos, incoming);
+}
+
+fn rebuild_visible(committed: &str, pending: &[PendingDelta], visible: &mut String) {
+    visible.clear();
+    visible.push_str(committed);
+    for p in pending {
+        visible.push_str(&p.delta);
+    }
+    if visible.len() > MAX_TEXT_PREVIEW_CHARS {
+        let mut start = visible.len().saturating_sub(MAX_TEXT_PREVIEW_CHARS);
+        while start < visible.len() && !visible.is_char_boundary(start) {
+            start += 1;
         }
+        visible.drain(..start);
     }
 }
 
-/// Apply a final `assistant.message` / `assistant.reasoning` event. Carries the
-/// full `content`. Many sessions stream deltas first and then send the final
-/// event with `content == accumulated deltas`; appending it would duplicate the
-/// text. We REPLACE only when the final content is strictly longer than what we
-/// already accumulated (i.e. the deltas did not cover the whole message — for
-/// example when delta streaming was suppressed). Otherwise we keep the
-/// streamed text.
+/// Apply a final `assistant.message` / `assistant.reasoning` event. Drains the
+/// reorder buffer into `committed`, then snap-replaces if the canonical
+/// `content` is longer than what we accumulated (covers tail garble).
 fn apply_full_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
     state.status = SessionRuntimeStatus::Running;
     let Some(content) = event_text_field(
@@ -104,22 +149,38 @@ fn apply_full_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: Text
     ) else {
         return;
     };
-    let target = match kind {
-        TextKind::Assistant => &mut state.assistant_text,
-        TextKind::Reasoning => &mut state.reasoning_text,
+    let (committed, pending, visible) = match kind {
+        TextKind::Assistant => (
+            &mut state.assistant_committed,
+            &mut state.assistant_pending,
+            &mut state.assistant_text,
+        ),
+        TextKind::Reasoning => (
+            &mut state.reasoning_committed,
+            &mut state.reasoning_pending,
+            &mut state.reasoning_text,
+        ),
     };
-    // Replace only if the final content is longer than the accumulated text;
-    // otherwise the deltas already produced the final text.
-    if content.chars().count() > target.chars().count() {
-        target.clear();
-        append_capped(target, &content);
+    // Drain pending into committed.
+    for p in pending.drain(..) {
+        append_capped(committed, &p.delta);
     }
+    // Snap-replace if the final content is longer (in chars).
+    if content.chars().count() > committed.chars().count() {
+        committed.clear();
+        append_capped(committed, &content);
+    }
+    rebuild_visible(committed, pending, visible);
 }
 
 fn start_turn(state: &mut SessionLiveState) {
     state.status = SessionRuntimeStatus::Running;
     state.assistant_text.clear();
     state.reasoning_text.clear();
+    state.assistant_committed.clear();
+    state.reasoning_committed.clear();
+    state.assistant_pending.clear();
+    state.reasoning_pending.clear();
     state.tools.clear();
     state.usage = None;
     state.pending_permission = None;

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs
@@ -21,12 +21,13 @@ pub fn apply_event(state: &mut SessionLiveState, event: &BridgeEvent) {
     state.last_event_id = event.id.clone();
     state.last_event_type = Some(event.event_type.clone());
     state.last_event_timestamp = Some(event.timestamp.clone());
-    if let Some(turn_id) = turn_id(event) {
-        state.current_turn_id = Some(turn_id);
-    }
+    // NOTE: `current_turn_id` is updated ONLY by `assistant.turn_start` (in
+    // `start_turn`). Updating it from every event would let a late delta from
+    // a previous turn flip the active-turn pointer back, contaminating the
+    // new turn's text. See `tests_reorder::previous_turn_delta_is_isolated`.
 
     match event.event_type.as_str() {
-        "assistant.turn_start" => start_turn(state),
+        "assistant.turn_start" => start_turn(state, event),
         "user.message" => state.status = SessionRuntimeStatus::Running,
         "assistant.message_delta" => append_delta(state, event, TextKind::Assistant),
         "assistant.reasoning_delta" => append_delta(state, event, TextKind::Reasoning),
@@ -71,6 +72,18 @@ enum TextKind {
 /// The visible `*_text` is recomputed as `committed + pending sorted joined`.
 fn append_delta(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
     state.status = SessionRuntimeStatus::Running;
+    if !belongs_to_active_turn(state, event) {
+        return;
+    }
+    let finalized = match kind {
+        TextKind::Assistant => state.assistant_finalized,
+        TextKind::Reasoning => state.reasoning_finalized,
+    };
+    if finalized {
+        // Final event already drained + snap-replaced this stream. A late
+        // delta would re-corrupt the canonical text — drop it.
+        return;
+    }
     let Some(delta) = event_text_field(
         &event.data,
         &[
@@ -136,6 +149,9 @@ fn rebuild_visible(committed: &str, pending: &[PendingDelta], visible: &mut Stri
 /// `content` is longer than what we accumulated (covers tail garble).
 fn apply_full_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: TextKind) {
     state.status = SessionRuntimeStatus::Running;
+    if !belongs_to_active_turn(state, event) {
+        return;
+    }
     let Some(content) = event_text_field(
         &event.data,
         &[
@@ -171,16 +187,41 @@ fn apply_full_text(state: &mut SessionLiveState, event: &BridgeEvent, kind: Text
         append_capped(committed, &content);
     }
     rebuild_visible(committed, pending, visible);
+    // Mark this stream finalized so any straggler delta arriving after the
+    // canonical text is dropped instead of re-corrupting it.
+    match kind {
+        TextKind::Assistant => state.assistant_finalized = true,
+        TextKind::Reasoning => state.reasoning_finalized = true,
+    }
 }
 
-fn start_turn(state: &mut SessionLiveState) {
+/// Returns true if `event` belongs to the currently active turn (or no active
+/// turn has been observed yet, in which case we accept everything to remain
+/// permissive on connection-attach / reattach paths).
+fn belongs_to_active_turn(state: &SessionLiveState, event: &BridgeEvent) -> bool {
+    let Some(active) = state.current_turn_id.as_deref() else {
+        return true;
+    };
+    let event_turn = turn_id(event);
+    match event_turn.as_deref() {
+        Some(t) => t == active,
+        // Event has no parent/turn id of its own — accept it on the active
+        // turn (deltas/finals without parentId can't be cross-turn anyway).
+        None => true,
+    }
+}
+
+fn start_turn(state: &mut SessionLiveState, event: &BridgeEvent) {
     state.status = SessionRuntimeStatus::Running;
+    state.current_turn_id = turn_id(event);
     state.assistant_text.clear();
     state.reasoning_text.clear();
     state.assistant_committed.clear();
     state.reasoning_committed.clear();
     state.assistant_pending.clear();
     state.reasoning_pending.clear();
+    state.assistant_finalized = false;
+    state.reasoning_finalized = false;
     state.tools.clear();
     state.usage = None;
     state.pending_permission = None;

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/tests.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::bridge::BridgeEvent;
-use serde_json::json;
+use crate::bridge::live_state::reducer::MAX_PARTIAL_RESULT_CHARS;
+use serde_json::{Value, json};
 
 fn event(event_type: &str, data: serde_json::Value) -> BridgeEvent {
     BridgeEvent {
@@ -204,7 +205,8 @@ fn live_text_preview_is_bounded() {
 #[test]
 fn tool_summaries_and_partial_results_are_bounded() {
     let store = LiveStateStore::new();
-    let large = "x".repeat(3 * 1024);
+    // Exceed the 64 KiB partial-result cap with a single jumbo payload.
+    let large = "x".repeat(80 * 1024);
     let mut state = store.apply_event(&event(
         "tool.execution_partial_result",
         json!({"toolCallId": "t0", "partialOutput": large}),
@@ -257,4 +259,190 @@ fn turn_start_clears_reducer_warnings() {
         state.reducer_warnings.is_empty(),
         "Expected warnings to be cleared on turn_start"
     );
+}
+
+// ─── Regression: deltas + final assistant.message must NOT duplicate text ───
+//
+// Pinned Copilot SDK emits `assistant.message_delta` with `deltaContent`
+// followed by a final `assistant.message` event carrying the FULL `content`.
+// Earlier reducer logic appended both, producing duplicated streamed text in
+// the live preview.
+#[test]
+fn assistant_message_final_after_deltas_does_not_duplicate_text() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event(
+        "assistant.message_delta",
+        json!({"messageId": "m1", "deltaContent": "Hello "}),
+    ));
+    store.apply_event(&event(
+        "assistant.message_delta",
+        json!({"messageId": "m1", "deltaContent": "world"}),
+    ));
+    let state = store.apply_event(&event(
+        "assistant.message",
+        json!({"messageId": "m1", "content": "Hello world"}),
+    ));
+    assert_eq!(state.assistant_text, "Hello world");
+}
+
+#[test]
+fn assistant_reasoning_final_after_deltas_does_not_duplicate_text() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event(
+        "assistant.reasoning_delta",
+        json!({"reasoningId": "r1", "deltaContent": "thinking "}),
+    ));
+    store.apply_event(&event(
+        "assistant.reasoning_delta",
+        json!({"reasoningId": "r1", "deltaContent": "hard"}),
+    ));
+    let state = store.apply_event(&event(
+        "assistant.reasoning",
+        json!({"reasoningId": "r1", "content": "thinking hard"}),
+    ));
+    assert_eq!(state.reasoning_text, "thinking hard");
+}
+
+/// When deltas were suppressed (e.g. server emitted only the final message)
+/// the final `content` must populate the live preview so the user sees it.
+#[test]
+fn assistant_message_without_deltas_populates_text() {
+    let store = LiveStateStore::new();
+    let state = store.apply_event(&event(
+        "assistant.message",
+        json!({"messageId": "m1", "content": "Standalone full message"}),
+    ));
+    assert_eq!(state.assistant_text, "Standalone full message");
+}
+
+/// `assistant.message_delta` must NOT pick up the `content` field. (Some
+/// callers historically logged the full content under `content` on deltas;
+/// treating that as a delta produced runaway duplication.)
+#[test]
+fn assistant_message_delta_ignores_content_field() {
+    let store = LiveStateStore::new();
+    let state = store.apply_event(&event(
+        "assistant.message_delta",
+        // No deltaContent — just a stale `content` field. We must ignore it.
+        json!({"messageId": "m1", "content": "irrelevant"}),
+    ));
+    assert_eq!(state.assistant_text, "");
+}
+
+// ─── Tool partial-output streaming regression ───────────────────────────────
+
+/// Cumulative partial_output snapshots (each event extends the previous):
+/// the live tool entry should carry the latest snapshot, never duplicated.
+#[test]
+fn tool_partial_result_handles_cumulative_snapshots() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "line 1\n"}),
+    ));
+    let state = store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "line 1\nline 2\n"}),
+    ));
+    assert_eq!(
+        state.tools[0]
+            .partial_result
+            .as_ref()
+            .and_then(Value::as_str),
+        Some("line 1\nline 2\n")
+    );
+}
+
+/// Incremental partial_output chunks (each event is a delta): they must be
+/// concatenated, not lost like the old `replace`-based code did.
+#[test]
+fn tool_partial_result_accumulates_incremental_chunks() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "line 1\n"}),
+    ));
+    let state = store.apply_event(&event(
+        "tool.execution_partial_result",
+        // not a prefix of "line 1\n" — treated as an incremental delta
+        json!({"toolCallId": "t1", "partialOutput": "line 2\n"}),
+    ));
+    assert_eq!(
+        state.tools[0]
+            .partial_result
+            .as_ref()
+            .and_then(Value::as_str),
+        Some("line 1\nline 2\n")
+    );
+}
+
+/// Final `result` from `tool.execution_complete` should replace the streamed
+/// partial output (the persisted tool result will take over from disk).
+#[test]
+fn tool_complete_result_replaces_partial_preview() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "streaming…"}),
+    ));
+    let state = store.apply_event(&event(
+        "tool.execution_complete",
+        json!({"toolCallId": "t1", "success": true, "result": "final output"}),
+    ));
+    assert_eq!(
+        state.tools[0]
+            .partial_result
+            .as_ref()
+            .and_then(Value::as_str),
+        Some("final output")
+    );
+    assert_eq!(state.tools[0].status, "complete");
+}
+
+/// Regression: when accumulated incremental partial output crosses the
+/// `MAX_PARTIAL_RESULT_CHARS` cap, the reducer compacts it to
+/// `{truncated: true, preview: ...}`. The next incremental string chunk must
+/// continue extending that preview rather than replacing it with only the
+/// new chunk (which would lose the entire stdout history).
+#[test]
+fn tool_partial_result_extends_preview_after_cap() {
+    let store = LiveStateStore::new();
+    let big = "a".repeat(MAX_PARTIAL_RESULT_CHARS - 100);
+    store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": big}),
+    ));
+    // Push past the cap; the stored value is now a compacted preview object.
+    let state_mid = store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "X".repeat(500)}),
+    ));
+    let preview_mid = state_mid.tools[0]
+        .partial_result
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .and_then(|o| o.get("preview"))
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+    assert!(preview_mid.contains("XXXXX"));
+
+    // Next incremental chunk must keep extending the accumulated preview's
+    // tail — i.e., the reducer must not clobber it with just "Z...".
+    let state = store.apply_event(&event(
+        "tool.execution_partial_result",
+        json!({"toolCallId": "t1", "partialOutput": "Z".repeat(50)}),
+    ));
+    let preview = state.tools[0]
+        .partial_result
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .and_then(|o| o.get("preview"))
+        .and_then(Value::as_str)
+        .unwrap();
+    assert!(
+        preview.contains("XXXXX"),
+        "preview should still contain prior X chunk after cap-crossing merge: {preview:?}"
+    );
+    assert!(preview.ends_with(&"Z".repeat(50)));
 }

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/tests.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/tests.rs
@@ -24,7 +24,11 @@ fn message_delta_appends_assistant_text() {
     ));
     assert_eq!(state.status, SessionRuntimeStatus::Running);
     assert_eq!(state.assistant_text, "hi");
-    assert_eq!(state.current_turn_id.as_deref(), Some("turn-1"));
+    // `current_turn_id` is only set by `assistant.turn_start`. A delta with
+    // no preceding turn_start does NOT set the active turn — this prevents a
+    // late delta from a previous turn from re-establishing it after a new
+    // turn has rotated.
+    assert_eq!(state.current_turn_id, None);
 }
 
 #[test]

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/tests_reorder.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/tests_reorder.rs
@@ -81,3 +81,101 @@ fn out_of_order_reasoning_deltas_are_reordered() {
     ));
     assert_eq!(state.reasoning_text, "AB");
 }
+
+/// Late deltas arriving AFTER `assistant.message` finalizes the stream must
+/// be dropped — appending them would re-corrupt the canonical text.
+#[test]
+fn late_delta_after_finalize_is_ignored() {
+    let store = LiveStateStore::new();
+    // Establish a turn so subsequent events are accepted onto it.
+    store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.turn_start".into(),
+        timestamp: "2026-04-27T00:00:00.000Z".into(),
+        id: Some("turn-1".into()),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data: json!({"turnId": "turn-1"}),
+    });
+    store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.001Z",
+        json!({"deltaContent": "hello "}),
+    ));
+    store.apply_event(&event_at(
+        "assistant.message",
+        "2026-04-27T00:00:00.010Z",
+        json!({"content": "hello world"}),
+    ));
+    let state = store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.002Z",
+        json!({"deltaContent": "world"}),
+    ));
+    assert_eq!(state.assistant_text, "hello world");
+}
+
+/// A previous-turn delta that arrives after the next `assistant.turn_start`
+/// must be rejected — its parent_id no longer matches the active turn.
+#[test]
+fn previous_turn_delta_is_isolated_after_rotation() {
+    let store = LiveStateStore::new();
+    let turn1_start = BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.turn_start".into(),
+        timestamp: "2026-04-27T00:00:00.000Z".into(),
+        id: Some("turn-1".into()),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data: json!({"turnId": "turn-1"}),
+    };
+    store.apply_event(&turn1_start);
+    store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.message_delta".into(),
+        timestamp: "2026-04-27T00:00:00.001Z".into(),
+        id: Some("d1".into()),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data: json!({"deltaContent": "first "}),
+    });
+    store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.message".into(),
+        timestamp: "2026-04-27T00:00:00.010Z".into(),
+        id: Some("m1".into()),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data: json!({"content": "first turn"}),
+    });
+    store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.turn_start".into(),
+        timestamp: "2026-04-27T00:00:01.000Z".into(),
+        id: Some("turn-2".into()),
+        parent_id: Some("turn-2".into()),
+        ephemeral: false,
+        data: json!({"turnId": "turn-2"}),
+    });
+    store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.message_delta".into(),
+        timestamp: "2026-04-27T00:00:01.001Z".into(),
+        id: Some("d2".into()),
+        parent_id: Some("turn-2".into()),
+        ephemeral: false,
+        data: json!({"deltaContent": "second"}),
+    });
+    // Straggler from the PREVIOUS turn arriving after rotation:
+    let state = store.apply_event(&BridgeEvent {
+        session_id: "s1".into(),
+        event_type: "assistant.message_delta".into(),
+        timestamp: "2026-04-27T00:00:00.002Z".into(),
+        id: Some("d1-late".into()),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data: json!({"deltaContent": "STRAGGLER"}),
+    });
+    assert_eq!(state.assistant_text, "second");
+    assert_eq!(state.current_turn_id.as_deref(), Some("turn-2"));
+}

--- a/crates/tracepilot-orchestrator/src/bridge/live_state/tests_reorder.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/tests_reorder.rs
@@ -1,0 +1,83 @@
+use super::*;
+use crate::bridge::BridgeEvent;
+use serde_json::json;
+
+fn event_at(event_type: &str, timestamp: &str, data: serde_json::Value) -> BridgeEvent {
+    BridgeEvent {
+        session_id: "s1".into(),
+        event_type: event_type.into(),
+        timestamp: timestamp.into(),
+        id: Some(format!("evt-{event_type}-{timestamp}")),
+        parent_id: Some("turn-1".into()),
+        ephemeral: false,
+        data,
+    }
+}
+
+/// Repro for the SDK race: pinned Copilot SDK `tokio::spawn`s a fresh task per
+/// `session.event` notification, so adjacent deltas can race into
+/// `event_tx.send` in non-source order. The reducer must sort by
+/// `event.timestamp` before committing.
+#[test]
+fn out_of_order_deltas_are_reordered_by_timestamp() {
+    let store = LiveStateStore::new();
+    // Source order: "hell" (t1) then "ow" (t2) then " world" (t3).
+    // Wire order: t1, t3, t2.
+    store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.001Z",
+        json!({"deltaContent": "hell"}),
+    ));
+    store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.003Z",
+        json!({"deltaContent": " world"}),
+    ));
+    let state = store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.002Z",
+        json!({"deltaContent": "ow"}),
+    ));
+    assert_eq!(state.assistant_text, "hellow world");
+}
+
+/// When the reorder window can't recover (e.g. the final event arrives while
+/// the pending tail is still garbled), the canonical `assistant.message`
+/// content snap-replaces if it's longer than what we accumulated.
+#[test]
+fn assistant_message_snap_replaces_garbled_pending_tail() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.002Z",
+        json!({"deltaContent": "world"}),
+    ));
+    store.apply_event(&event_at(
+        "assistant.message_delta",
+        "2026-04-27T00:00:00.001Z",
+        json!({"deltaContent": "hello "}),
+    ));
+    let state = store.apply_event(&event_at(
+        "assistant.message",
+        "2026-04-27T00:00:00.010Z",
+        json!({"content": "hello world (canonical)"}),
+    ));
+    assert_eq!(state.assistant_text, "hello world (canonical)");
+}
+
+/// Reasoning deltas use the same buffer logic.
+#[test]
+fn out_of_order_reasoning_deltas_are_reordered() {
+    let store = LiveStateStore::new();
+    store.apply_event(&event_at(
+        "assistant.reasoning_delta",
+        "2026-04-27T00:00:00.002Z",
+        json!({"deltaContent": "B"}),
+    ));
+    let state = store.apply_event(&event_at(
+        "assistant.reasoning_delta",
+        "2026-04-27T00:00:00.001Z",
+        json!({"deltaContent": "A"}),
+    ));
+    assert_eq!(state.reasoning_text, "AB");
+}

--- a/crates/tracepilot-orchestrator/src/bridge/manager/session_tasks.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/manager/session_tasks.rs
@@ -77,16 +77,6 @@ impl BridgeManager {
         working_directory: Option<&str>,
         model: Option<&str>,
     ) -> Result<BridgeSessionInfo, BridgeError> {
-        let bt = std::backtrace::Backtrace::force_capture();
-        info!(
-            target: "tracepilot::sdk_diag",
-            "[sdk-diag] resume_session session={} cwd={:?} model={:?} already_tracked={}\n  backtrace:\n{}",
-            session_id,
-            working_directory,
-            model,
-            self.sessions.contains_key(session_id),
-            bt,
-        );
         // Already tracked — no-op. This branch runs *before* the preference
         // check so sessions resumed prior to the user toggling the pref off
         // remain steerable (documented on `BridgeError::DisabledByPreference`).
@@ -173,17 +163,6 @@ impl BridgeManager {
         payload: BridgeMessagePayload,
     ) -> Result<String, BridgeError> {
         let session = self.require_session(session_id)?;
-        let prompt_preview: String = payload.prompt.chars().take(60).collect();
-        let bt = std::backtrace::Backtrace::force_capture();
-        info!(
-            target: "tracepilot::sdk_diag",
-            "[sdk-diag] send_message session={} mode={:?} prompt_chars={} preview={:?}\n  backtrace:\n{}",
-            session_id,
-            payload.mode,
-            payload.prompt.chars().count(),
-            prompt_preview,
-            bt,
-        );
 
         let opts = copilot_sdk::MessageOptions {
             prompt: payload.prompt,
@@ -298,7 +277,6 @@ impl BridgeManager {
                                 // live-state reducer) can read fields like `deltaContent` directly.
                                 data: flatten_event_data(&event.data),
                             };
-                            log_sdk_diag_event(&sid, &bridge_event);
                             let state = live_state.apply_event(&bridge_event);
                             if state_tx.send(state).is_err() {
                                 debug!("No SDK session-state receivers for {}", sid);
@@ -351,55 +329,6 @@ impl BridgeManager {
             is_remote: false,
         }
     }
-}
-
-/// TEMPORARY diagnostic logging for the SDK live-stream bug investigation
-/// (PR #536 follow-up). Logs every assistant.* / session.* / tool.execution_*
-/// event at info! level with a stable `[sdk-diag]` prefix users can grep in
-/// `Tracepilot.txt`. Includes a short content preview, message/turn IDs, and
-/// the event broadcast `id` so we can detect duplicates in the stream.
-///
-/// TODO(#536-followup): remove once the garbled-stream / double-send /
-/// duplicate-resume root causes are resolved.
-fn log_sdk_diag_event(session_id: &str, event: &BridgeEvent) {
-    let et = event.event_type.as_str();
-    let interesting = et.starts_with("assistant.")
-        || et.starts_with("session.")
-        || et.starts_with("tool.execution_")
-        || et == "user_input.requested"
-        || et == "user_input.resolved";
-    if !interesting {
-        return;
-    }
-    fn s(v: &serde_json::Value, k: &str) -> Option<String> {
-        v.get(k).and_then(|x| x.as_str()).map(|s| s.to_string())
-    }
-    fn preview(v: &serde_json::Value, k: &str) -> Option<String> {
-        v.get(k).and_then(|x| x.as_str()).map(|s| {
-            let n = s.chars().count().min(80);
-            let truncated: String = s.chars().take(n).collect();
-            format!(
-                "{:?}{}",
-                truncated,
-                if n < s.chars().count() { "…" } else { "" }
-            )
-        })
-    }
-    let d = &event.data;
-    info!(
-        target: "tracepilot::sdk_diag",
-        "[sdk-diag] event session={} type={} id={:?} parent={:?} msgId={:?} reasoningId={:?} toolCallId={:?} delta={} content={} chunk={}",
-        session_id,
-        et,
-        event.id.as_deref().unwrap_or("-"),
-        event.parent_id.as_deref().unwrap_or("-"),
-        s(d, "messageId").as_deref().unwrap_or("-"),
-        s(d, "reasoningId").as_deref().unwrap_or("-"),
-        s(d, "toolCallId").as_deref().unwrap_or("-"),
-        preview(d, "deltaContent").as_deref().unwrap_or("-"),
-        preview(d, "content").as_deref().unwrap_or("-"),
-        preview(d, "chunkContent").as_deref().unwrap_or("-"),
-    );
 }
 
 /// Flatten the externally-tagged `SessionEventData` enum into its inner payload.

--- a/crates/tracepilot-orchestrator/src/bridge/manager/session_tasks.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/manager/session_tasks.rs
@@ -77,6 +77,16 @@ impl BridgeManager {
         working_directory: Option<&str>,
         model: Option<&str>,
     ) -> Result<BridgeSessionInfo, BridgeError> {
+        let bt = std::backtrace::Backtrace::force_capture();
+        info!(
+            target: "tracepilot::sdk_diag",
+            "[sdk-diag] resume_session session={} cwd={:?} model={:?} already_tracked={}\n  backtrace:\n{}",
+            session_id,
+            working_directory,
+            model,
+            self.sessions.contains_key(session_id),
+            bt,
+        );
         // Already tracked — no-op. This branch runs *before* the preference
         // check so sessions resumed prior to the user toggling the pref off
         // remain steerable (documented on `BridgeError::DisabledByPreference`).
@@ -163,6 +173,17 @@ impl BridgeManager {
         payload: BridgeMessagePayload,
     ) -> Result<String, BridgeError> {
         let session = self.require_session(session_id)?;
+        let prompt_preview: String = payload.prompt.chars().take(60).collect();
+        let bt = std::backtrace::Backtrace::force_capture();
+        info!(
+            target: "tracepilot::sdk_diag",
+            "[sdk-diag] send_message session={} mode={:?} prompt_chars={} preview={:?}\n  backtrace:\n{}",
+            session_id,
+            payload.mode,
+            payload.prompt.chars().count(),
+            prompt_preview,
+            bt,
+        );
 
         let opts = copilot_sdk::MessageOptions {
             prompt: payload.prompt,
@@ -277,6 +298,7 @@ impl BridgeManager {
                                 // live-state reducer) can read fields like `deltaContent` directly.
                                 data: flatten_event_data(&event.data),
                             };
+                            log_sdk_diag_event(&sid, &bridge_event);
                             let state = live_state.apply_event(&bridge_event);
                             if state_tx.send(state).is_err() {
                                 debug!("No SDK session-state receivers for {}", sid);
@@ -329,6 +351,55 @@ impl BridgeManager {
             is_remote: false,
         }
     }
+}
+
+/// TEMPORARY diagnostic logging for the SDK live-stream bug investigation
+/// (PR #536 follow-up). Logs every assistant.* / session.* / tool.execution_*
+/// event at info! level with a stable `[sdk-diag]` prefix users can grep in
+/// `Tracepilot.txt`. Includes a short content preview, message/turn IDs, and
+/// the event broadcast `id` so we can detect duplicates in the stream.
+///
+/// TODO(#536-followup): remove once the garbled-stream / double-send /
+/// duplicate-resume root causes are resolved.
+fn log_sdk_diag_event(session_id: &str, event: &BridgeEvent) {
+    let et = event.event_type.as_str();
+    let interesting = et.starts_with("assistant.")
+        || et.starts_with("session.")
+        || et.starts_with("tool.execution_")
+        || et == "user_input.requested"
+        || et == "user_input.resolved";
+    if !interesting {
+        return;
+    }
+    fn s(v: &serde_json::Value, k: &str) -> Option<String> {
+        v.get(k).and_then(|x| x.as_str()).map(|s| s.to_string())
+    }
+    fn preview(v: &serde_json::Value, k: &str) -> Option<String> {
+        v.get(k).and_then(|x| x.as_str()).map(|s| {
+            let n = s.chars().count().min(80);
+            let truncated: String = s.chars().take(n).collect();
+            format!(
+                "{:?}{}",
+                truncated,
+                if n < s.chars().count() { "…" } else { "" }
+            )
+        })
+    }
+    let d = &event.data;
+    info!(
+        target: "tracepilot::sdk_diag",
+        "[sdk-diag] event session={} type={} id={:?} parent={:?} msgId={:?} reasoningId={:?} toolCallId={:?} delta={} content={} chunk={}",
+        session_id,
+        et,
+        event.id.as_deref().unwrap_or("-"),
+        event.parent_id.as_deref().unwrap_or("-"),
+        s(d, "messageId").as_deref().unwrap_or("-"),
+        s(d, "reasoningId").as_deref().unwrap_or("-"),
+        s(d, "toolCallId").as_deref().unwrap_or("-"),
+        preview(d, "deltaContent").as_deref().unwrap_or("-"),
+        preview(d, "content").as_deref().unwrap_or("-"),
+        preview(d, "chunkContent").as_deref().unwrap_or("-"),
+    );
 }
 
 /// Flatten the externally-tagged `SessionEventData` enum into its inner payload.

--- a/packages/ui/src/components/ToolCallDetail.vue
+++ b/packages/ui/src/components/ToolCallDetail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TurnToolCall } from "@tracepilot/types";
-import { computed } from "vue";
+import { computed, inject } from "vue";
+import { LIVE_TOOL_PARTIAL_OUTPUT_KEY } from "../composables/liveToolPartialOutput";
 import { formatDuration, formatTime } from "../utils/formatters";
 import ToolArgsRenderer from "./renderers/ToolArgsRenderer.vue";
 import ToolErrorDisplay from "./renderers/ToolErrorDisplay.vue";
@@ -24,6 +25,21 @@ const emit = defineEmits<{
   "retry-full-result": [toolCallId: string];
 }>();
 
+const livePartialOutputs = inject(LIVE_TOOL_PARTIAL_OUTPUT_KEY, null);
+
+// Live streaming stdout from the SDK live-state reducer, only visible
+// while the final result hasn't been persisted/loaded yet. Once the
+// persisted `resultContent` (or fetched `fullResult`) arrives, the
+// real result block takes over.
+const livePartial = computed<string | null>(() => {
+  const id = props.tc.toolCallId;
+  if (!id) return null;
+  const map = livePartialOutputs?.value;
+  if (!map) return null;
+  const value = map.get(id);
+  return typeof value === "string" && value.length > 0 ? value : null;
+});
+
 const displayResult = computed(() => {
   if (props.fullResult != null) return props.fullResult;
   return props.tc.resultContent ?? null;
@@ -37,6 +53,9 @@ const isTruncated = computed(
 );
 
 const isRichEnabled = computed(() => props.richEnabled !== false);
+
+// Show the live streaming preview only while no persisted result exists.
+const showLivePartial = computed(() => !displayResult.value && !!livePartial.value);
 </script>
 
 <template>
@@ -70,6 +89,15 @@ const isRichEnabled = computed(() => props.richEnabled !== false);
     <!-- Arguments -->
     <ToolArgsRenderer :tc="tc" :rich-enabled="isRichEnabled" />
 
+    <!-- Live streaming stdout (visible only while no persisted result) -->
+    <div v-if="showLivePartial" class="tool-result-section tool-result-section--live">
+      <div class="tool-live-header">
+        <span class="tool-live-dot" aria-hidden="true" />
+        <span class="tool-live-label">Streaming output…</span>
+      </div>
+      <pre class="tool-live-output">{{ livePartial }}</pre>
+    </div>
+
     <!-- Result -->
     <div v-if="displayResult" class="tool-result-section">
       <ToolResultRenderer
@@ -100,3 +128,53 @@ const isRichEnabled = computed(() => props.richEnabled !== false);
     </div>
   </div>
 </template>
+
+<style scoped>
+.tool-result-section--live {
+  border: 1px solid var(--border-muted);
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: var(--canvas-default, transparent);
+}
+
+.tool-live-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tool-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-fg, #1f883d);
+  box-shadow: 0 0 0 0 currentColor;
+  animation: tool-live-dot-pulse 1.6s ease-out infinite;
+}
+
+@keyframes tool-live-dot-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(31, 136, 61, 0.45); }
+  70%  { box-shadow: 0 0 0 6px rgba(31, 136, 61, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(31, 136, 61, 0); }
+}
+
+.tool-live-output {
+  margin: 0;
+  padding: 6px 8px;
+  max-height: 400px;
+  overflow: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  background: var(--canvas-inset);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/packages/ui/src/components/renderers/ToolArgsRenderer.vue
+++ b/packages/ui/src/components/renderers/ToolArgsRenderer.vue
@@ -24,17 +24,12 @@ const props = defineProps<{
 }>();
 
 /**
- * Start open when:
- *  - the registry marks this tool as auto-expanding its args (e.g. ask_user)
- *    and no result has arrived yet, OR
- *  - the tool is currently streaming (no result yet, not complete) so the
- *    user can watch the parameters as they're filled in.
+ * Open by default while the tool is still streaming (so the user can see
+ * what command is being run alongside the live stdout) or when the
+ * registry marks this tool as auto-expanding (e.g. ask_user). Stays
+ * open after completion unless the user collapses it.
  */
-const isOpen = ref(
-  !props.tc.resultContent &&
-    props.tc.isComplete !== true &&
-    (shouldAutoExpandArgs(props.tc.toolName) || props.tc.isComplete === false),
-);
+const isOpen = ref(props.tc.isComplete === false || shouldAutoExpandArgs(props.tc.toolName));
 
 const entry = computed(() => getRendererEntry(props.tc.toolName));
 

--- a/packages/ui/src/components/renderers/ToolArgsRenderer.vue
+++ b/packages/ui/src/components/renderers/ToolArgsRenderer.vue
@@ -24,11 +24,16 @@ const props = defineProps<{
 }>();
 
 /**
- * Start open when the registry marks this tool as auto-expanding its args
- * (e.g. ask_user) and no result has arrived yet — saves the user a second click.
+ * Start open when:
+ *  - the registry marks this tool as auto-expanding its args (e.g. ask_user)
+ *    and no result has arrived yet, OR
+ *  - the tool is currently streaming (no result yet, not complete) so the
+ *    user can watch the parameters as they're filled in.
  */
 const isOpen = ref(
-  shouldAutoExpandArgs(props.tc.toolName) && !props.tc.resultContent && !props.tc.isComplete,
+  !props.tc.resultContent &&
+    props.tc.isComplete !== true &&
+    (shouldAutoExpandArgs(props.tc.toolName) || props.tc.isComplete === false),
 );
 
 const entry = computed(() => getRendererEntry(props.tc.toolName));

--- a/packages/ui/src/composables/liveToolPartialOutput.ts
+++ b/packages/ui/src/composables/liveToolPartialOutput.ts
@@ -1,0 +1,16 @@
+import type { ComputedRef, InjectionKey } from "vue";
+
+/**
+ * Provides per-toolCallId live partial-output snapshots from the SDK
+ * live-state reducer. Consumers (e.g. `ToolCallDetail`) can inject this
+ * to surface streaming stdout (shell/powershell) on the in-progress
+ * persisted tool call, before its final `result` is loaded.
+ *
+ * The map is keyed by `toolCallId` and yields the latest accumulated
+ * partial output string (already merged by the live-state reducer).
+ *
+ * The provider should set this to `null` (or simply not provide it) when
+ * no live state is available for the current view.
+ */
+export const LIVE_TOOL_PARTIAL_OUTPUT_KEY: InjectionKey<ComputedRef<Map<string, string>>> =
+  Symbol("LiveToolPartialOutput");

--- a/packages/ui/src/composables/useToggleSet.ts
+++ b/packages/ui/src/composables/useToggleSet.ts
@@ -9,6 +9,7 @@ export function useToggleSet<T = string>(): {
   set: Ref<Set<T>>;
   toggle: (key: T) => void;
   has: (key: T) => boolean;
+  add: (key: T) => void;
   clear: () => void;
 } {
   const set = ref<Set<T>>(new Set()) as Ref<Set<T>>;
@@ -25,9 +26,13 @@ export function useToggleSet<T = string>(): {
     return set.value.has(key);
   }
 
+  function add(key: T) {
+    set.value.add(key);
+  }
+
   function clear() {
     set.value.clear();
   }
 
-  return { set, toggle, has, clear };
+  return { set, toggle, has, add, clear };
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -79,6 +79,7 @@ export { default as TokenBar } from "./components/TokenBar.vue";
 export { default as ToolCallDetail } from "./components/ToolCallDetail.vue";
 export { default as ToolCallItem } from "./components/ToolCallItem.vue";
 export { default as ToolDetailPanel } from "./components/ToolDetailPanel.vue";
+export { LIVE_TOOL_PARTIAL_OUTPUT_KEY } from "./composables/liveToolPartialOutput";
 export type {
   UseAsyncDataOptions,
   UseAsyncDataReturn,


### PR DESCRIPTION
## Summary

Three reported regressions in the `--ui-server` SDK live-streaming UI:

1. **Garbled message/reasoning deltas** in the live preview (e.g. `owhell world` mid-stream).
2. **Tool partial output** for shell/powershell streamed live but truncated and not surfaced on the persisted ToolCallItem after auto-refresh.
3. **Popout window auto-scroll** intermittently dropping its lock during fast streaming.

## Root causes

1. Pinned Copilot Rust SDK at `client.rs:1310-1326` `tokio::spawn`s a fresh task per `session.event` notification, so adjacent deltas race into `event_tx.send` in non-source order at the SDK boundary.
2. Reducer was replacing (not accumulating) `partial_result`, frontend was capping it again at 1200 chars, and persisted ToolCallItem had no link to the live partial.
3. `isProgrammaticScroll` guard only protected smooth scrolls; instant data-driven scrolls could land just before a streaming-induced `scrollHeight` growth, leaving the post-scroll position >disengageThreshold from the new bottom and flipping the lock off.

## Approach

- **Reorder buffer** with `DELTA_REORDER_WINDOW=4` in BOTH the TS frontend reducer (`apps/desktop/src/stores/sdk/liveTurns.ts`) and the Rust live-state reducer (`crates/tracepilot-orchestrator/src/bridge/live_state/reducer.rs`). Visible text = committed prefix + sorted-pending suffix, keyed by `event.timestamp`. Final `assistant.message` / `assistant.reasoning` events drain pending and snap-replace if canonical content is longer.
- **Late-delta + cross-turn guards** (added after GPT-5.5 review): `assistantFinalized`/`reasoningFinalized` flags drop stragglers arriving after the final event; `current_turn_id` is now set only by `assistant.turn_start`, and reducers reject deltas/finals whose `parentId` disagrees with the active turn.
- **Tool partial output**: reducer accumulates with merge logic, cap raised to 64 KiB, frontend strips its 1200-char re-truncation, and `ChatViewMode.vue` provides `LIVE_TOOL_PARTIAL_OUTPUT_KEY` so the inline tool detail surfaces live partial on the persisted ToolCallItem (auto-refresh aware: persisted result wins once loaded).
- **Popout auto-scroll**: `isProgrammaticScroll` guard extended to instant scrolls; ResizeObserver maintains lock on streaming content growth.

## Wire-format compatibility

Internal Rust reorder/finalize fields use `#[serde(skip)]` so `SessionLiveState` JSON to the frontend is unchanged.

## Tests

- `apps/desktop/src/stores/sdk/__tests__/liveTurns.reorder.test.ts` — 5 tests (reorder, snap-replace, reasoning reorder, late-delta-after-finalize, cross-turn isolation).
- `crates/tracepilot-orchestrator/src/bridge/live_state/tests_reorder.rs` — 5 tests (mirrors above).
- `apps/desktop/src/composables/__tests__/useAutoScroll.popout.test.ts` — popout scroll-lock regression coverage.
- `crates/tracepilot-orchestrator/src/bridge/live_state/tests.rs` — extended for partial-result accumulation + cap.

## Validation

- `cargo test -p tracepilot-orchestrator --lib bridge::live_state` — 29 tests pass.
- `pnpm --filter @tracepilot/desktop test -- src/stores/sdk/__tests__` — 40 tests pass.
- `cargo clippy -p tracepilot-orchestrator --lib --tests -- -D warnings` clean.
- Lefthook hooks (rustfmt, biome, typecheck, filesize) pass.

## Review-driven changes

GPT-5.5 review flagged three concerns; commit `2d8567f4` addresses the two High-severity ones (late-delta-after-finalize and cross-turn contamination). Same-millisecond timestamp inversions remain unaddressable without an SDK-side monotonic sequence; the final-event snap-replace heals these eventually.
