### PR TITLE
🎨 Palette: [UX improvement] Hide decorative button characters from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+## 2026-05-01 - Screen reader noise on icon-only buttons\n**Learning:** Decorative characters inside buttons (like '✕' or '×') can be read aloud confusingly by screen readers, even if the button has an `aria-label`. \n**Action:** Always wrap raw unicode decorative characters or svgs inside buttons with `<span aria-hidden="true">`.

--- a/packages/ui/src/components/EnvVarTable.vue
+++ b/packages/ui/src/components/EnvVarTable.vue
@@ -60,7 +60,9 @@ function removeRow(vars: EnvVar[], index: number) {
       />
       <span v-else class="env-cell env-col-value">{{ v.value }}</span>
 
-      <button v-if="editable" class="env-remove" @click="removeRow(vars, i)" aria-label="Remove variable">×</button>
+      <button v-if="editable" class="env-remove" @click="removeRow(vars, i)" aria-label="Remove variable">
+        <span aria-hidden="true">×</span>
+      </button>
     </div>
     <div v-if="vars.length === 0" class="env-empty">No environment variables</div>
     <button v-if="editable" class="env-add" @click="addRow(vars)">+ Add Variable</button>

--- a/packages/ui/src/components/ErrorAlert.vue
+++ b/packages/ui/src/components/ErrorAlert.vue
@@ -59,7 +59,7 @@ defineEmits<{
         aria-label="Dismiss"
         @click="$emit('dismiss')"
       >
-        ✕
+        <span aria-hidden="true">✕</span>
       </button>
     </span>
   </div>

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -40,7 +40,9 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           <slot name="header">
             <h3>{{ title }}</h3>
           </slot>
-          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close">✕</button>
+          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close">
+            <span aria-hidden="true">✕</span>
+          </button>
         </div>
         <div class="modal-body">
           <slot />

--- a/packages/ui/src/components/SubagentPanel/SubagentPanelHeader.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanelHeader.vue
@@ -24,7 +24,9 @@ function statusClass(s: SubagentStatus): string {
       aria-label="Close panel"
       title="Close (Esc)"
       @click="emit('close')"
-    >✕</button>
+    >
+      <span aria-hidden="true">✕</span>
+    </button>
     <div class="sap-info">
       <div class="sap-name" :style="{ color: agentColor }">
         <span class="sap-name-icon">{{ agentIcon }}</span>

--- a/packages/ui/src/components/TagList.vue
+++ b/packages/ui/src/components/TagList.vue
@@ -39,7 +39,9 @@ function onKeydown(e: KeyboardEvent, tags: string[]) {
   <div class="tag-list">
     <span v-for="(tag, i) in tags" :key="tag" class="tag-item">
       {{ tag }}
-      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag">×</button>
+      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag">
+        <span aria-hidden="true">×</span>
+      </button>
     </span>
     <input
       v-if="editable"

--- a/packages/ui/src/components/ToastContainer.vue
+++ b/packages/ui/src/components/ToastContainer.vue
@@ -57,7 +57,9 @@ function onAction(action: { label: string; onClick: () => void }, id: string) {
           </button>
         </div>
 
-        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)">✕</button>
+        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)">
+          <span aria-hidden="true">✕</span>
+        </button>
 
         <div
           v-if="t.duration > 0"

--- a/packages/ui/src/components/ToolDetailPanel.vue
+++ b/packages/ui/src/components/ToolDetailPanel.vue
@@ -51,7 +51,9 @@ defineEmits<{
         >{{ badge.label }}</Badge>
         <Badge v-if="tc.isSubagent" variant="neutral">agent</Badge>
       </div>
-      <button class="detail-close" @click.stop="$emit('close')" aria-label="Close detail panel">✕</button>
+      <button class="detail-close" @click.stop="$emit('close')" aria-label="Close detail panel">
+        <span aria-hidden="true">✕</span>
+      </button>
     </div>
 
     <!-- Metadata grid -->


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative symbols (e.g., '✕', '×') inside close/remove buttons across multiple UI components.

🎯 Why: To prevent screen readers from confusingly announcing raw unicode decorative characters (e.g., reading "times" or "multiply") instead of or alongside the provided `aria-label`.

📸 Before/After: N/A - Visually identical.

♿ Accessibility: Ensures that assistive technologies rely solely on the explicit `aria-label` (e.g., "Close", "Remove tag") rather than interpreting decorative text characters.

---
*PR created automatically by Jules for task [18356757924062317355](https://jules.google.com/task/18356757924062317355) started by @MattShelton04*