### PR TITLE
🎨 Palette: Add ARIA labels to copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-28 - Setup palette.md
+**Learning:** Initialized journal.
+**Action:** Ready to record critical learnings.

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -165,13 +165,14 @@ function copyTableAsJson() {
             class="fcv__copy-btn"
             :class="{ 'fcv__copy-btn--copied': dbCopied }"
             :title="dbCopied ? 'Copied!' : 'Copy table as JSON'"
+            :aria-label="dbCopied ? 'Copied!' : 'Copy table as JSON'"
             @click="copyTableAsJson"
           >
-            <svg v-if="!dbCopied" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" v-if="!dbCopied" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
               <rect x="5" y="5" width="9" height="10" rx="1"/>
               <path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v9a1 1 0 001 1h2"/>
             </svg>
-            <svg v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="3 8 6.5 12 13 4"/>
             </svg>
           </button>
@@ -278,13 +279,14 @@ function copyTableAsJson() {
           class="fcv__copy-btn"
           :class="{ 'fcv__copy-btn--copied': textCopied }"
           :title="textCopied ? 'Copied!' : 'Copy file contents'"
+          :aria-label="textCopied ? 'Copied!' : 'Copy file contents'"
           @click="copyFileContent"
         >
-          <svg v-if="!textCopied" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" v-if="!textCopied" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
             <rect x="5" y="5" width="9" height="10" rx="1"/>
             <path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v9a1 1 0 001 1h2"/>
           </svg>
-          <svg v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 8 6.5 12 13 4"/>
           </svg>
         </button>


### PR DESCRIPTION
### 💡 What
Added dynamic `aria-label` attributes to the table-copy and text-copy buttons in `FileContentViewer.vue`. Also added `aria-hidden="true"` to the decorative SVG icons inside these buttons.

### 🎯 Why
Icon-only buttons rely entirely on their visual representation for meaning. For users leveraging assistive technologies like screen readers, the lack of an `aria-label` makes these buttons unintelligible ("button"). By adding these labels dynamically, we provide immediate context (e.g., "Copy file contents" vs. "Copied!"). The `aria-hidden="true"` prevents screen readers from redundantly announcing the SVG structure.

### 📸 Before/After
**Before:**
```html
<button class="fcv__copy-btn" title="Copy file contents">
  <svg>...</svg>
</button>
```

**After:**
```html
<button class="fcv__copy-btn" title="Copy file contents" aria-label="Copy file contents">
  <svg aria-hidden="true">...</svg>
</button>
```

### ♿ Accessibility
- Enhanced screen reader support for icon-only copy buttons in the File Viewer.
- Reduced noise for assistive technologies by explicitly hiding decorative SVGs.

---
*PR created automatically by Jules for task [11995958306103654302](https://jules.google.com/task/11995958306103654302) started by @MattShelton04*