### PR TITLE
refactor: address technical debt in core and indexer

### DIFF
--- a/crates/tracepilot-core/src/parsing/events/raw.rs
+++ b/crates/tracepilot-core/src/parsing/events/raw.rs
@@ -1,6 +1,7 @@
 //! Raw JSONL line parsing — reads `events.jsonl` into [`RawEvent`] envelopes.
 
 use crate::error::{Result, TracePilotError};
+use crate::parsing::EVENTS_JSONL;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -29,6 +30,14 @@ pub struct RawEvent {
 /// Returns `(events, malformed_line_count)` so the caller can track parse quality.
 #[tracing::instrument(skip_all, fields(path = %path.display()))]
 pub(super) fn parse_events_jsonl(path: &Path) -> Result<(Vec<RawEvent>, usize)> {
+    if !path.ends_with(EVENTS_JSONL) {
+        tracing::warn!(
+            path = %path.display(),
+            "Parsing event log from file not named {}",
+            EVENTS_JSONL
+        );
+    }
+
     let file = std::fs::File::open(path)
         .map_err(|e| TracePilotError::io_context("Failed to open", path.display(), e))?;
     // Estimate event count from file size (~1KB per event) to reduce Vec reallocations
@@ -44,11 +53,12 @@ pub(super) fn parse_events_jsonl(path: &Path) -> Result<(Vec<RawEvent>, usize)> 
         let line = line.map_err(|e| {
             TracePilotError::io_context("Failed to read line", format!("{}", line_num + 1), e)
         })?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
+        let line = line.trim();
+        if line.is_empty() {
             continue;
         }
-        match serde_json::from_str::<RawEvent>(trimmed) {
+
+        match serde_json::from_str::<RawEvent>(line) {
             Ok(event) => events.push(event),
             Err(e) => {
                 tracing::warn!(line = line_num + 1, error = %e, "Skipping malformed event line");

--- a/crates/tracepilot-core/src/parsing/events/typed.rs
+++ b/crates/tracepilot-core/src/parsing/events/typed.rs
@@ -103,13 +103,13 @@ pub(crate) fn typed_data_from_raw(
     /// Uses `&Value` as a `Deserializer` directly — no clone on the success path.
     /// The clone is deferred to the error fallback, which is rare in practice.
     macro_rules! try_deser {
-        ($variant:ident, $data_type:ty, $wire:expr, $data:expr) => {{
+        ($variant:ident, $data_type:ty, $data:expr, $event_type:expr) => {{
             match <$data_type as serde::de::Deserialize>::deserialize($data) {
                 Ok(typed) => (TypedEventData::$variant(typed), None),
                 Err(e) => (
                     TypedEventData::Other($data.clone()),
                     Some(EventParseWarning::DeserializationFailed {
-                        event_type: $wire.to_string(),
+                        event_type: $event_type.to_string(),
                         error: e.to_string(),
                     }),
                 ),
@@ -119,210 +119,128 @@ pub(crate) fn typed_data_from_raw(
 
     match event_type {
         SessionEventType::SessionStart => {
-            try_deser!(SessionStart, SessionStartData, "session.start", data)
+            try_deser!(SessionStart, SessionStartData, data, event_type)
         }
         SessionEventType::SessionShutdown => {
-            try_deser!(SessionShutdown, ShutdownData, "session.shutdown", data)
+            try_deser!(SessionShutdown, ShutdownData, data, event_type)
         }
-        SessionEventType::UserMessage => {
-            try_deser!(UserMessage, UserMessageData, "user.message", data)
-        }
+        SessionEventType::UserMessage => try_deser!(UserMessage, UserMessageData, data, event_type),
         SessionEventType::AssistantMessage => {
-            try_deser!(
-                AssistantMessage,
-                AssistantMessageData,
-                "assistant.message",
-                data
-            )
+            try_deser!(AssistantMessage, AssistantMessageData, data, event_type)
         }
         SessionEventType::AssistantTurnStart => {
-            try_deser!(TurnStart, TurnStartData, "assistant.turn_start", data)
+            try_deser!(TurnStart, TurnStartData, data, event_type)
         }
-        SessionEventType::AssistantTurnEnd => {
-            try_deser!(TurnEnd, TurnEndData, "assistant.turn_end", data)
-        }
+        SessionEventType::AssistantTurnEnd => try_deser!(TurnEnd, TurnEndData, data, event_type),
         SessionEventType::ToolExecutionStart => {
-            try_deser!(
-                ToolExecutionStart,
-                ToolExecStartData,
-                "tool.execution_start",
-                data
-            )
+            try_deser!(ToolExecutionStart, ToolExecStartData, data, event_type)
         }
         SessionEventType::ToolExecutionComplete => {
             try_deser!(
                 ToolExecutionComplete,
                 ToolExecCompleteData,
-                "tool.execution_complete",
-                data
+                data,
+                event_type
             )
         }
         SessionEventType::SubagentStarted => {
-            try_deser!(
-                SubagentStarted,
-                SubagentStartedData,
-                "subagent.started",
-                data
-            )
+            try_deser!(SubagentStarted, SubagentStartedData, data, event_type)
         }
         SessionEventType::SubagentCompleted => {
-            try_deser!(
-                SubagentCompleted,
-                SubagentCompletedData,
-                "subagent.completed",
-                data
-            )
+            try_deser!(SubagentCompleted, SubagentCompletedData, data, event_type)
         }
         SessionEventType::SubagentFailed => {
-            try_deser!(SubagentFailed, SubagentFailedData, "subagent.failed", data)
+            try_deser!(SubagentFailed, SubagentFailedData, data, event_type)
         }
         SessionEventType::SessionCompactionComplete => {
-            try_deser!(
-                CompactionComplete,
-                CompactionCompleteData,
-                "session.compaction_complete",
-                data
-            )
+            try_deser!(CompactionComplete, CompactionCompleteData, data, event_type)
         }
         SessionEventType::SessionCompactionStart => {
-            try_deser!(
-                CompactionStart,
-                CompactionStartData,
-                "session.compaction_start",
-                data
-            )
+            try_deser!(CompactionStart, CompactionStartData, data, event_type)
         }
         SessionEventType::SessionModelChange => {
-            try_deser!(ModelChange, ModelChangeData, "session.model_change", data)
+            try_deser!(ModelChange, ModelChangeData, data, event_type)
         }
         SessionEventType::SessionError => {
-            try_deser!(SessionError, SessionErrorData, "session.error", data)
+            try_deser!(SessionError, SessionErrorData, data, event_type)
         }
         SessionEventType::SessionResume => {
-            try_deser!(SessionResume, SessionResumeData, "session.resume", data)
+            try_deser!(SessionResume, SessionResumeData, data, event_type)
         }
         SessionEventType::SystemNotification => {
-            try_deser!(
-                SystemNotification,
-                SystemNotificationData,
-                "system.notification",
-                data
-            )
+            try_deser!(SystemNotification, SystemNotificationData, data, event_type)
         }
         SessionEventType::SkillInvoked => {
-            try_deser!(SkillInvoked, SkillInvokedData, "skill.invoked", data)
+            try_deser!(SkillInvoked, SkillInvokedData, data, event_type)
         }
-        SessionEventType::Abort => {
-            try_deser!(Abort, AbortData, "abort", data)
-        }
+        SessionEventType::Abort => try_deser!(Abort, AbortData, data, event_type),
         SessionEventType::SessionPlanChanged => {
-            try_deser!(PlanChanged, PlanChangedData, "session.plan_changed", data)
+            try_deser!(PlanChanged, PlanChangedData, data, event_type)
         }
-        SessionEventType::SessionInfo => {
-            try_deser!(SessionInfo, SessionInfoData, "session.info", data)
-        }
+        SessionEventType::SessionInfo => try_deser!(SessionInfo, SessionInfoData, data, event_type),
         SessionEventType::SessionContextChanged => {
-            try_deser!(
-                ContextChanged,
-                SessionContext,
-                "session.context_changed",
-                data
-            )
+            try_deser!(ContextChanged, SessionContext, data, event_type)
         }
         SessionEventType::SessionWorkspaceFileChanged => {
             try_deser!(
                 WorkspaceFileChanged,
                 WorkspaceFileChangedData,
-                "session.workspace_file_changed",
-                data
+                data,
+                event_type
             )
         }
         SessionEventType::ToolUserRequested => {
-            try_deser!(
-                ToolUserRequested,
-                ToolUserRequestedData,
-                "tool.user_requested",
-                data
-            )
+            try_deser!(ToolUserRequested, ToolUserRequestedData, data, event_type)
         }
         // New event types
         SessionEventType::SessionTruncation => {
-            try_deser!(
-                SessionTruncation,
-                SessionTruncationData,
-                "session.truncation",
-                data
-            )
+            try_deser!(SessionTruncation, SessionTruncationData, data, event_type)
         }
         SessionEventType::AssistantReasoning => {
-            try_deser!(
-                AssistantReasoning,
-                AssistantReasoningData,
-                "assistant.reasoning",
-                data
-            )
+            try_deser!(AssistantReasoning, AssistantReasoningData, data, event_type)
         }
         SessionEventType::SystemMessage => {
-            try_deser!(SystemMessage, SystemMessageData, "system.message", data)
+            try_deser!(SystemMessage, SystemMessageData, data, event_type)
         }
         SessionEventType::SessionWarning => {
-            try_deser!(SessionWarning, SessionWarningData, "session.warning", data)
+            try_deser!(SessionWarning, SessionWarningData, data, event_type)
         }
         SessionEventType::SessionModeChanged => {
-            try_deser!(
-                SessionModeChanged,
-                SessionModeChangedData,
-                "session.mode_changed",
-                data
-            )
+            try_deser!(SessionModeChanged, SessionModeChangedData, data, event_type)
         }
         SessionEventType::SessionTaskComplete => {
             try_deser!(
                 SessionTaskComplete,
                 SessionTaskCompleteData,
-                "session.task_complete",
-                data
+                data,
+                event_type
             )
         }
         SessionEventType::SubagentSelected => {
-            try_deser!(
-                SubagentSelected,
-                SubagentSelectedData,
-                "subagent.selected",
-                data
-            )
+            try_deser!(SubagentSelected, SubagentSelectedData, data, event_type)
         }
         SessionEventType::SubagentDeselected => {
-            try_deser!(
-                SubagentDeselected,
-                SubagentDeselectedData,
-                "subagent.deselected",
-                data
-            )
+            try_deser!(SubagentDeselected, SubagentDeselectedData, data, event_type)
         }
-        SessionEventType::HookStart => {
-            try_deser!(HookStart, HookStartData, "hook.start", data)
-        }
-        SessionEventType::HookEnd => {
-            try_deser!(HookEnd, HookEndData, "hook.end", data)
-        }
+        SessionEventType::HookStart => try_deser!(HookStart, HookStartData, data, event_type),
+        SessionEventType::HookEnd => try_deser!(HookEnd, HookEndData, data, event_type),
         SessionEventType::SessionHandoff => {
-            try_deser!(SessionHandoff, SessionHandoffData, "session.handoff", data)
+            try_deser!(SessionHandoff, SessionHandoffData, data, event_type)
         }
         SessionEventType::SessionImportLegacy => {
             try_deser!(
                 SessionImportLegacy,
                 SessionImportLegacyData,
-                "session.import_legacy",
-                data
+                data,
+                event_type
             )
         }
         SessionEventType::SessionRemoteSteerableChanged => {
             try_deser!(
                 SessionRemoteSteerableChanged,
                 SessionRemoteSteerableChangedData,
-                "session.remote_steerable_changed",
-                data
+                data,
+                event_type
             )
         }
         SessionEventType::Unknown(name) => (

--- a/crates/tracepilot-core/src/parsing/mod.rs
+++ b/crates/tracepilot-core/src/parsing/mod.rs
@@ -17,3 +17,14 @@ pub mod events;
 pub mod rewind_snapshots;
 pub mod session_db;
 pub mod workspace;
+
+/// File name for the JSONL event log.
+pub const EVENTS_JSONL: &str = "events.jsonl";
+/// File name for the YAML workspace metadata.
+pub const WORKSPACE_YAML: &str = "workspace.yaml";
+/// File name for the SQLite session database.
+pub const SESSION_DB: &str = "session.db";
+/// Directory name for checkpoints.
+pub const CHECKPOINTS_DIR: &str = "checkpoints";
+/// Directory name for rewind snapshots.
+pub const REWIND_SNAPSHOTS_DIR: &str = "rewind-snapshots";

--- a/crates/tracepilot-core/src/session/discovery.rs
+++ b/crates/tracepilot-core/src/session/discovery.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::error::{Result, TracePilotError};
+use crate::parsing::{EVENTS_JSONL, SESSION_DB, WORKSPACE_YAML};
 
 /// Maximum age of session activity before a lock file is considered stale.
 const STALE_LOCK_THRESHOLD: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
@@ -60,9 +61,9 @@ pub fn discover_sessions(base_dir: &Path) -> Result<Vec<DiscoveredSession>> {
 
         sessions.push(DiscoveredSession {
             id,
-            has_workspace_yaml: path.join("workspace.yaml").exists(),
-            has_events_jsonl: path.join("events.jsonl").exists(),
-            has_session_db: path.join("session.db").exists(),
+            has_workspace_yaml: path.join(WORKSPACE_YAML).exists(),
+            has_events_jsonl: path.join(EVENTS_JSONL).exists(),
+            has_session_db: path.join(SESSION_DB).exists(),
             path,
         });
     }
@@ -103,7 +104,7 @@ fn has_recent_activity(session_dir: &Path) -> bool {
     let now = SystemTime::now();
 
     // Check events.jsonl first (best activity indicator)
-    if is_file_recent(&session_dir.join("events.jsonl"), now) {
+    if is_file_recent(&session_dir.join(EVENTS_JSONL), now) {
         return true;
     }
 
@@ -207,7 +208,7 @@ mod tests {
 
         let uuid_dir = tmp.path().join("c86fe369-c858-4d91-81da-203c5e276e33");
         fs::create_dir_all(&uuid_dir).unwrap();
-        fs::write(uuid_dir.join("workspace.yaml"), "id: test").unwrap();
+        fs::write(uuid_dir.join(WORKSPACE_YAML), "id: test").unwrap();
 
         let not_uuid = tmp.path().join("not-a-uuid");
         fs::create_dir_all(&not_uuid).unwrap();
@@ -311,7 +312,7 @@ mod tests {
         );
         filetime::set_file_mtime(&lock_path, old_time).unwrap();
         // Create recent events.jsonl
-        fs::write(tmp.path().join("events.jsonl"), "{}").unwrap();
+        fs::write(tmp.path().join(EVENTS_JSONL), "{}").unwrap();
         // Recent events → should be active despite stale lock
         assert!(has_lock_file(tmp.path()));
     }

--- a/crates/tracepilot-core/src/summary/loader.rs
+++ b/crates/tracepilot-core/src/summary/loader.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::error::Result;
 use crate::models::session_summary::SessionSummary;
+use crate::parsing::EVENTS_JSONL;
 use crate::parsing::events::{TypedEvent, parse_typed_events};
 
 use super::artifacts::apply_artifact_flags;
@@ -57,7 +58,7 @@ fn load_session_summary_impl(session_dir: &Path, retain_events: bool) -> Result<
     let mut summary = load_workspace_summary(session_dir)?;
 
     // 2–5. Events processing — parse ONCE, derive count from len()
-    let events_path = session_dir.join("events.jsonl");
+    let events_path = session_dir.join(EVENTS_JSONL);
     let mut typed_events_out = None;
     let mut diagnostics_out = None;
 

--- a/crates/tracepilot-core/src/summary/workspace.rs
+++ b/crates/tracepilot-core/src/summary/workspace.rs
@@ -2,11 +2,12 @@ use std::path::Path;
 
 use crate::error::{Result, TracePilotError};
 use crate::models::session_summary::SessionSummary;
+use crate::parsing::WORKSPACE_YAML;
 use crate::parsing::workspace::{WorkspaceMetadata, parse_workspace_yaml};
 
 /// Parse `workspace.yaml` when present, otherwise fall back to the directory ID.
 pub(super) fn load_workspace_summary(session_dir: &Path) -> Result<SessionSummary> {
-    let workspace_path = session_dir.join("workspace.yaml");
+    let workspace_path = session_dir.join(WORKSPACE_YAML);
     if workspace_path.exists() {
         match parse_workspace_yaml(&workspace_path) {
             Ok(ws) => Ok(summary_from_workspace(ws)),

--- a/crates/tracepilot-indexer/src/index_db/session_writer/prune.rs
+++ b/crates/tracepilot-indexer/src/index_db/session_writer/prune.rs
@@ -19,12 +19,12 @@ impl IndexDb {
             return Ok(0);
         }
 
-        self.conn.execute_batch("BEGIN")?;
+        self.conn.execute_batch("SAVEPOINT prune_deleted")?;
         let result = (|| -> Result<()> {
             // Use json_each() to pass all live IDs as a single JSON array parameter,
             // avoiding the N individual INSERT statements into a temp table.
             let live_json = serde_json::to_string(&live_ids.iter().collect::<Vec<_>>())
-                .expect("string serialization is infallible");
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
 
             self.conn.execute(
                 "DELETE FROM sessions WHERE id NOT IN (SELECT value FROM json_each(?1))",
@@ -39,11 +39,14 @@ impl IndexDb {
 
         match result {
             Ok(()) => {
-                self.conn.execute_batch("COMMIT")?;
+                self.conn.execute_batch("RELEASE SAVEPOINT prune_deleted")?;
                 Ok(count)
             }
             Err(e) => {
-                if let Err(rb_err) = self.conn.execute_batch("ROLLBACK") {
+                if let Err(rb_err) = self
+                    .conn
+                    .execute_batch("ROLLBACK TO SAVEPOINT prune_deleted")
+                {
                     tracing::warn!(error = %rb_err, "ROLLBACK after prune_deleted failed");
                 }
                 Err(e)

--- a/crates/tracepilot-tauri-bindings/src/commands/session/events.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/session/events.rs
@@ -4,6 +4,7 @@ use crate::config::SharedConfig;
 use crate::error::CmdResult;
 use crate::helpers::with_session_path;
 use crate::types::{EventCache, EventItem, EventsResponse, FreshnessResponse};
+use tracepilot_core::parsing::EVENTS_JSONL;
 
 use super::shared::{load_cached_typed_events, system_time_to_unix_millis};
 
@@ -16,7 +17,7 @@ pub async fn check_session_freshness(
 ) -> CmdResult<FreshnessResponse> {
     let sid = crate::validators::validate_session_id(&session_id)?;
     with_session_path(&state, sid, |path| {
-        let meta = std::fs::metadata(path.join("events.jsonl")).ok();
+        let meta = std::fs::metadata(path.join(EVENTS_JSONL)).ok();
         let file_size = meta.as_ref().map_or(0, |m| m.len());
         let file_mtime = meta.and_then(|m| m.modified().ok());
         Ok(FreshnessResponse {
@@ -44,7 +45,7 @@ pub async fn get_session_events(
     let cache_session_id = session_id.clone();
 
     with_session_path(&state, sid, move |path| {
-        let events_path = path.join("events.jsonl");
+        let events_path = path.join(EVENTS_JSONL);
         let (all_events, _, _) = load_cached_typed_events(&cache, &cache_session_id, &events_path)?;
 
         let all_event_types: Vec<String> = {
@@ -105,7 +106,7 @@ pub async fn get_tool_result(
     let cache_session_id = session_id.clone();
 
     with_session_path(&state, sid, move |path| {
-        let events_path = path.join("events.jsonl");
+        let events_path = path.join(EVENTS_JSONL);
         let (events, _, _) = load_cached_typed_events(&cache, &cache_session_id, &events_path)?;
 
         let mut last_result: Option<serde_json::Value> = None;

--- a/crates/tracepilot-tauri-bindings/src/commands/session/resume.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/session/resume.rs
@@ -1,6 +1,8 @@
 //! `resume_session_in_terminal` — spawn a detached terminal running the CLI's
 //! resume command for the given session.
 
+use tracepilot_core::parsing::WORKSPACE_YAML;
+
 use crate::config::SharedConfig;
 use crate::error::{BindingsError, CmdResult};
 use crate::helpers::read_config;
@@ -38,7 +40,7 @@ pub async fn resume_session_in_terminal(
             &sid,
             &session_state_dir,
         )?;
-        let workspace_path = session_path.join("workspace.yaml");
+        let workspace_path = session_path.join(WORKSPACE_YAML);
         let metadata = tracepilot_core::parsing::workspace::parse_workspace_yaml(&workspace_path)?;
         Ok::<Option<std::path::PathBuf>, BindingsError>(metadata.cwd.map(std::path::PathBuf::from))
     })


### PR DESCRIPTION
### Fixes implemented:
1. **refactor(core): use enum-derived wire strings for typed events**
   - Centralizes wire-format strings in the SessionEventType enum.
   - Removed 41 redundant hardcoded strings.
2. **refactor(core): centralize session file name constants**
   - Added public constants for EVENTS_JSONL, WORKSPACE_YAML, etc.
   - Updated ~15 sites for consistency.
3. **refactor(indexer): use SAVEPOINT for prune_deleted transaction**
   - Standardized transaction pattern and removed an expect() call.

### Verification:
- All tests passed: cargo test -p tracepilot-core -p tracepilot-tauri-bindings -p tracepilot-indexer
- Clippy clean: cargo clippy -p <crate> -- -D warnings