### PR TITLE
refactor: technical debt reduction (formatting and I/O helpers)

### DIFF
--- a/apps/desktop/src/components/analytics/AnalyticsCacheHealthRow.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsCacheHealthRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { AnalyticsData } from "@tracepilot/types";
 import { formatNumber, SectionPanel } from "@tracepilot/ui";
+import { formatPercent } from "@/utils/percentageFormatting";
 
 defineProps<{
   data: AnalyticsData;
@@ -11,10 +12,10 @@ defineProps<{
   <div class="grid-2 mb-4" v-if="data.cacheStats">
     <!-- Cache Efficiency -->
     <SectionPanel v-if="data.cacheStats" title="Cache Efficiency">
-      <div class="cache-hit-rate" :title="`${data.cacheStats.cacheHitRate.toFixed(1)}% of input tokens were served from the prompt cache`">
+      <div class="cache-hit-rate" :title="`${formatPercent(data.cacheStats.cacheHitRate)} of input tokens were served from the prompt cache`">
         <div class="cache-hit-rate-label">
           <span>Cache Hit Rate</span>
-          <strong>{{ data.cacheStats.cacheHitRate.toFixed(1) }}%</strong>
+          <strong>{{ formatPercent(data.cacheStats.cacheHitRate) }}</strong>
         </div>
         <div class="cache-progress-track">
           <div

--- a/apps/desktop/src/components/mcp/McpServerCard.vue
+++ b/apps/desktop/src/components/mcp/McpServerCard.vue
@@ -4,6 +4,7 @@ import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { ROUTE_NAMES } from "@/config/routes";
 import { pushRoute } from "@/router/navigation";
+import { formatCompactNumber } from "@/utils/numberFormatting";
 import McpStatusDot from "./McpStatusDot.vue";
 
 const props = defineProps<{
@@ -45,7 +46,7 @@ const statusDotClass = computed(() => {
 
 const tokensFormatted = computed(() => {
   const t = props.server.totalTokens;
-  return t >= 1000 ? `~${(t / 1000).toFixed(1)}k` : `~${t}`;
+  return `~${formatCompactNumber(t)}`;
 });
 
 const description = computed(() => {

--- a/apps/desktop/src/components/mcp/McpTokenSummary.vue
+++ b/apps/desktop/src/components/mcp/McpTokenSummary.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { formatCompactNumber } from "@/utils/numberFormatting";
 
 const props = withDefaults(
   defineProps<{
@@ -15,19 +16,14 @@ const props = withDefaults(
   },
 );
 
-const formatted = computed(() => {
-  if (props.tokens >= 1000) {
-    return `~${(props.tokens / 1000).toFixed(1)}k`;
-  }
-  return `~${props.tokens}`;
-});
+const formatted = computed(() => `~${formatCompactNumber(props.tokens)}`);
 
 const percentage = computed(() => {
   if (props.contextSize <= 0) return 0;
   return Number(((props.tokens / props.contextSize) * 100).toFixed(1));
 });
 
-const contextLabel = computed(() => `${props.contextSize / 1000}k`);
+const contextLabel = computed(() => formatCompactNumber(props.contextSize));
 </script>
 
 <template>

--- a/apps/desktop/src/components/mcp/McpToolList.vue
+++ b/apps/desktop/src/components/mcp/McpToolList.vue
@@ -2,6 +2,8 @@
 import type { McpTool } from "@tracepilot/types";
 import { computed, ref } from "vue";
 
+import { formatCompactNumber } from "@/utils/numberFormatting";
+
 const props = defineProps<{
   tools: McpTool[];
 }>();
@@ -37,7 +39,7 @@ const filteredTools = computed(() => {
       <div class="tool-header">
         <code class="tool-name">{{ tool.name }}</code>
         <span class="tool-tokens" :title="`${tool.estimatedTokens.toLocaleString()} estimated tokens`">
-          {{ tool.estimatedTokens >= 1000 ? `${(tool.estimatedTokens / 1000).toFixed(1)}k` : tool.estimatedTokens }} tok
+          {{ formatCompactNumber(tool.estimatedTokens) }} tok
         </span>
       </div>
       <p v-if="tool.description" class="tool-description">{{ tool.description }}</p>

--- a/apps/desktop/src/components/metrics/MetricsCacheBreakdown.vue
+++ b/apps/desktop/src/components/metrics/MetricsCacheBreakdown.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { formatNumber, SectionPanel } from "@tracepilot/ui";
 import { computed } from "vue";
+import { formatPercent } from "@/utils/percentageFormatting";
 
 const props = defineProps<{
   cacheHitRatio: number;
@@ -25,8 +26,8 @@ const cachePercent = computed(() => Math.round(props.cacheHitRatio * 100));
           <div class="cache-bar-fill" :style="{ width: `${cacheHitRatio * 100}%` }" />
         </div>
         <div class="cache-bar-legend">
-          <span class="legend-cached">{{ (cacheHitRatio * 100).toFixed(1) }}% cached</span>
-          <span class="legend-uncached">{{ ((1 - cacheHitRatio) * 100).toFixed(1) }}% uncached</span>
+          <span class="legend-cached">{{ formatPercent(cacheHitRatio, { isRatio: true }) }} cached</span>
+          <span class="legend-uncached">{{ formatPercent(1 - cacheHitRatio, { isRatio: true }) }} uncached</span>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/skills/SkillCard.vue
+++ b/apps/desktop/src/components/skills/SkillCard.vue
@@ -5,6 +5,8 @@ import { ROUTE_NAMES } from "@/config/routes";
 import { pushRoute } from "@/router/navigation";
 import SkillScopeBadge from "./SkillScopeBadge.vue";
 
+import { formatCompactNumber } from "@/utils/numberFormatting";
+
 const props = defineProps<{
   skill: SkillSummary;
 }>();
@@ -40,8 +42,7 @@ function onDelete(event: Event) {
 }
 
 function formatTokens(n: number): string {
-  if (n >= 1_000) return `~${(n / 1_000).toFixed(1)}k tok`;
-  return `~${n} tok`;
+  return `~${formatCompactNumber(n)} tok`;
 }
 </script>
 

--- a/apps/desktop/src/components/skills/SkillTokenBar.vue
+++ b/apps/desktop/src/components/skills/SkillTokenBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { formatCompactNumber } from "@/utils/numberFormatting";
 
 const props = defineProps<{
   tokens: number;
@@ -16,8 +17,7 @@ const barClass = computed(() => {
 });
 
 function formatTokens(n: number): string {
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
+  return formatCompactNumber(n);
 }
 </script>
 

--- a/apps/desktop/src/components/tokenFlow/TokenFlowSankey.vue
+++ b/apps/desktop/src/components/tokenFlow/TokenFlowSankey.vue
@@ -2,6 +2,7 @@
 import { formatNumber } from "@tracepilot/ui";
 import { computed, ref } from "vue";
 import { SANKEY_LAYOUT, type SankeyLink, type SankeyNode } from "@/composables/useSankeyLayout";
+import { formatPercent } from "@/utils/percentageFormatting";
 
 const props = defineProps<{
   sankeyData: { nodes: SankeyNode[]; links: SankeyLink[] };
@@ -75,8 +76,8 @@ function showLinkTooltip(link: SankeyLink, event: MouseEvent) {
   const src = props.sankeyData.nodes.find((n) => n.id === link.source);
   const tgt = props.sankeyData.nodes.find((n) => n.id === link.target);
   const total = props.totalTokens || 1;
-  const pct = ((link.tokens / total) * 100).toFixed(1);
-  tooltipText.value = `${src?.label ?? link.source} → ${tgt?.label ?? link.target}\n${formatNumber(link.tokens)} tokens (${pct}%)`;
+  const pct = formatPercent(link.tokens / total, { isRatio: true });
+  tooltipText.value = `${src?.label ?? link.source} → ${tgt?.label ?? link.target}\n${formatNumber(link.tokens)} tokens (${pct})`;
   positionTooltip(event);
   tooltipVisible.value = true;
 }
@@ -84,8 +85,8 @@ function showLinkTooltip(link: SankeyLink, event: MouseEvent) {
 function showNodeTooltip(node: SankeyNode, event: MouseEvent) {
   hoveredNode.value = node.id;
   const total = props.totalTokens || 1;
-  const pct = ((node.tokens / total) * 100).toFixed(1);
-  tooltipText.value = `${node.label}\n${formatNumber(node.tokens)} tokens (${pct}%)`;
+  const pct = formatPercent(node.tokens / total, { isRatio: true });
+  tooltipText.value = `${node.label}\n${formatNumber(node.tokens)} tokens (${pct})`;
   positionTooltip(event);
   tooltipVisible.value = true;
 }

--- a/apps/desktop/src/composables/useModelComparison.ts
+++ b/apps/desktop/src/composables/useModelComparison.ts
@@ -4,6 +4,7 @@ import { useAnalyticsPage } from "@/composables/useAnalyticsPage";
 import { usePreferencesStore } from "@/stores/preferences";
 import { MODEL_PALETTE } from "@/utils/chartColors";
 import { formatModelDelta } from "@/utils/deltaFormatting";
+import { formatCompactNumber } from "@/utils/numberFormatting";
 import {
   radarAxisEnd,
   radarLabelPos,
@@ -315,7 +316,7 @@ export function useModelComparison() {
     if (normMode.value === "share") return `${value.toFixed(1)}%`;
     if (isCost) {
       // Compact cost format for large values
-      if (Math.abs(value) >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+      if (Math.abs(value) >= 1_000) return `$${formatCompactNumber(value).toUpperCase()}`;
       return formatCost(value);
     }
     if (normMode.value === "per-10m-tokens") {

--- a/apps/desktop/src/utils/numberFormatting.ts
+++ b/apps/desktop/src/utils/numberFormatting.ts
@@ -1,0 +1,18 @@
+/**
+ * Format a number into a compact string representation (e.g. 1,200 -> 1.2k).
+ * Strips trailing .0 for a cleaner look.
+ *
+ * @param value The numeric value to format
+ * @param decimals Number of decimal places for the compact form (default: 1)
+ * @returns Formatted string
+ */
+export function formatCompactNumber(value: number, decimals = 1): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(decimals).replace(/\.0+$/, "")}M`;
+  }
+  if (abs >= 1_000) {
+    return `${(value / 1_000).toFixed(decimals).replace(/\.0+$/, "")}k`;
+  }
+  return value.toString();
+}

--- a/apps/desktop/src/utils/percentageFormatting.ts
+++ b/apps/desktop/src/utils/percentageFormatting.ts
@@ -1,0 +1,20 @@
+/**
+ * Format a number as a percentage string (e.g. 0.123 -> "12.3%").
+ *
+ * @param value The numeric value (either a ratio 0..1 or a percentage 0..100)
+ * @param options Formatting options
+ * @returns Formatted string
+ */
+export function formatPercent(
+  value: number,
+  options: {
+    /** If true, multiplies value by 100 (default: false) */
+    isRatio?: boolean;
+    /** Number of decimal places (default: 1) */
+    decimals?: number;
+  } = {},
+): string {
+  const { isRatio = false, decimals = 1 } = options;
+  const pct = isRatio ? value * 100 : value;
+  return `${pct.toFixed(decimals)}%`;
+}

--- a/apps/desktop/src/views/ToolAnalysisView.vue
+++ b/apps/desktop/src/views/ToolAnalysisView.vue
@@ -14,6 +14,7 @@ import { computed } from "vue";
 import AnalyticsPageHeader from "@/components/AnalyticsPageHeader.vue";
 import { useAnalyticsPage } from "@/composables/useAnalyticsPage";
 import { CHART_COLORS } from "@/utils/chartColors";
+import { formatPercent } from "@/utils/percentageFormatting";
 
 const { tooltip, positionTooltip, dismissTooltip, onBarMouseEnter, findNearestIndex } =
   useChartTooltip();
@@ -51,9 +52,9 @@ function onSuccessFailureMouseMove(event: MouseEvent) {
   if (bestIdx < 0) return;
   const row = chart.rows[bestIdx];
   const total = row.successCount + row.failureCount;
-  const rate = total > 0 ? ((row.successCount / total) * 100).toFixed(1) : "0.0";
+  const rate = formatPercent(total > 0 ? row.successCount / total : 0, { isRatio: true });
   tooltip.visible = true;
-  tooltip.content = `${row.tool.name} — ${formatNumberFull(row.successCount)} success / ${formatNumberFull(row.failureCount)} failure (${rate}%)`;
+  tooltip.content = `${row.tool.name} — ${formatNumberFull(row.successCount)} success / ${formatNumberFull(row.failureCount)} failure (${rate})`;
   tooltip.chartId = "success-failure";
   tooltip.highlightIndex = bestIdx;
   positionTooltip(event, container);

--- a/apps/desktop/src/views/skills/SkillsManagerView.vue
+++ b/apps/desktop/src/views/skills/SkillsManagerView.vue
@@ -4,6 +4,7 @@ import { PageHeader, PageShell, useConfirmDialog } from "@tracepilot/ui";
 import { computed, onMounted, ref } from "vue";
 import SkillCard from "@/components/skills/SkillCard.vue";
 import SkillImportWizard from "@/components/skills/SkillImportWizard.vue";
+import { formatCompactNumber } from "@/utils/numberFormatting";
 import { useSkillsStore } from "@/stores/skills";
 
 const store = useSkillsStore();
@@ -28,8 +29,7 @@ onMounted(() => {
 });
 
 function formatTokens(n: number): string {
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
+  return formatCompactNumber(n);
 }
 
 function formatTokensWithCommas(n: number): string {

--- a/crates/tracepilot-core/src/error.rs
+++ b/crates/tracepilot-core/src/error.rs
@@ -82,6 +82,28 @@ impl TracePilotError {
             source: Some(Box::new(source)),
         }
     }
+
+    /// Read a file to string with context-rich errors.
+    pub fn read_to_string(path: &std::path::Path) -> Result<String> {
+        std::fs::read_to_string(path)
+            .map_err(|e| Self::io_context("Failed to read", path.display(), e))
+    }
+
+    /// Read and parse a JSON file with context-rich errors.
+    pub fn read_json<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> Result<T> {
+        let file = std::fs::File::open(path)
+            .map_err(|e| Self::io_context("Failed to read", path.display(), e))?;
+        let reader = std::io::BufReader::new(file);
+        serde_json::from_reader(reader).map_err(|e| Self::parse_context("JSON", path.display(), e))
+    }
+
+    /// Read and parse a YAML file with context-rich errors.
+    pub fn read_yaml<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> Result<T> {
+        let file = std::fs::File::open(path)
+            .map_err(|e| Self::io_context("Failed to read", path.display(), e))?;
+        let reader = std::io::BufReader::new(file);
+        serde_yml::from_reader(reader).map_err(|e| Self::parse_context("YAML", path.display(), e))
+    }
 }
 
 #[cfg(test)]

--- a/crates/tracepilot-core/src/parsing/checkpoints.rs
+++ b/crates/tracepilot-core/src/parsing/checkpoints.rs
@@ -36,8 +36,7 @@ pub fn parse_checkpoints(session_dir: &Path) -> Result<Option<CheckpointIndex>> 
         return Ok(None);
     }
 
-    let content = std::fs::read_to_string(&index_path)
-        .map_err(|e| TracePilotError::io_context("Failed to read", index_path.display(), e))?;
+    let content = TracePilotError::read_to_string(&index_path)?;
 
     let checkpoints_dir = session_paths.checkpoints_dir();
     let mut entries = Vec::new();
@@ -95,9 +94,7 @@ pub fn parse_checkpoints(session_dir: &Path) -> Result<Option<CheckpointIndex>> 
             continue;
         }
 
-        let file_content = Some(std::fs::read_to_string(&canonical_file).map_err(|e| {
-            TracePilotError::io_context("Failed to read checkpoint", canonical_file.display(), e)
-        })?);
+        let file_content = Some(TracePilotError::read_to_string(&canonical_file)?);
         entries.push(CheckpointEntry {
             number,
             title: title.to_string(),

--- a/crates/tracepilot-core/src/parsing/rewind_snapshots.rs
+++ b/crates/tracepilot-core/src/parsing/rewind_snapshots.rs
@@ -35,13 +35,7 @@ pub fn parse_rewind_index(session_dir: &Path) -> Result<Option<RewindIndex>> {
         return Ok(None);
     }
 
-    let content = std::fs::read_to_string(&index_path)
-        .map_err(|e| TracePilotError::io_context("Failed to read", index_path.display(), e))?;
-
-    let index: RewindIndex = serde_json::from_str(&content)
-        .map_err(|e| TracePilotError::parse_context("JSON", index_path.display(), e))?;
-
-    Ok(Some(index))
+    Ok(Some(TracePilotError::read_json(&index_path)?))
 }
 
 #[cfg(test)]

--- a/crates/tracepilot-core/src/parsing/workspace.rs
+++ b/crates/tracepilot-core/src/parsing/workspace.rs
@@ -22,11 +22,7 @@ pub struct WorkspaceMetadata {
 
 /// Parse a `workspace.yaml` file from a session directory.
 pub fn parse_workspace_yaml(path: &Path) -> Result<WorkspaceMetadata> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| TracePilotError::io_context("Failed to read", path.display(), e))?;
-    let metadata: WorkspaceMetadata = serde_yml::from_str(&content)
-        .map_err(|e| TracePilotError::parse_context("YAML", path.display(), e))?;
-    Ok(metadata)
+    TracePilotError::read_yaml(path)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses three independent areas of technical debt by introducing shared utilities and standardizing common patterns.

### Fix 1: Compact Number Formatting Utility (TS)
- **What**: Introduced `formatCompactNumber` in `apps/desktop/src/utils/numberFormatting.ts`. Refactored 7+ components/composables (e.g., `McpServerCard`, `SkillCard`, `useModelComparison`) to use this shared helper.
- **Why**: Eliminates duplicated logic for scaling large numbers (e.g., tokens) and ensures consistent display (e.g., `1.2k`) across the frontend.
- **Evidence**: 7 ad-hoc implementations -> 1 shared helper.

### Fix 2: Context-Rich Read & Parse Helpers (Rust)
- **What**: Added `read_json`, `read_yaml`, and `read_to_string` methods to `TracePilotError` in `tracepilot-core`. Refactored parsers in `rewind_snapshots.rs`, `workspace.rs`, and `checkpoints.rs`.
- **Why**: Standardizes the common "read then parse" pattern. Encapsulates rich error context (`io_context` + `parse_context`) while using memory-efficient `BufReader`.
- **Evidence**: 4 call sites -> 1-line standard helpers.

### Fix 3: Percentage Formatting Utility (TS)
- **What**: Introduced `formatPercent` in `apps/desktop/src/utils/percentageFormatting.ts`. Refactored 4 components/views (e.g., `AnalyticsCacheHealthRow`, `MetricsCacheBreakdown`, `TokenFlowSankey`).
- **Why**: Centralizes percentage display logic, safely handling both ratios (0–1) and percentages (0–100) with consistent decimal rounding.
- **Evidence**: 4 sites -> 1 helper.

---

### Verification
- `pnpm --filter @tracepilot/desktop typecheck` (Exit Code: 0)
- `cargo test -p tracepilot-core` (Exit Code: 0, 281 tests passed)
- `cargo clippy -p tracepilot-core -- -D warnings` (Exit Code: 0)
