### PR TITLE
🎨 Palette: Add aria-hidden to decorative close button icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Screen reader accessibility for purely decorative elements
+**Learning:** Decorative unicode characters like '✕' and '×' in interactive elements, even when an `aria-label` is present, can confuse screen readers if not properly hidden using `aria-hidden="true"`.
+**Action:** Always wrap raw unicode symbols or decorative SVGs inside buttons with `<span aria-hidden="true">` or `<svg aria-hidden="true">` respectively to prevent screen readers from reading them incorrectly.

--- a/packages/ui/src/components/EnvVarTable.vue
+++ b/packages/ui/src/components/EnvVarTable.vue
@@ -60,7 +60,7 @@ function removeRow(vars: EnvVar[], index: number) {
       />
       <span v-else class="env-cell env-col-value">{{ v.value }}</span>
 
-      <button v-if="editable" class="env-remove" @click="removeRow(vars, i)" aria-label="Remove variable">×</button>
+      <button v-if="editable" class="env-remove" @click="removeRow(vars, i)" aria-label="Remove variable"><span aria-hidden="true">×</span></button>
     </div>
     <div v-if="vars.length === 0" class="env-empty">No environment variables</div>
     <button v-if="editable" class="env-add" @click="addRow(vars)">+ Add Variable</button>

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -40,7 +40,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           <slot name="header">
             <h3>{{ title }}</h3>
           </slot>
-          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close">✕</button>
+          <button class="btn btn-ghost btn-sm" @click="close" aria-label="Close"><span aria-hidden="true">✕</span></button>
         </div>
         <div class="modal-body">
           <slot />

--- a/packages/ui/src/components/SubagentPanel/SubagentPanelHeader.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanelHeader.vue
@@ -24,7 +24,7 @@ function statusClass(s: SubagentStatus): string {
       aria-label="Close panel"
       title="Close (Esc)"
       @click="emit('close')"
-    >✕</button>
+    ><span aria-hidden="true">✕</span></button>
     <div class="sap-info">
       <div class="sap-name" :style="{ color: agentColor }">
         <span class="sap-name-icon">{{ agentIcon }}</span>

--- a/packages/ui/src/components/TagList.vue
+++ b/packages/ui/src/components/TagList.vue
@@ -39,7 +39,7 @@ function onKeydown(e: KeyboardEvent, tags: string[]) {
   <div class="tag-list">
     <span v-for="(tag, i) in tags" :key="tag" class="tag-item">
       {{ tag }}
-      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag">×</button>
+      <button v-if="editable" class="tag-remove" @click="removeTag(tags, i)" aria-label="Remove tag"><span aria-hidden="true">×</span></button>
     </span>
     <input
       v-if="editable"

--- a/packages/ui/src/components/ToastContainer.vue
+++ b/packages/ui/src/components/ToastContainer.vue
@@ -57,7 +57,7 @@ function onAction(action: { label: string; onClick: () => void }, id: string) {
           </button>
         </div>
 
-        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)">✕</button>
+        <button class="toast-dismiss" aria-label="Dismiss" @click="dismiss(t.id)"><span aria-hidden="true">✕</span></button>
 
         <div
           v-if="t.duration > 0"

--- a/packages/ui/src/components/ToolDetailPanel.vue
+++ b/packages/ui/src/components/ToolDetailPanel.vue
@@ -51,7 +51,7 @@ defineEmits<{
         >{{ badge.label }}</Badge>
         <Badge v-if="tc.isSubagent" variant="neutral">agent</Badge>
       </div>
-      <button class="detail-close" @click.stop="$emit('close')" aria-label="Close detail panel">✕</button>
+      <button class="detail-close" @click.stop="$emit('close')" aria-label="Close detail panel"><span aria-hidden="true">✕</span></button>
     </div>
 
     <!-- Metadata grid -->


### PR DESCRIPTION
### What
Wrapped decorative unicode characters like `'✕'` and `'×'` inside buttons with `<span aria-hidden="true">` across several Vue components in `@tracepilot/ui`.
Files updated:
- `TagList.vue`
- `ModalDialog.vue`
- `SubagentPanelHeader.vue`
- `ToastContainer.vue`
- `ToolDetailPanel.vue`
- `EnvVarTable.vue`

### Why
Screen readers can get confused when a raw symbol is inside a button, often reading out the symbol name (e.g. "times" or "multiplication X") alongside the `aria-label`, resulting in a noisy or confusing user experience.

### Before/After
**Before:** `<button aria-label="Close">✕</button>` (Screen readers might announce "Close, times")
**After:** `<button aria-label="Close"><span aria-hidden="true">✕</span></button>` (Screen readers just announce "Close")

### Accessibility
This change improves semantic accessibility and aligns with best practices for handling text nodes that are meant purely for visual decoration inside interactive components.

---
*PR created automatically by Jules for task [3138386837942891745](https://jules.google.com/task/3138386837942891745) started by @MattShelton04*