### PR TITLE
🎨 Palette: Add accessibility to search result copy button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - Add accessibility to search result copy button
+**Learning:** Icon-only buttons containing SVG elements require dynamic `aria-label` attributes to accurately describe their function to screen readers, especially when their state changes (e.g., from "Copy content" to "Copied!"). The inner `<svg>` tags should also include `aria-hidden="true"` so that the screen reader correctly announces the button label without erroneously interpreting the SVG element.
+**Action:** When creating or modifying icon-only buttons (such as copy buttons), ensure `aria-label` matches the visible tooltip functionality and `aria-hidden="true"` is applied to the child `<svg>` elements to avoid redundant or confusing screen reader announcements.

--- a/apps/desktop/src/components/search/SearchResultCard.vue
+++ b/apps/desktop/src/components/search/SearchResultCard.vue
@@ -125,12 +125,13 @@ watch(
         class="result-copy-btn"
         :class="{ 'result-copy-btn--copied': copied }"
         :title="copied ? 'Copied!' : 'Copy content'"
+        :aria-label="copied ? 'Copied!' : 'Copy content'"
         @click.stop="handleCopy"
       >
-        <svg v-if="!copied" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
+        <svg v-if="!copied" aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
           <rect x="5" y="5" width="9" height="9" rx="1" /><path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
         </svg>
-        <svg v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
+        <svg v-else aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
           <polyline points="3 8 6.5 11.5 13 5" />
         </svg>
       </button>


### PR DESCRIPTION
## 💡 What
Added dynamic `aria-label` attribute and `aria-hidden="true"` tags to the SVG icons within the copy button of the `SearchResultCard.vue` component.

## 🎯 Why
Icon-only buttons are often inaccessible to screen readers. The copy button in the search results lacked an `aria-label`, meaning screen readers would either announce nothing or attempt to read the SVG tags. Adding a dynamic `aria-label` that mirrors the tooltip text provides proper context.

## 📸 Before/After
- **Before:** `<button class="result-copy-btn" title="Copy content"><svg>...</svg></button>`
- **After:** `<button class="result-copy-btn" title="Copy content" aria-label="Copy content"><svg aria-hidden="true">...</svg></button>`

## ♿ Accessibility
- Added `aria-label` to dynamically match the "Copied!" vs "Copy content" state.
- Added `aria-hidden="true"` to the decorative `<svg>` tags to prevent screen readers from reading raw SVG elements incorrectly.

---
*PR created automatically by Jules for task [9700311860982107546](https://jules.google.com/task/9700311860982107546) started by @MattShelton04*