### PR TITLE
refactor: technical debt consolidation (orchestrator, bindings, frontend)

### DIFF
--- a/apps/desktop/src/composables/useSessionDetail.ts
+++ b/apps/desktop/src/composables/useSessionDetail.ts
@@ -209,9 +209,11 @@ export function createSessionDetailInstance() {
             if (!sessionGuard.isValid(token)) return;
             detail.value = result;
           });
-          if (silentError.value && sessionGuard.isValid(token)) {
+          if (sessionGuard.isValid(token)) {
             error.value = silentError.value;
-            logError(`${LOG_PREFIX} Failed to refresh detail:`, silentError.value);
+            if (silentError.value) {
+              logError(`${LOG_PREFIX} Failed to refresh detail:`, silentError.value);
+            }
           }
         })(),
       );

--- a/apps/desktop/src/composables/useSessionDetail.ts
+++ b/apps/desktop/src/composables/useSessionDetail.ts
@@ -24,7 +24,7 @@
  */
 import { getSessionDetail, getSessionEvents, getSessionTurns } from "@tracepilot/client";
 import type { EventsResponse, SessionDetail } from "@tracepilot/types";
-import { toErrorMessage, useAsyncGuard } from "@tracepilot/ui";
+import { runAction, runMutation, toErrorMessage, useAsyncGuard } from "@tracepilot/ui";
 import type { InjectionKey, UnwrapNestedRefs } from "vue";
 import { inject, reactive, ref, shallowRef } from "vue";
 import { logDebug, logError, logWarn } from "@/utils/logger";
@@ -113,7 +113,7 @@ export function createSessionDetailInstance() {
       saveToCache(sessionId.value);
     }
 
-    const token = sessionGuard.start();
+    const _token = sessionGuard.start();
     sessionId.value = id;
     error.value = null;
     clearSectionErrors();
@@ -146,17 +146,19 @@ export function createSessionDetailInstance() {
     loading.value = true;
     resetSectionData();
 
-    try {
-      const result = await getSessionDetail(id);
-      if (!sessionGuard.isValid(token)) return;
-      detail.value = result;
-      loaded.value.add("detail");
-    } catch (e) {
-      if (!sessionGuard.isValid(token)) return;
+    await runAction({
+      loading,
+      error,
+      guard: sessionGuard,
+      action: () => getSessionDetail(id),
+      onSuccess: (result) => {
+        detail.value = result;
+        loaded.value.add("detail");
+      },
+    });
+
+    if (error.value) {
       detail.value = null;
-      error.value = toErrorMessage(e);
-    } finally {
-      if (sessionGuard.isValid(token)) loading.value = false;
     }
   }
 
@@ -196,20 +198,20 @@ export function createSessionDetailInstance() {
     const token = sessionGuard.current();
     const loadedSections = new Set(loaded.value);
 
-    const promises: Promise<void>[] = [];
+    const promises: Promise<unknown>[] = [];
 
     if (loadedSections.has("detail")) {
       promises.push(
         (async () => {
-          try {
+          const silentError = ref<string | null>(null);
+          await runMutation(silentError, async () => {
             const result = await getSessionDetail(id);
             if (!sessionGuard.isValid(token)) return;
             detail.value = result;
-            error.value = null;
-          } catch (e) {
-            if (!sessionGuard.isValid(token)) return;
-            error.value = toErrorMessage(e);
-            logError(`${LOG_PREFIX} Failed to refresh detail:`, e);
+          });
+          if (silentError.value && sessionGuard.isValid(token)) {
+            error.value = silentError.value;
+            logError(`${LOG_PREFIX} Failed to refresh detail:`, silentError.value);
           }
         })(),
       );

--- a/apps/desktop/src/composables/useTimelineToolState.ts
+++ b/apps/desktop/src/composables/useTimelineToolState.ts
@@ -179,7 +179,7 @@ export function useTimelineToolState(
    */
   watch(allToolCalls, (newAll) => {
     const sel = selectedTool.value;
-    if (!sel || !sel.toolCallId) return;
+    if (!sel?.toolCallId) return;
     const match = newAll.find((tc) => tc.toolCallId === sel.toolCallId);
     if (match) {
       selectedTool.value = match;

--- a/apps/desktop/src/stores/search.ts
+++ b/apps/desktop/src/stores/search.ts
@@ -1,6 +1,6 @@
 import { searchContent } from "@tracepilot/client";
 import type { SearchContentType, SearchResult } from "@tracepilot/types";
-import { toErrorMessage, useAsyncGuard } from "@tracepilot/ui";
+import { runAction, useAsyncGuard } from "@tracepilot/ui";
 import { defineStore } from "pinia";
 import { nextTick, watch } from "vue";
 import { useRecentSearches } from "@/composables/useRecentSearches";
@@ -95,61 +95,58 @@ export const useSearchStore = defineStore("search", () => {
     const mergedSession = parsed.session ?? q.sessionId.value;
     const mergedSort = parsed.sort ?? effectiveSort;
 
-    const token = searchGuard.start();
-    q.loading.value = true;
-    q.error.value = null;
-
-    try {
-      const { dateFromUnix, dateToUnix, error: dateError } = q.parseDateRange();
-      if (dateError) {
-        q.error.value = dateError;
-        q.clearSearchResults();
-        f.facets.value = null;
-        return;
-      }
-
-      const response = await searchContent(searchQuery, {
-        contentTypes: mergedContentTypes.length > 0 ? mergedContentTypes : undefined,
-        excludeContentTypes:
-          q.excludeContentTypes.value.length > 0 ? q.excludeContentTypes.value : undefined,
-        repositories: mergedRepo ? [mergedRepo] : undefined,
-        toolNames: mergedTool ? [mergedTool] : undefined,
-        sessionId: mergedSession ?? undefined,
-        dateFromUnix,
-        dateToUnix,
-        limit: q.pageSize.value,
-        offset: (q.page.value - 1) * q.pageSize.value,
-        sortBy: mergedSort !== "relevance" ? mergedSort : undefined,
-      });
-
-      if (!searchGuard.isValid(token)) return;
-
-      q.results.value = response.results;
-      q.totalCount.value = response.totalCount;
-      q.hasMore.value = response.hasMore;
-      q.latencyMs.value = response.latencyMs;
-
-      // Record to recent searches (only for text queries, not browse mode)
-      if (q.query.value.trim().length > 0 && response.totalCount > 0) {
-        addRecentSearch(q.query.value.trim(), response.totalCount);
-      }
-
-      // Fetch facets using the same parsed query and merged filters as the search.
-      // Use searchQuery directly (empty string = browse mode); don't fall back to raw
-      // query.value which may contain qualifier syntax like "type:error".
-      const facetQuery = searchQuery || undefined;
-      f.fetchFacets(facetQuery, {
-        contentTypes: mergedContentTypes,
-        repo: mergedRepo,
-        tool: mergedTool,
-        session: mergedSession,
-      });
-    } catch (e) {
-      if (!searchGuard.isValid(token)) return;
-      q.error.value = toErrorMessage(e);
+    const { dateFromUnix, dateToUnix, error: dateError } = q.parseDateRange();
+    if (dateError) {
+      q.error.value = dateError;
       q.clearSearchResults();
-    } finally {
-      if (searchGuard.isValid(token)) q.loading.value = false;
+      f.facets.value = null;
+      return;
+    }
+
+    await runAction({
+      loading: q.loading,
+      error: q.error,
+      guard: searchGuard,
+      action: () =>
+        searchContent(searchQuery, {
+          contentTypes: mergedContentTypes.length > 0 ? mergedContentTypes : undefined,
+          excludeContentTypes:
+            q.excludeContentTypes.value.length > 0 ? q.excludeContentTypes.value : undefined,
+          repositories: mergedRepo ? [mergedRepo] : undefined,
+          toolNames: mergedTool ? [mergedTool] : undefined,
+          sessionId: mergedSession ?? undefined,
+          dateFromUnix,
+          dateToUnix,
+          limit: q.pageSize.value,
+          offset: (q.page.value - 1) * q.pageSize.value,
+          sortBy: mergedSort !== "relevance" ? mergedSort : undefined,
+        }),
+      onSuccess: (response) => {
+        q.results.value = response.results;
+        q.totalCount.value = response.totalCount;
+        q.hasMore.value = response.hasMore;
+        q.latencyMs.value = response.latencyMs;
+
+        // Record to recent searches (only for text queries, not browse mode)
+        if (q.query.value.trim().length > 0 && response.totalCount > 0) {
+          addRecentSearch(q.query.value.trim(), response.totalCount);
+        }
+
+        // Fetch facets using the same parsed query and merged filters as the search.
+        // Use searchQuery directly (empty string = browse mode); don't fall back to raw
+        // query.value which may contain qualifier syntax like "type:error".
+        const facetQuery = searchQuery || undefined;
+        f.fetchFacets(facetQuery, {
+          contentTypes: mergedContentTypes,
+          repo: mergedRepo,
+          tool: mergedTool,
+          session: mergedSession,
+        });
+      },
+    });
+
+    if (q.error.value) {
+      q.clearSearchResults();
     }
   }
 

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -193,18 +193,23 @@ export const useSessionsStore = defineStore("sessions", () => {
       return;
     }
 
-    indexing.value = true;
-    error.value = null;
-    try {
-      await indexInflight.run(() => reindexSessions());
-      sessions.value = await refreshSessionsAfterIndex();
-    } catch (e) {
-      if (!isAlreadyIndexingError(e)) {
-        error.value = toErrorMessage(e);
-      }
-    } finally {
-      indexing.value = false;
-    }
+    await runAction({
+      loading: indexing,
+      error,
+      action: async () => {
+        try {
+          await indexInflight.run(() => reindexSessions());
+        } catch (e) {
+          if (!isAlreadyIndexingError(e)) {
+            throw e;
+          }
+        }
+        return refreshSessionsAfterIndex();
+      },
+      onSuccess: (result) => {
+        sessions.value = result;
+      },
+    });
   }
 
   /**

--- a/crates/tracepilot-core/src/paths.rs
+++ b/crates/tracepilot-core/src/paths.rs
@@ -41,7 +41,7 @@ impl CopilotPaths {
         Self::from_home(home.as_ref().join(COPILOT_DIR_NAME))
     }
 
-    pub fn default() -> Option<Self> {
+    pub fn try_default() -> Option<Self> {
         crate::utils::home_dir_opt().map(Self::from_user_home)
     }
 
@@ -96,8 +96,8 @@ impl TracePilotPaths {
         Self::from_root(copilot_home.as_ref().join(TRACEPILOT_DIR_NAME))
     }
 
-    pub fn default() -> Option<Self> {
-        CopilotPaths::default().map(|p| p.tracepilot())
+    pub fn try_default() -> Option<Self> {
+        CopilotPaths::try_default().map(|p| p.tracepilot())
     }
 
     pub fn root(&self) -> &Path {
@@ -167,7 +167,7 @@ pub fn default_copilot_home() -> PathBuf {
 }
 
 pub fn default_copilot_home_opt() -> Option<PathBuf> {
-    CopilotPaths::default().map(|p| p.home().to_path_buf())
+    CopilotPaths::try_default().map(|p| p.home().to_path_buf())
 }
 
 pub fn default_session_state_dir() -> PathBuf {

--- a/crates/tracepilot-orchestrator/src/config_injector.rs
+++ b/crates/tracepilot-orchestrator/src/config_injector.rs
@@ -90,14 +90,12 @@ pub fn create_backup(file_path: &Path, backup_dir: &Path, label: &str) -> Result
     // Write sidecar metadata atomically so a crash never leaves the backup
     // file without a discoverable sidecar.
     let sidecar_path = backup_dir.join(format!("{}.meta.json", backup_name));
-    let sidecar_tmp = sidecar_path.with_extension("tmp");
     let sidecar = serde_json::json!({
         "source_path": file_path.to_string_lossy(),
         "label": label,
         "original_filename": file_path.file_name().unwrap_or_default().to_string_lossy(),
     });
-    std::fs::write(&sidecar_tmp, serde_json::to_string_pretty(&sidecar)?)?;
-    std::fs::rename(&sidecar_tmp, &sidecar_path)?;
+    crate::json_io::atomic_json_write(&sidecar_path, &sidecar)?;
 
     Ok(BackupEntry {
         id: backup_path.to_string_lossy().to_string(),

--- a/crates/tracepilot-orchestrator/src/repo_registry.rs
+++ b/crates/tracepilot-orchestrator/src/repo_registry.rs
@@ -36,14 +36,6 @@ fn registry_path_in(tracepilot_home: &Path) -> PathBuf {
     tracepilot_core::paths::TracePilotPaths::from_root(tracepilot_home).repo_registry_json()
 }
 
-/// Ensure the parent directory exists.
-fn ensure_dir(path: &Path) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    Ok(())
-}
-
 /// Read the registry from disk. Returns empty registry if file doesn't exist.
 fn read_registry() -> Result<RegistryFile> {
     let path = registry_path()?;
@@ -57,25 +49,13 @@ fn read_registry_from_path(path: &Path) -> Result<RegistryFile> {
             repos: Vec::new(),
         });
     }
-    let data = std::fs::read_to_string(&path)?;
+    let data = std::fs::read_to_string(path)?;
     let registry: RegistryFile = serde_json::from_str(&data)?;
     Ok(registry)
 }
 
 fn write_registry_to_path(path: &Path, registry: &RegistryFile) -> Result<()> {
-    ensure_dir(path)?;
-
-    let json = serde_json::to_string_pretty(registry)?;
-    let temp_path = path.with_extension("json.tmp");
-    std::fs::write(&temp_path, &json)?;
-
-    // On Windows, rename fails if target exists; remove first (best-effort: the
-    // rename below will surface the real error if the target still exists).
-    if path.exists() {
-        let _: std::io::Result<()> = std::fs::remove_file(&path);
-    }
-    std::fs::rename(&temp_path, &path)?;
-    Ok(())
+    crate::json_io::atomic_json_write(path, registry)
 }
 
 /// Normalize a path for deduplication. On Windows, lowercases for

--- a/crates/tracepilot-orchestrator/src/templates/dismissed.rs
+++ b/crates/tracepilot-orchestrator/src/templates/dismissed.rs
@@ -84,9 +84,7 @@ fn write_dismissed_defaults_in(tracepilot_home: &Path, ids: &[String]) -> Result
 }
 
 fn write_dismissed_defaults_to_path(ids: &[String], path: &Path) -> Result<()> {
-    let content = serde_json::to_string_pretty(ids)?;
-    std::fs::write(path, content)?;
-    Ok(())
+    crate::json_io::atomic_json_write(path, &ids)
 }
 
 /// Dismiss a default template so it no longer appears.

--- a/crates/tracepilot-orchestrator/src/templates/storage.rs
+++ b/crates/tracepilot-orchestrator/src/templates/storage.rs
@@ -94,12 +94,8 @@ pub fn save_template_in(tracepilot_home: &Path, template: &SessionTemplate) -> R
 
     let dir = templates_dir_in(tracepilot_home)?;
     let path = dir.join(format!("{}.json", template.id));
-    let temp = dir.join(format!(".{}.json.tmp", template.id));
 
-    let content = serde_json::to_string_pretty(template)?;
-    std::fs::write(&temp, &content)?;
-    std::fs::rename(&temp, &path)?;
-    Ok(())
+    crate::json_io::atomic_json_write(&path, template)
 }
 
 /// Delete a template by ID. For default templates, this dismisses them instead.

--- a/crates/tracepilot-tauri-bindings/src/commands/export_import/import.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/export_import/import.rs
@@ -28,17 +28,7 @@ pub async fn preview_import(
             tracepilot_export::import::MigrationStatus::Available { .. }
         );
 
-        let issues: Vec<ImportIssue> = preview
-            .issues
-            .into_iter()
-            .map(|i| ImportIssue {
-                severity: match i.severity {
-                    tracepilot_export::import::IssueSeverity::Error => "error".into(),
-                    tracepilot_export::import::IssueSeverity::Warning => "warning".into(),
-                },
-                message: i.message,
-            })
-            .collect();
+        let issues: Vec<ImportIssue> = preview.issues.into_iter().map(Into::into).collect();
 
         let sessions: Vec<ImportSessionPreview> = preview
             .sessions

--- a/crates/tracepilot-tauri-bindings/src/commands/mcp.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/mcp.rs
@@ -5,12 +5,6 @@ use crate::config::SharedConfig;
 use crate::error::CmdResult;
 use crate::helpers::read_config;
 use std::collections::HashMap;
-use tracepilot_orchestrator::OrchestratorError;
-
-/// Helper to convert McpError to OrchestratorError inside spawn_blocking.
-fn mcp<T>(r: Result<T, tracepilot_orchestrator::mcp::McpError>) -> Result<T, OrchestratorError> {
-    r.map_err(OrchestratorError::from)
-}
 
 // -- Server CRUD --
 
@@ -30,9 +24,9 @@ pub async fn mcp_get_server(
     name: String,
 ) -> CmdResult<tracepilot_orchestrator::mcp::types::McpServerConfig> {
     let home = read_config(&state).copilot_home();
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::config::get_server_in(
+    blocking_cmd!(tracepilot_orchestrator::mcp::config::get_server_in(
         &home, &name
-    )))
+    ))
 }
 
 #[tauri::command]
@@ -43,9 +37,9 @@ pub async fn mcp_add_server(
     config: tracepilot_orchestrator::mcp::types::McpServerConfig,
 ) -> CmdResult<()> {
     let home = read_config(&state).copilot_home();
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::config::add_server_in(
+    blocking_cmd!(tracepilot_orchestrator::mcp::config::add_server_in(
         &home, &name, config
-    )))
+    ))
 }
 
 #[tauri::command]
@@ -56,9 +50,9 @@ pub async fn mcp_update_server(
     config: tracepilot_orchestrator::mcp::types::McpServerConfig,
 ) -> CmdResult<()> {
     let home = read_config(&state).copilot_home();
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::config::update_server_in(
+    blocking_cmd!(tracepilot_orchestrator::mcp::config::update_server_in(
         &home, &name, config
-    )))
+    ))
 }
 
 #[tauri::command]
@@ -68,9 +62,9 @@ pub async fn mcp_remove_server(
     name: String,
 ) -> CmdResult<tracepilot_orchestrator::mcp::types::McpServerConfig> {
     let home = read_config(&state).copilot_home();
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::config::remove_server_in(
+    blocking_cmd!(tracepilot_orchestrator::mcp::config::remove_server_in(
         &home, &name
-    )))
+    ))
 }
 
 #[tauri::command]
@@ -81,9 +75,9 @@ pub async fn mcp_toggle_server(
     name: String,
 ) -> CmdResult<bool> {
     let home = read_config(&state).copilot_home();
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::config::toggle_server_in(
+    blocking_cmd!(tracepilot_orchestrator::mcp::config::toggle_server_in(
         &home, &name
-    )))
+    ))
 }
 
 // -- Health checks --
@@ -112,7 +106,7 @@ pub async fn mcp_check_server_health(
 ) -> CmdResult<tracepilot_orchestrator::mcp::health::McpHealthResultCached> {
     let home = read_config(&state).copilot_home();
     let config = tokio::task::spawn_blocking(move || {
-        mcp(tracepilot_orchestrator::mcp::config::get_server_in(&home, &name).map(|c| (name, c)))
+        tracepilot_orchestrator::mcp::config::get_server_in(&home, &name).map(|c| (name, c))
     })
     .await??;
 
@@ -128,9 +122,9 @@ pub async fn mcp_check_server_health(
 pub async fn mcp_import_from_file(
     path: String,
 ) -> CmdResult<tracepilot_orchestrator::mcp::import::McpImportResult> {
-    blocking_cmd!(mcp(tracepilot_orchestrator::mcp::import::import_from_file(
+    blocking_cmd!(tracepilot_orchestrator::mcp::import::import_from_file(
         std::path::Path::new(&path),
-    )))
+    ))
 }
 
 #[tauri::command]
@@ -141,13 +135,11 @@ pub async fn mcp_import_from_github(
     path: Option<String>,
     git_ref: Option<String>,
 ) -> CmdResult<tracepilot_orchestrator::mcp::import::McpImportResult> {
-    blocking_cmd!(mcp(
-        tracepilot_orchestrator::mcp::import::import_from_github(
-            &owner,
-            &repo,
-            path.as_deref(),
-            git_ref.as_deref(),
-        )
+    blocking_cmd!(tracepilot_orchestrator::mcp::import::import_from_github(
+        &owner,
+        &repo,
+        path.as_deref(),
+        git_ref.as_deref(),
     ))
 }
 
@@ -162,7 +154,7 @@ pub async fn mcp_compute_diff(
     let home = read_config(&state).copilot_home();
     blocking_cmd!({
         let config = tracepilot_orchestrator::mcp::config::load_config_in(&home)?;
-        Ok::<_, OrchestratorError>(tracepilot_orchestrator::mcp::diff::compute_diff(
+        Ok::<_, crate::error::BindingsError>(tracepilot_orchestrator::mcp::diff::compute_diff(
             &config.mcp_servers,
             &incoming,
         ))

--- a/crates/tracepilot-tauri-bindings/src/commands/mcp.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/mcp.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 // -- Server CRUD --
 
 #[tauri::command]
-#[tracing::instrument(level = "debug", err)]
+#[tracing::instrument(level = "debug", skip(state), err)]
 pub async fn mcp_list_servers(
     state: tauri::State<'_, SharedConfig>,
 ) -> CmdResult<Vec<(String, tracepilot_orchestrator::mcp::types::McpServerConfig)>> {
@@ -18,7 +18,7 @@ pub async fn mcp_list_servers(
 }
 
 #[tauri::command]
-#[tracing::instrument(level = "debug", err, fields(server = %name))]
+#[tracing::instrument(level = "debug", skip(state), err, fields(server = %name))]
 pub async fn mcp_get_server(
     state: tauri::State<'_, SharedConfig>,
     name: String,
@@ -30,7 +30,7 @@ pub async fn mcp_get_server(
 }
 
 #[tauri::command]
-#[tracing::instrument(skip(config), err, fields(server = %name))]
+#[tracing::instrument(skip(state, config), err, fields(server = %name))]
 pub async fn mcp_add_server(
     state: tauri::State<'_, SharedConfig>,
     name: String,
@@ -43,7 +43,7 @@ pub async fn mcp_add_server(
 }
 
 #[tauri::command]
-#[tracing::instrument(skip(config), err, fields(server = %name))]
+#[tracing::instrument(skip(state, config), err, fields(server = %name))]
 pub async fn mcp_update_server(
     state: tauri::State<'_, SharedConfig>,
     name: String,
@@ -56,7 +56,7 @@ pub async fn mcp_update_server(
 }
 
 #[tauri::command]
-#[tracing::instrument(err, fields(server = %name))]
+#[tracing::instrument(skip(state), err, fields(server = %name))]
 pub async fn mcp_remove_server(
     state: tauri::State<'_, SharedConfig>,
     name: String,
@@ -68,7 +68,7 @@ pub async fn mcp_remove_server(
 }
 
 #[tauri::command]
-#[tracing::instrument(err, fields(server = %name))]
+#[tracing::instrument(skip(state), err, fields(server = %name))]
 #[specta::specta]
 pub async fn mcp_toggle_server(
     state: tauri::State<'_, SharedConfig>,
@@ -83,7 +83,7 @@ pub async fn mcp_toggle_server(
 // -- Health checks --
 
 #[tauri::command]
-#[tracing::instrument(err)]
+#[tracing::instrument(skip(state), err)]
 pub async fn mcp_check_health(
     state: tauri::State<'_, SharedConfig>,
 ) -> CmdResult<HashMap<String, tracepilot_orchestrator::mcp::health::McpHealthResultCached>> {
@@ -99,7 +99,7 @@ pub async fn mcp_check_health(
 }
 
 #[tauri::command]
-#[tracing::instrument(err, fields(server = %name))]
+#[tracing::instrument(skip(state), err, fields(server = %name))]
 pub async fn mcp_check_server_health(
     state: tauri::State<'_, SharedConfig>,
     name: String,
@@ -146,7 +146,7 @@ pub async fn mcp_import_from_github(
 // -- Diff --
 
 #[tauri::command]
-#[tracing::instrument(skip(incoming), err, fields(incoming_count = incoming.len()))]
+#[tracing::instrument(skip(state, incoming), err, fields(incoming_count = incoming.len()))]
 pub async fn mcp_compute_diff(
     state: tauri::State<'_, SharedConfig>,
     incoming: HashMap<String, tracepilot_orchestrator::mcp::types::McpServerConfig>,

--- a/crates/tracepilot-tauri-bindings/src/commands/skills.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/skills.rs
@@ -2,14 +2,6 @@
 
 use crate::blocking_cmd;
 use crate::error::CmdResult;
-use tracepilot_orchestrator::OrchestratorError;
-
-/// Helper to convert SkillsError to OrchestratorError inside spawn_blocking.
-fn sk<T>(
-    r: Result<T, tracepilot_orchestrator::skills::SkillsError>,
-) -> Result<T, OrchestratorError> {
-    r.map_err(OrchestratorError::from)
-}
 
 /// Validate that a skill_dir is within a known skills root before any operation.
 fn check_skill_dir(skill_dir: &str) -> Result<(), tracepilot_orchestrator::skills::SkillsError> {
@@ -23,10 +15,8 @@ fn check_skill_dir(skill_dir: &str) -> Result<(), tracepilot_orchestrator::skill
 pub async fn skills_list_all(
     repo_root: Option<String>,
 ) -> CmdResult<Vec<tracepilot_orchestrator::skills::types::SkillSummary>> {
-    blocking_cmd!(sk(
-        tracepilot_orchestrator::skills::discovery::discover_all(
-            repo_root.as_deref().map(std::path::Path::new),
-        )
+    blocking_cmd!(tracepilot_orchestrator::skills::discovery::discover_all(
+        repo_root.as_deref().map(std::path::Path::new),
     ))
 }
 
@@ -36,9 +26,9 @@ pub async fn skills_get_skill(
     skill_dir: String,
 ) -> CmdResult<tracepilot_orchestrator::skills::types::Skill> {
     let dir = skill_dir.clone();
-    blocking_cmd!(sk(check_skill_dir(&dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::get_skill(std::path::Path::new(&dir))
-    })))
+    }))
 }
 
 // -- CRUD --
@@ -47,12 +37,10 @@ pub async fn skills_get_skill(
 #[tracing::instrument(skip(description, body), err, fields(%name, body_len = body.len()))]
 pub async fn skills_create(name: String, description: String, body: String) -> CmdResult<String> {
     let sn = crate::validators::validate_skill_name(&name)?;
-    blocking_cmd!(sk(tracepilot_orchestrator::skills::manager::create_skill(
-        &sn,
-        &description,
-        &body
+    blocking_cmd!(
+        tracepilot_orchestrator::skills::manager::create_skill(&sn, &description, &body)
+            .map(|p| p.to_string_lossy().to_string())
     )
-    .map(|p| p.to_string_lossy().to_string())))
 }
 
 #[tauri::command]
@@ -62,58 +50,58 @@ pub async fn skills_update(
     frontmatter: tracepilot_orchestrator::skills::types::SkillFrontmatter,
     body: String,
 ) -> CmdResult<()> {
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::update_skill(
             std::path::Path::new(&skill_dir),
             &frontmatter,
             &body,
         )
-    })))
+    }))
 }
 
 #[tauri::command]
 #[tracing::instrument(skip(skill_dir, raw_content), err, fields(raw_len = raw_content.len()))]
 pub async fn skills_update_raw(skill_dir: String, raw_content: String) -> CmdResult<()> {
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::update_skill_raw(
             std::path::Path::new(&skill_dir),
             &raw_content,
         )
-    })))
+    }))
 }
 
 #[tauri::command]
 #[tracing::instrument(skip(skill_dir), err)]
 pub async fn skills_delete(skill_dir: String) -> CmdResult<()> {
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::delete_skill(std::path::Path::new(&skill_dir))
-    })))
+    }))
 }
 
 #[tauri::command]
 #[tracing::instrument(skip(skill_dir), err, fields(%new_name))]
 pub async fn skills_rename(skill_dir: String, new_name: String) -> CmdResult<String> {
     let sn = crate::validators::validate_skill_name(&new_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::rename_skill(
             std::path::Path::new(&skill_dir),
             &sn,
         )
         .map(|p| p.to_string_lossy().to_string())
-    })))
+    }))
 }
 
 #[tauri::command]
 #[tracing::instrument(skip(skill_dir), err, fields(%new_name))]
 pub async fn skills_duplicate(skill_dir: String, new_name: String) -> CmdResult<String> {
     let sn = crate::validators::validate_skill_name(&new_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::manager::duplicate_skill(
             std::path::Path::new(&skill_dir),
             &sn,
         )
         .map(|p| p.to_string_lossy().to_string())
-    })))
+    }))
 }
 
 // -- Assets --
@@ -122,9 +110,9 @@ pub async fn skills_duplicate(skill_dir: String, new_name: String) -> CmdResult<
 pub async fn skills_list_assets(
     skill_dir: String,
 ) -> CmdResult<Vec<tracepilot_orchestrator::skills::types::SkillAsset>> {
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::assets::list_assets(std::path::Path::new(&skill_dir))
-    })))
+    }))
 }
 
 #[tauri::command]
@@ -135,13 +123,13 @@ pub async fn skills_add_asset(
     content: Vec<u8>,
 ) -> CmdResult<()> {
     crate::validators::validate_asset_name(&asset_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::assets::add_asset(
             std::path::Path::new(&skill_dir),
             &asset_name,
             &content,
         )
-    })))
+    }))
 }
 
 #[tauri::command]
@@ -152,36 +140,36 @@ pub async fn skills_copy_asset_from(
     source_path: String,
 ) -> CmdResult<()> {
     crate::validators::validate_asset_name(&asset_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::assets::copy_asset_from(
             std::path::Path::new(&skill_dir),
             &asset_name,
             std::path::Path::new(&source_path),
         )
-    })))
+    }))
 }
 
 #[tauri::command]
 #[tracing::instrument(skip(skill_dir), err, fields(%asset_name))]
 pub async fn skills_remove_asset(skill_dir: String, asset_name: String) -> CmdResult<()> {
     crate::validators::validate_asset_name(&asset_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::assets::remove_asset(
             std::path::Path::new(&skill_dir),
             &asset_name,
         )
-    })))
+    }))
 }
 
 #[tauri::command]
 pub async fn skills_read_asset(skill_dir: String, asset_name: String) -> CmdResult<String> {
     crate::validators::validate_asset_name(&asset_name)?;
-    blocking_cmd!(sk(check_skill_dir(&skill_dir).and_then(|_| {
+    blocking_cmd!(check_skill_dir(&skill_dir).and_then(|_| {
         tracepilot_orchestrator::skills::assets::read_asset(
             std::path::Path::new(&skill_dir),
             &asset_name,
         )
-    })))
+    }))
 }
 
 // -- Import --
@@ -219,11 +207,9 @@ pub async fn skills_import_local(
         tokio::task::spawn_blocking(move || resolve_skills_dest(&scope, repo_root.as_deref()))
             .await??;
 
-    blocking_cmd!(sk(
-        tracepilot_orchestrator::skills::import::import_from_local(
-            std::path::Path::new(&source_dir),
-            &dest,
-        )
+    blocking_cmd!(tracepilot_orchestrator::skills::import::import_from_local(
+        std::path::Path::new(&source_dir),
+        &dest,
     ))
 }
 
@@ -239,11 +225,9 @@ pub async fn skills_import_file(
         tokio::task::spawn_blocking(move || resolve_skills_dest(&scope, repo_root.as_deref()))
             .await??;
 
-    blocking_cmd!(sk(
-        tracepilot_orchestrator::skills::import::import_from_file(
-            std::path::Path::new(&file_path),
-            &dest,
-        )
+    blocking_cmd!(tracepilot_orchestrator::skills::import::import_from_file(
+        std::path::Path::new(&file_path),
+        &dest,
     ))
 }
 
@@ -262,14 +246,12 @@ pub async fn skills_import_github(
         tokio::task::spawn_blocking(move || resolve_skills_dest(&scope, repo_root.as_deref()))
             .await??;
 
-    blocking_cmd!(sk(
-        tracepilot_orchestrator::skills::import::import_from_github(
-            &owner,
-            &repo,
-            skill_path.as_deref(),
-            git_ref.as_deref(),
-            &dest,
-        )
+    blocking_cmd!(tracepilot_orchestrator::skills::import::import_from_github(
+        &owner,
+        &repo,
+        skill_path.as_deref(),
+        git_ref.as_deref(),
+        &dest,
     ))
 }
 
@@ -279,9 +261,9 @@ pub async fn skills_import_github(
 pub async fn skills_discover_local(
     dir: String,
 ) -> CmdResult<Vec<tracepilot_orchestrator::skills::types::LocalSkillPreview>> {
-    blocking_cmd!(sk(
+    blocking_cmd!(
         tracepilot_orchestrator::skills::import::discover_local_skills(std::path::Path::new(&dir),)
-    ))
+    )
 }
 
 // -- GitHub auth --
@@ -300,14 +282,14 @@ pub async fn skills_discover_github(
     path: Option<String>,
     git_ref: Option<String>,
 ) -> CmdResult<Vec<tracepilot_orchestrator::skills::types::GitHubSkillPreview>> {
-    blocking_cmd!(sk(
+    blocking_cmd!(
         tracepilot_orchestrator::skills::import::discover_github_skills(
             &owner,
             &repo,
             path.as_deref(),
             git_ref.as_deref(),
         )
-    ))
+    )
 }
 
 #[tauri::command]
@@ -324,7 +306,7 @@ pub async fn skills_import_github_skill(
         tokio::task::spawn_blocking(move || resolve_skills_dest(&scope, repo_root.as_deref()))
             .await??;
 
-    blocking_cmd!(sk(
+    blocking_cmd!(
         tracepilot_orchestrator::skills::import::import_github_skill(
             &owner,
             &repo,
@@ -332,7 +314,7 @@ pub async fn skills_import_github_skill(
             git_ref.as_deref(),
             &dest,
         )
-    ))
+    )
 }
 
 // -- Repository discovery (batch scan) --

--- a/crates/tracepilot-tauri-bindings/src/config/mod.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/mod.rs
@@ -47,7 +47,7 @@ pub use tool_rendering::ToolRenderingConfig;
 pub use ui::UiConfig;
 
 pub fn config_file_path() -> Option<PathBuf> {
-    tracepilot_core::paths::TracePilotPaths::default().map(|p| p.config_toml())
+    tracepilot_core::paths::TracePilotPaths::try_default().map(|p| p.config_toml())
 }
 
 fn home_dir() -> Option<PathBuf> {

--- a/crates/tracepilot-tauri-bindings/src/error/bindings.rs
+++ b/crates/tracepilot-tauri-bindings/src/error/bindings.rs
@@ -71,6 +71,18 @@ pub enum BindingsError {
     Internal(String),
 }
 
+impl From<tracepilot_orchestrator::skills::SkillsError> for BindingsError {
+    fn from(e: tracepilot_orchestrator::skills::SkillsError) -> Self {
+        Self::Orchestrator(e.into())
+    }
+}
+
+impl From<tracepilot_orchestrator::mcp::McpError> for BindingsError {
+    fn from(e: tracepilot_orchestrator::mcp::McpError) -> Self {
+        Self::Orchestrator(e.into())
+    }
+}
+
 impl BindingsError {
     /// Stable, machine-readable error code. The frontend branches on this.
     pub fn code(&self) -> ErrorCode {

--- a/crates/tracepilot-tauri-bindings/src/types.rs
+++ b/crates/tracepilot-tauri-bindings/src/types.rs
@@ -264,6 +264,18 @@ pub struct ImportIssue {
     pub message: String,
 }
 
+impl From<tracepilot_export::import::ValidationIssue> for ImportIssue {
+    fn from(issue: tracepilot_export::import::ValidationIssue) -> Self {
+        Self {
+            severity: match issue.severity {
+                tracepilot_export::import::IssueSeverity::Error => "error".into(),
+                tracepilot_export::import::IssueSeverity::Warning => "warning".into(),
+            },
+            message: issue.message,
+        }
+    }
+}
+
 /// Summary of a session found in an import archive.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
This PR addresses 3 independent areas of technical debt across the Rust backend and Vue frontend.

### 1. Orchestrator: Atomic JSON Writes
- **What**: Replaced manual atomic write-to-temp-then-rename logic with the shared \tomic_json_write\ helper.
- **Why**: Centralizes I/O logic, prevents data corruption on partial writes, and ensures consistent Windows behavior.
- **Evidence**: 4 manual implementations removed in favor of 1 shared helper.

### 2. Tauri Bindings: Unified Error Propagation
- **What**: Removed redundant \sk\ and \mcp\ error conversion shims by implementing \From\ traits for \SkillsError\, \McpError\, and \ValidationIssue\.
- **Why**: Eliminates boilerplate for 25+ IPC commands and aligns with ADR-0005.
- **Evidence**: Removed over 20 redundant call sites; simplified 3 helper modules.

### 3. Frontend: Standardized runAction Usage
- **What**: Refactored \search.ts\, \sessions.ts\, and \useSessionDetail.ts\ to use \unAction\/\unMutation\ helpers.
- **Why**: Enforces ADR-0006, ensuring consistent loading/error state management and race-condition prevention via \AsyncGuard\.
- **Evidence**: 3 major stores updated; includes fix for cross-session error leakage.

## Verification Results
| Command | Area | Exit Code |
| :--- | :--- | :--- |
| \cargo clippy -p tracepilot-orchestrator\ | Orchestrator | 0 |
| \cargo test -p tracepilot-orchestrator\ | Orchestrator | 0 (400 passed) |
| \cargo clippy -p tracepilot-tauri-bindings\ | Bindings | 0 |
| \cargo test -p tracepilot-tauri-bindings\ | Bindings | 0 (183 passed) |
| \pnpm --filter @tracepilot/desktop typecheck\ | Frontend | 0 |
| \pnpm dlx @biomejs/biome check\ | Frontend | 0 |