### PR TITLE
🎨 Palette: [UX] Add aria-hidden to decorative SVGs in Worktree components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Missing aria-hidden on decorative SVGs
+**Learning:** Many SVGs used for decorative icons inside interactive elements or links are missing `aria-hidden="true"`. This is a common pattern across many components (`AppSidebar.vue`, `SkillEditorMarkdownEditor.vue`, etc.), leading to screen readers announcing confusing SVG source data or duplicate content instead of reading the provided `aria-label`.
+**Action:** Always verify decorative SVGs have `aria-hidden="true"` when adding `aria-label` to parent elements, and when reviewing UI components.

--- a/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
+++ b/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
@@ -120,7 +120,7 @@ watch(
           <div class="modal-header">
             <h2 id="create-wt-title" class="modal-title">Create Worktree</h2>
             <button class="icon-btn" aria-label="Close" @click="close">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>
 
@@ -167,7 +167,7 @@ watch(
                 @click="handleFetchRemote"
               >
                 <LoadingSpinner v-if="fetchingRemote" size="sm" />
-                <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" /></svg>
+                <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M23 4v6h-6" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" /></svg>
                 {{ fetchingRemote ? 'Fetching…' : 'Fetch Latest from Remote' }}
               </button>
             </div>
@@ -195,7 +195,7 @@ watch(
             </div>
 
             <div class="modal-tip">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-fg)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" /></svg>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent-fg)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" /></svg>
               <span>A worktree lets you check out a branch in a separate directory so you can work on multiple branches simultaneously without stashing changes.</span>
             </div>
           </div>
@@ -203,7 +203,7 @@ watch(
           <div class="modal-footer">
             <button class="btn btn-sm" @click="close">Cancel</button>
             <button class="btn btn-primary btn-sm" :disabled="!newBranch.trim() || !createModalRepoPath" @click="handleCreate">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
               Create Worktree
             </button>
           </div>

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -26,11 +26,11 @@ const emit = defineEmits<{
       <div class="detail-header">
         <div class="detail-header-left">
           <div class="wt-row-icon" :class="worktree.isMainWorktree ? 'wt-row-icon--main' : 'wt-row-icon--' + worktree.status">
-            <svg v-if="worktree.isMainWorktree" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <svg v-if="worktree.isMainWorktree" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               <circle cx="12" cy="15" r="2" />
             </svg>
-            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <line x1="6" y1="3" x2="6" y2="15" />
               <circle cx="18" cy="6" r="3" />
               <circle cx="6" cy="18" r="3" />
@@ -40,12 +40,12 @@ const emit = defineEmits<{
           <span class="detail-branch">{{ worktree.branch }}</span>
           <span class="badge" :class="'badge-' + worktree.status">{{ worktree.status }}</span>
           <span v-if="worktree.isLocked" class="badge badge-locked" :title="worktree.lockedReason">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
             locked
           </span>
         </div>
-        <button class="icon-btn" @click="emit('close')">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+        <button class="icon-btn" aria-label="Close" @click="emit('close')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>
 
@@ -107,15 +107,15 @@ const emit = defineEmits<{
 
       <div class="detail-actions">
         <button class="btn btn-sm" @click="emit('open-explorer', worktree!.path)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
           Open Folder
         </button>
         <button class="btn btn-sm" @click="emit('open-terminal', worktree!.path)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>
           Open Terminal
         </button>
         <button class="btn btn-sm" @click="emit('navigate-launcher', worktree!)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="5 3 19 12 5 21 5 3" /></svg>
           Launch Session Here
         </button>
         <button
@@ -123,7 +123,7 @@ const emit = defineEmits<{
           class="btn btn-sm"
           @click="emit('navigate-session', worktree.linkedSessionId!)"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3" /><line x1="8" y1="12" x2="16" y2="12" /></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3" /><line x1="8" y1="12" x2="16" y2="12" /></svg>
           View Session
         </button>
         <button

--- a/apps/desktop/src/components/worktree/WorktreeList.vue
+++ b/apps/desktop/src/components/worktree/WorktreeList.vue
@@ -84,11 +84,11 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
     >
       <!-- Icon -->
       <div class="wt-row-icon" :class="wt.isMainWorktree ? 'wt-row-icon--main' : 'wt-row-icon--' + wt.status">
-        <svg v-if="wt.isMainWorktree" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg v-if="wt.isMainWorktree" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
           <circle cx="12" cy="15" r="2" />
         </svg>
-        <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <line x1="6" y1="3" x2="6" y2="15" />
           <circle cx="18" cy="6" r="3" />
           <circle cx="6" cy="18" r="3" />
@@ -137,6 +137,7 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
           stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
           :title="wt.lockedReason ? `Locked: ${wt.lockedReason}` : 'Locked'"
         >
           <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
@@ -149,14 +150,14 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
 
       <!-- Actions -->
       <div class="wt-row-actions" @click.stop>
-        <button class="icon-btn" title="Open Folder" @click="emit('open-explorer', wt.path)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
+        <button class="icon-btn" title="Open Folder" aria-label="Open Folder" @click="emit('open-explorer', wt.path)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" /></svg>
         </button>
-        <button class="icon-btn" title="Open Terminal" @click="emit('open-terminal', wt.path)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>
+        <button class="icon-btn" title="Open Terminal" aria-label="Open Terminal" @click="emit('open-terminal', wt.path)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>
         </button>
-        <button class="icon-btn" title="Launch Session Here" @click="emit('navigate-launcher', wt)">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+        <button class="icon-btn" title="Launch Session Here" aria-label="Launch Session Here" @click="emit('navigate-launcher', wt)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="5 3 19 12 5 21 5 3" /></svg>
         </button>
         <button
           class="icon-btn"


### PR DESCRIPTION
### 💡 What
Added `aria-hidden="true"` to decorative SVGs inside icon-only buttons across the Worktree components (`WorktreeList.vue`, `WorktreeDetailPanel.vue`, `CreateWorktreeModal.vue`). Also added `aria-label`s to any icon buttons that were missing them (e.g., Close buttons).

### 🎯 Why
Screen readers will often announce the raw `<svg>` code or unhelpful internal data if an SVG doesn't have an `aria-hidden="true"` attribute, even if the parent button has an `aria-label`. This makes navigation confusing for visually impaired users.

### 📸 Before/After
N/A (Visuals remain identical).

### ♿ Accessibility
- Prevents screen readers from announcing meaningless decorative SVG code.
- Ensures all interactive icon buttons have explicit, dynamic `aria-label` text for screen readers to consume properly.

---
*PR created automatically by Jules for task [14495053947274558501](https://jules.google.com/task/14495053947274558501) started by @MattShelton04*