### PR TITLE
⚡ Bolt: Optimize SQLite batch inserts

### DIFF
--- a/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
+++ b/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
@@ -26,8 +26,8 @@ pub fn build_in_placeholders(n: usize) -> String {
     s
 }
 
-/// Build a complete `INSERT … VALUES (?1,?2),(…)` SQL string into a single
-/// pre-allocated buffer, using numbered bind parameters.
+/// Build a complete `INSERT … VALUES (?,?),(…)` SQL string into a single
+/// pre-allocated buffer, using sequential bind parameters.
 ///
 /// Avoids all intermediate `String`/`Vec` allocations that a `.map().collect().join()`
 /// chain produces (~600 per 50-row × 9-column batch).
@@ -43,7 +43,7 @@ pub fn build_in_placeholders(n: usize) -> String {
 /// use tracepilot_core::utils::sqlite::build_placeholder_sql;
 /// assert_eq!(
 ///     build_placeholder_sql("INSERT INTO t (a,b) VALUES", 2, 2),
-///     "INSERT INTO t (a,b) VALUES (?1,?2),(?3,?4)",
+///     "INSERT INTO t (a,b) VALUES (?,?),(?,?)",
 /// );
 /// ```
 #[must_use]
@@ -53,30 +53,29 @@ pub fn build_placeholder_sql(sql_prefix: &str, num_rows: usize, params_per_row: 
         params_per_row > 0,
         "build_placeholder_sql requires params_per_row > 0"
     );
-    use crate::utils::InfallibleWrite;
-    // SQLite max bind parameter is ?32766 (5 digits). Each param slot is
-    // "?NNNNN" (up to 6 chars) + "," separator = 7 chars. Each row adds "(", ")"
-    // and "," between rows = 3 chars. Capacity is a tight upper bound.
-    let total_params = num_rows * params_per_row;
-    let param_digits = total_params.checked_ilog10().unwrap_or(0) as usize + 1;
+    if num_rows == 0 || params_per_row == 0 {
+        return sql_prefix.to_string();
+    }
+
     let mut sql = String::with_capacity(
-        sql_prefix.len() + 1 + num_rows * (params_per_row * (param_digits + 2) + 3),
+        sql_prefix.len() + 1 + num_rows * (params_per_row * 2 + 1) + num_rows - 1,
     );
     sql.push_str(sql_prefix);
     sql.push(' ');
-    for i in 0..num_rows {
-        if i > 0 {
-            sql.push(',');
-        }
-        sql.push('(');
-        let start = i * params_per_row + 1;
-        for n in start..start + params_per_row {
-            if n > start {
-                sql.push(',');
-            }
-            sql.push_fmt(format_args!("?{n}"));
-        }
-        sql.push(')');
+
+    let mut row_str = String::with_capacity(params_per_row * 2 + 1);
+    row_str.push('(');
+    row_str.push('?');
+    for _ in 1..params_per_row {
+        row_str.push(',');
+        row_str.push('?');
+    }
+    row_str.push(')');
+
+    sql.push_str(&row_str);
+    for _ in 1..num_rows {
+        sql.push(',');
+        sql.push_str(&row_str);
     }
     sql
 }

--- a/crates/tracepilot-indexer/src/index_db/batch_insert.rs
+++ b/crates/tracepilot-indexer/src/index_db/batch_insert.rs
@@ -74,39 +74,47 @@ pub(crate) fn batched_insert<'a, T, F>(
     sql_prefix: &str,
     params_per_row: usize,
     items: &'a [T],
-    to_params: F,
+    mut to_params: F,
 ) -> Result<()>
 where
-    F: for<'b> Fn(&'a T, &'b mut Vec<&'a dyn ToSql>),
+    F: for<'b> FnMut(&'a T, &'b mut Vec<&'a dyn ToSql>),
 {
     if items.is_empty() {
         return Ok(());
     }
 
-    // All full-sized chunks share the same SQL shape — build it lazily on first
-    // use so sessions with < BATCH_CHUNK_SIZE rows (most analytics tables) pay
-    // zero allocation for the full-chunk string they never use.
-    let mut full_sql: Option<String> = None;
+    // Cache the prepared statement for full chunks.
+    // Re-preparing the same 100-row statement inside the loop is a major bottleneck
+    // when writing thousands of rows. Caching it here bypasses `sqlite3_prepare_v2`
+    // for everything except the final partial chunk.
+    let mut full_stmt_cache: Option<rusqlite::Statement<'_>> = None;
 
     for chunk in items.chunks(BATCH_CHUNK_SIZE) {
-        let partial;
-        let sql: &str = if chunk.len() == BATCH_CHUNK_SIZE {
-            full_sql.get_or_insert_with(|| {
-                build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row)
-            })
+        if chunk.len() == BATCH_CHUNK_SIZE {
+            if full_stmt_cache.is_none() {
+                let sql = build_placeholder_sql(sql_prefix, BATCH_CHUNK_SIZE, params_per_row);
+                full_stmt_cache = Some(conn.prepare(&sql)?);
+            }
+            let stmt = full_stmt_cache.as_mut().unwrap();
+
+            let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
+            for item in chunk {
+                to_params(item, &mut params);
+            }
+
+            stmt.execute(rusqlite::params_from_iter(params))?;
         } else {
-            partial = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
-            &partial
-        };
+            // Partial chunk logic remains dynamic to avoid polluting SQLite's statement cache
+            let sql = build_placeholder_sql(sql_prefix, chunk.len(), params_per_row);
+            let mut stmt = conn.prepare(&sql)?;
 
-        let mut stmt = conn.prepare(sql)?;
+            let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
+            for item in chunk {
+                to_params(item, &mut params);
+            }
 
-        let mut params: Vec<&'a dyn ToSql> = Vec::with_capacity(chunk.len() * params_per_row);
-        for item in chunk {
-            to_params(item, &mut params);
+            stmt.execute(rusqlite::params_from_iter(params))?;
         }
-
-        stmt.execute(rusqlite::params_from_iter(params))?;
     }
 
     Ok(())
@@ -120,13 +128,13 @@ mod tests {
     #[test]
     fn build_placeholder_sql_single_row_single_col() {
         let sql = build_placeholder_sql("INSERT INTO t (v) VALUES", 1, 1);
-        assert_eq!(sql, "INSERT INTO t (v) VALUES (?1)");
+        assert_eq!(sql, "INSERT INTO t (v) VALUES (?)");
     }
 
     #[test]
     fn build_placeholder_sql_multi_row_multi_col() {
         let sql = build_placeholder_sql("INSERT INTO t (a,b) VALUES", 2, 2);
-        assert_eq!(sql, "INSERT INTO t (a,b) VALUES (?1,?2),(?3,?4)");
+        assert_eq!(sql, "INSERT INTO t (a,b) VALUES (?,?),(?,?)");
     }
 
     #[test]


### PR DESCRIPTION
This PR merges the best performance improvements from Google Jules (Bolt) regarding SQLite batch inserts. It uses sequential bindings instead of formatted numbered parameters to reduce allocations, and caches the rusqlite statement object in atched_insert.

Supersedes #551, #569, #558, #535, #568, #552, #539, #559, #504.