### PR TITLE
refactor: extract mutex lock helpers to deduplicate pattern

### DIFF
--- a/crates/tracepilot-orchestrator/src/bridge/live_state/store.rs
+++ b/crates/tracepilot-orchestrator/src/bridge/live_state/store.rs
@@ -14,8 +14,18 @@ impl LiveStateStore {
         Self::default()
     }
 
+    /// Helper to acquire the states write lock, handling poisoned mutexes.
+    fn states_write(&self) -> std::sync::RwLockWriteGuard<'_, HashMap<String, SessionLiveState>> {
+        self.states.write().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Helper to acquire the states read lock, handling poisoned mutexes.
+    fn states_read(&self) -> std::sync::RwLockReadGuard<'_, HashMap<String, SessionLiveState>> {
+        self.states.read().unwrap_or_else(|e| e.into_inner())
+    }
+
     pub fn apply_event(&self, event: &BridgeEvent) -> SessionLiveState {
-        let mut states = self.states.write().unwrap_or_else(|e| e.into_inner());
+        let mut states = self.states_write();
         let state = states
             .entry(event.session_id.clone())
             .or_insert_with(|| SessionLiveState::new(&event.session_id));
@@ -29,7 +39,7 @@ impl LiveStateStore {
         status: SessionRuntimeStatus,
         last_error: Option<String>,
     ) -> SessionLiveState {
-        let mut states = self.states.write().unwrap_or_else(|e| e.into_inner());
+        let mut states = self.states_write();
         let state = states
             .entry(session_id.to_string())
             .or_insert_with(|| SessionLiveState::new(session_id));
@@ -39,21 +49,11 @@ impl LiveStateStore {
     }
 
     pub fn get(&self, session_id: &str) -> Option<SessionLiveState> {
-        self.states
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(session_id)
-            .cloned()
+        self.states_read().get(session_id).cloned()
     }
 
     pub fn list(&self) -> Vec<SessionLiveState> {
-        let mut states: Vec<_> = self
-            .states
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .values()
-            .cloned()
-            .collect();
+        let mut states: Vec<_> = self.states_read().values().cloned().collect();
         states.sort_by(|a, b| a.session_id.cmp(&b.session_id));
         states
     }

--- a/crates/tracepilot-orchestrator/src/mcp/config.rs
+++ b/crates/tracepilot-orchestrator/src/mcp/config.rs
@@ -15,6 +15,14 @@ use std::sync::Mutex;
 /// Static mutex to serialize config file writes (mirrors repo_registry pattern).
 static CONFIG_LOCK: Mutex<()> = Mutex::new(());
 
+/// Helper to acquire the config lock, handling poisoned mutexes.
+///
+/// Returns the lock guard if successful, or the inner mutex guard
+/// if the mutex was poisoned (indicating a previous thread panic).
+fn config_lock() -> std::sync::MutexGuard<'static, ()> {
+    CONFIG_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// The on-disk format for `mcp-config.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -60,7 +68,7 @@ fn save_config_unlocked_in(
 
 /// Save the MCP configuration to disk atomically.
 pub fn save_config(config: &McpConfigFile) -> crate::error::Result<()> {
-    let _lock = CONFIG_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _lock = config_lock();
     save_config_unlocked(config)
 }
 
@@ -69,7 +77,7 @@ fn with_config_mut<F, T>(f: F) -> Result<T, McpError>
 where
     F: FnOnce(&mut McpConfigFile) -> Result<T, McpError>,
 {
-    let _lock = CONFIG_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _lock = config_lock();
     let mut config = load_config().map_err(McpError::from_orchestrator)?;
     let result = f(&mut config)?;
     save_config_unlocked(&config).map_err(McpError::from_orchestrator)?;
@@ -80,7 +88,7 @@ fn with_config_mut_in<F, T>(copilot_home: &Path, f: F) -> Result<T, McpError>
 where
     F: FnOnce(&mut McpConfigFile) -> Result<T, McpError>,
 {
-    let _lock = CONFIG_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _lock = config_lock();
     let mut config = load_config_in(copilot_home).map_err(McpError::from_orchestrator)?;
     let result = f(&mut config)?;
     save_config_unlocked_in(copilot_home, &config).map_err(McpError::from_orchestrator)?;

--- a/crates/tracepilot-orchestrator/src/repo_registry.rs
+++ b/crates/tracepilot-orchestrator/src/repo_registry.rs
@@ -16,6 +16,14 @@ const SCHEMA_VERSION: u32 = 1;
 /// Process-level lock serializing all registry file operations.
 static REGISTRY_LOCK: Mutex<()> = Mutex::new(());
 
+/// Helper to acquire the registry lock, handling poisoned mutexes.
+///
+/// Returns the lock guard if successful, or the inner mutex guard
+/// if the mutex was poisoned (indicating a previous thread panic).
+fn registry_lock() -> std::sync::MutexGuard<'static, ()> {
+    REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RegistryFile {
@@ -85,13 +93,13 @@ fn repo_name_from_path(path: &str) -> String {
 
 /// List all registered repos.
 pub fn list_registered_repos() -> Result<Vec<RegisteredRepo>> {
-    let _guard = REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = registry_lock();
     let registry = read_registry()?;
     Ok(registry.repos)
 }
 
 pub fn list_registered_repos_in(tracepilot_home: &Path) -> Result<Vec<RegisteredRepo>> {
-    let _guard = REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = registry_lock();
     let registry = read_registry_from_path(&registry_path_in(tracepilot_home))?;
     Ok(registry.repos)
 }
@@ -132,7 +140,7 @@ fn add_repo_at_path(
     let root = worktrees::get_repo_root(p)?;
     let normalized = normalize_path(&root);
 
-    let _guard = REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = registry_lock();
     let mut registry = read_registry_from_path(registry_path)?;
 
     // Check for duplicates — single traversal to find and update
@@ -173,7 +181,7 @@ pub fn remove_repo_in(tracepilot_home: &Path, path: &str) -> Result<()> {
 
 fn remove_repo_at_path(registry_path: &Path, path: &str) -> Result<()> {
     let normalized = normalize_path(path);
-    let _guard = REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = registry_lock();
     let mut registry = read_registry_from_path(registry_path)?;
     let before = registry.repos.len();
     registry
@@ -200,7 +208,7 @@ pub fn update_last_used_in(tracepilot_home: &Path, path: &str) -> Result<()> {
 
 fn update_last_used_at_path(registry_path: &Path, path: &str) -> Result<()> {
     let normalized = normalize_path(path);
-    let _guard = REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = registry_lock();
     let mut registry = read_registry_from_path(registry_path)?;
     if let Some(repo) = registry
         .repos


### PR DESCRIPTION
## Tech Debt Fixes - 3 Independent Refactors

### Fix 1: repo_registry.rs
- Created egistry_lock() helper function
- Replaced 5 occurrences of REGISTRY_LOCK.lock().unwrap_or_else(|e| e.into_inner()) with egistry_lock()
- Evidence: 5 sites → 1 helper

### Fix 2: mcp/config.rs
- Created config_lock() helper function
- Replaced 3 occurrences of CONFIG_LOCK.lock().unwrap_or_else(|e| e.into_inner()) with config_lock()
- Evidence: 3 sites → 1 helper

### Fix 3: bridge/live_state/store.rs
- Created states_write() and states_read() helper methods
- Replaced 4 occurrences of .write().unwrap_or_else(|e| e.into_inner()) and .read().unwrap_or_else(|e| e.into_inner()) with helpers
- Evidence: 4 sites → 2 helpers

## Verification

All fixes are independent (different files/modules), pass clippy, and have no test regressions.

### Test/Lint Commands (all exit code 0):
`
cargo clippy -p tracepilot-orchestrator -- -D warnings
cargo test -p tracepilot-orchestrator --lib
`

### Code Reviews:
- 2 parallel subagents reviewed all changes
- No bugs, logic errors, or convention violations found
- Thread safety verified

## Branch
cli/tech_debt_2c025af4