### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in detached terminal spawn

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-21 - [Critical] Detached Terminal Command Injection
+**Vulnerability:** The detached terminal spawn functions (`spawn_terminal_macos` and `spawn_terminal_linux` in `terminal.rs`) passed unescaped `program` and `args` to `osascript -e` and Linux terminal `-e` respectively. Arbitrary command injection was possible if spawned with attacker-controlled arguments.
+**Learning:** Even internal helper methods intended to open standard terminals are dangerous vectors if they interpolate strings rather than securely passing raw command arguments.
+**Prevention:** Always use proper quoting logic like `shell_quote()` when a shell string context (like `-e`) is unavoidable to wrap command arguments safely before execution.

--- a/crates/tracepilot-orchestrator/src/process/terminal.rs
+++ b/crates/tracepilot-orchestrator/src/process/terminal.rs
@@ -176,11 +176,9 @@ fn spawn_terminal_macos(
     }
 
     if !program.is_empty() {
-        let cmd_str = if args.is_empty() {
-            program.to_string()
-        } else {
-            format!("{} {}", program, args.join(" "))
-        };
+        let mut escaped_args = vec![shell_quote(program)];
+        escaped_args.extend(args.iter().map(|a| shell_quote(a)));
+        let cmd_str = escaped_args.join(" ");
         parts.push(cmd_str);
     }
 
@@ -218,11 +216,9 @@ fn spawn_terminal_linux(
 
         // If a program is specified, pass it via -e; otherwise just open a shell
         if !program.is_empty() {
-            let cmd_str = if args.is_empty() {
-                program.to_string()
-            } else {
-                format!("{} {}", program, args.join(" "))
-            };
+            let mut escaped_args = vec![crate::process::shell_quote(program)];
+            escaped_args.extend(args.iter().map(|a| crate::process::shell_quote(a)));
+            let cmd_str = escaped_args.join(" ");
             command.args(["-e", &cmd_str]);
         }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: The detached terminal spawn functions (`spawn_terminal_macos` and `spawn_terminal_linux`) constructed terminal shell scripts (via `osascript` on macOS and `-e` on Linux) by joining raw arguments as strings (`args.join(" ")`). If `program` or `args` were attacker-controlled, arbitrary shell commands could be injected and executed.

🎯 Impact: An attacker controlling terminal input arguments could achieve arbitrary code execution via shell command injection whenever a detached terminal process was spawned.

🔧 Fix: Used the existing `shell_quote` utility function inside `tracepilot-orchestrator/src/process/terminal.rs` to individually quote and safely escape the `program` name and each argument before joining them into the shell execution string.

✅ Verification: Run `cargo test -p tracepilot-orchestrator` and `cargo clippy` to verify no breaking regressions and that the module safely integrates `shell_quote`.

---
*PR created automatically by Jules for task [12263721588426493740](https://jules.google.com/task/12263721588426493740) started by @MattShelton04*