### PR TITLE
🎨 Palette: [a11y improvement for modal dialog close button]

### DIFF
--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -40,7 +40,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           <slot name="header">
             <h3>{{ title }}</h3>
           </slot>
-          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close">✕</button>
+          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close"><span aria-hidden="true">✕</span></button>
         </div>
         <div class="modal-body">
           <slot />

--- a/packages/ui/src/components/TagList.vue
+++ b/packages/ui/src/components/TagList.vue
@@ -39,7 +39,7 @@ function onKeydown(e: KeyboardEvent, tags: string[]) {
   <div class="tag-list">
     <span v-for="(tag, i) in tags" :key="tag" class="tag-item">
       {{ tag }}
-      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag">×</button>
+      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag"><span aria-hidden="true">×</span></button>
     </span>
     <input
       v-if="editable"


### PR DESCRIPTION
💡 **What:** Wrapped decorative close symbols (`✕` and `×`) inside `<span aria-hidden="true">` for the close buttons in `ModalDialog.vue` and `TagList.vue`.
🎯 **Why:** Prevents screen readers from confusingly announcing the literal character names (e.g., "times" or "multiply") instead of the correct `aria-label` ("Close" or "Remove tag"). This is a robust accessibility best practice for buttons using plain text icons.
📸 **Before/After:** Visually identical. Screen reader experience improved.
♿ **Accessibility:** Prevents incorrect verbalization of visual unicode text symbols used as icons inside buttons.

---
*PR created automatically by Jules for task [9344227894267520340](https://jules.google.com/task/9344227894267520340) started by @MattShelton04*