### PR TITLE
🛡️ Sentinel: Fix command injection in detached terminal spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ packages/ui/src/__vrt__/__screenshots__/**/*-diff.png
 
 # Agent planning artifacts
 .agent/
+.jules/
 package-lock.json

--- a/crates/tracepilot-orchestrator/src/process/terminal.rs
+++ b/crates/tracepilot-orchestrator/src/process/terminal.rs
@@ -176,11 +176,9 @@ fn spawn_terminal_macos(
     }
 
     if !program.is_empty() {
-        let cmd_str = if args.is_empty() {
-            program.to_string()
-        } else {
-            format!("{} {}", program, args.join(" "))
-        };
+        let mut escaped_args = vec![shell_quote(program)];
+        escaped_args.extend(args.iter().map(|a| shell_quote(a)));
+        let cmd_str = escaped_args.join(" ");
         parts.push(cmd_str);
     }
 
@@ -218,11 +216,9 @@ fn spawn_terminal_linux(
 
         // If a program is specified, pass it via -e; otherwise just open a shell
         if !program.is_empty() {
-            let cmd_str = if args.is_empty() {
-                program.to_string()
-            } else {
-                format!("{} {}", program, args.join(" "))
-            };
+            let mut escaped_args = vec![crate::process::shell_quote(program)];
+            escaped_args.extend(args.iter().map(|a| crate::process::shell_quote(a)));
+            let cmd_str = escaped_args.join(" ");
             command.args(["-e", &cmd_str]);
         }
 


### PR DESCRIPTION
This PR merges the critical security fix from Google Jules (Sentinel) regarding detached terminal spawn. It also adds .jules to .gitignore.

Supersedes #556.