### PR TITLE
fix: constrain explorer tab width

### DIFF
--- a/apps/desktop/src/__tests__/components/session/SessionDetailPanel.test.ts
+++ b/apps/desktop/src/__tests__/components/session/SessionDetailPanel.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { setupPinia } from "@tracepilot/test-utils";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SessionDetailPanel from "@/components/session/SessionDetailPanel.vue";
+import type { SessionDetailContext } from "@/composables/useSessionDetail";
+
+const mocks = vi.hoisted(() => ({
+  isSessionRunning: vi.fn(),
+  openInExplorer: vi.fn(),
+  resumeSessionInTerminal: vi.fn(),
+}));
+
+vi.mock("@tracepilot/client", async () => {
+  const { createClientMock } = await import("../../mocks/client");
+  return createClientMock({
+    isSessionRunning: mocks.isSessionRunning,
+    openInExplorer: mocks.openInExplorer,
+    resumeSessionInTerminal: mocks.resumeSessionInTerminal,
+  });
+});
+
+function createStore(): SessionDetailContext {
+  return {
+    sessionId: "session-1",
+    detail: {
+      id: "session-1",
+      summary: "Explorer Layout Session",
+      repository: "MattShelton04/TracePilot",
+      branch: "main",
+      hostType: "cli",
+      eventCount: 4,
+      turnCount: 2,
+      hasPlan: false,
+      hasCheckpoints: false,
+    },
+    turns: [],
+    turnsVersion: 0,
+    events: null,
+    todos: null,
+    checkpoints: null,
+    plan: null,
+    shutdownMetrics: null,
+    incidents: null,
+    loading: false,
+    error: null,
+    loaded: new Set(["detail"]),
+    turnsError: null,
+    eventsError: null,
+    todosError: null,
+    checkpointsError: null,
+    planError: null,
+    metricsError: null,
+    incidentsError: null,
+    pendingCheckpointFocus: null,
+    focusCheckpoint: vi.fn(),
+    loadDetail: vi.fn(),
+    loadTurns: vi.fn(),
+    loadEvents: vi.fn(),
+    loadTodos: vi.fn(),
+    loadCheckpoints: vi.fn(),
+    loadPlan: vi.fn(),
+    loadShutdownMetrics: vi.fn(),
+    loadIncidents: vi.fn(),
+    reset: vi.fn(),
+    refreshAll: vi.fn(),
+    prefetchSession: vi.fn(),
+  } as unknown as SessionDetailContext;
+}
+
+describe("SessionDetailPanel", () => {
+  beforeEach(() => {
+    setupPinia();
+    vi.clearAllMocks();
+    mocks.isSessionRunning.mockResolvedValue(false);
+  });
+
+  it("keeps Explorer fill-content mode inside the standard constrained page shell", () => {
+    const wrapper = mount(SessionDetailPanel, {
+      props: {
+        store: createStore(),
+        sessionId: "session-1",
+        router: null,
+        tabMode: "local",
+        activeSubTab: "explorer",
+        fillContent: true,
+        refreshEnabled: false,
+      },
+      slots: {
+        default: '<div class="explorer-slot">Explorer</div>',
+      },
+    });
+
+    expect(wrapper.find(".page-content.explorer-mode").exists()).toBe(true);
+    expect(wrapper.find(".page-content-inner").exists()).toBe(true);
+    expect(wrapper.find(".page-content-fluid").exists()).toBe(false);
+  });
+
+  it("preserves the constrained shell width when Explorer switches the shell to flex layout", () => {
+    const css = readFileSync("src/styles/features/session-explorer.css", "utf8");
+
+    expect(css).toMatch(
+      /\.page-content\.explorer-mode \.page-content-inner\s*\{[^}]*width:\s*100%;/s,
+    );
+  });
+});

--- a/apps/desktop/src/components/session/SessionDetailPanel.vue
+++ b/apps/desktop/src/components/session/SessionDetailPanel.vue
@@ -195,7 +195,7 @@ watch(isSessionActive, (active) => {
 </script>
 
 <template>
-  <PageShell :fluid="fillContent" :class="{ 'explorer-mode': fillContent }">
+  <PageShell :class="{ 'explorer-mode': fillContent }">
     <!-- Loading state -->
     <div v-if="store.loading" style="padding-top: 8px;">
       <SkeletonLoader variant="text" :count="1" />

--- a/apps/desktop/src/styles/features/session-explorer.css
+++ b/apps/desktop/src/styles/features/session-explorer.css
@@ -1,7 +1,8 @@
 /* ── Session Explorer — fill-height layout ────────────────────────────────────
  *
  * When the Explorer tab is active, .page-content must become a flex column
- * so that .detail-tab-content can grow to fill all remaining viewport height.
+ * so that .detail-tab-content can grow to fill all remaining viewport height
+ * while preserving the standard PageShell max-width wrapper used by other tabs.
  *
  * Scoped to .explorer-mode (applied by SessionDetailPanel via :class binding)
  * so no other session tabs are affected.
@@ -15,14 +16,16 @@
 }
 
 /*
- * PageShell renders a .page-content-fluid wrapper div in fluid mode (no
- * max-width constraint). Make it a flex column so the height chain reaches
- * .detail-tab-content without relying on an anonymous > div selector.
+ * Make the standard constrained PageShell wrapper a flex column so the height
+ * chain reaches .detail-tab-content without opting into full-bleed width. The
+ * explicit width preserves PageShell's normal block-width behavior after the
+ * wrapper becomes a flex item.
  */
-.page-content.explorer-mode .page-content-fluid {
+.page-content.explorer-mode .page-content-inner {
   display: flex;
   flex-direction: column;
   flex: 1;
+  width: 100%;
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary

- keep Session Explorer in the standard constrained PageShell wrapper instead of switching to fluid/full-bleed width
- preserve full-height Explorer behavior by applying flex layout to `.page-content-inner` with `width: 100%`
- add regression coverage for the wrapper and flex-width root cause

## Validation

- `pnpm --filter @tracepilot/desktop test -- src/__tests__/components/session/SessionDetailPanel.test.ts`
- `pnpm --filter @tracepilot/desktop typecheck`
- `pnpm exec biome check --error-on-warnings apps\desktop\src\components\session\SessionDetailPanel.vue apps\desktop\src\styles\features\session-explorer.css apps\desktop\src\__tests__\components\session\SessionDetailPanel.test.ts`
- `node C:\Users\mattt\.copilot\session-state\53b74aa6-cf36-47a0-90b8-8978274f1fc7\files\validate-explorer-layout.mjs`
- pre-push hook: `pnpm -r typecheck`, `rustfmt-all`, file-size check

Note: full `pnpm lint` is currently blocked by pre-existing generated files under `packages\ui\playwright\.cache`, so I also ran Biome directly on the touched files.
