### PR TITLE
Refactor: Technical debt cleanup and shared utility adoption

### DIFF
--- a/apps/desktop/src/__tests__/composables/useRecentSearches.test.ts
+++ b/apps/desktop/src/__tests__/composables/useRecentSearches.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 import type { RecentSearch } from "../../composables/useRecentSearches";
 import { useRecentSearches } from "../../composables/useRecentSearches";
 
@@ -86,11 +87,12 @@ describe("useRecentSearches", () => {
       expect(recentSearches.value[0].resultCount).toBe(20);
       expect(recentSearches.value[1].query).toBe("second");
     });
-
-    it("persists to localStorage after adding", () => {
+    it("persists to localStorage after adding", async () => {
       const { addRecentSearch } = useRecentSearches();
 
       addRecentSearch("test", 3);
+      await nextTick();
+      await nextTick();
 
       expect(mockStorage.setItem).toHaveBeenCalledWith(
         "tracepilot-recent-searches",
@@ -128,14 +130,18 @@ describe("useRecentSearches", () => {
       expect(recentSearches.value[0].query).toBe("keep");
     });
 
-    it("persists to localStorage after removing", () => {
+    it("persists to localStorage after removing", async () => {
       const { addRecentSearch, removeRecentSearch } = useRecentSearches();
 
       addRecentSearch("keep", 1);
       addRecentSearch("remove", 2);
+      await nextTick();
+      await nextTick();
       mockStorage.setItem.mockClear();
 
       removeRecentSearch("remove");
+      await nextTick();
+      await nextTick();
 
       expect(mockStorage.setItem).toHaveBeenCalled();
       const saved = JSON.parse(storageMap["tracepilot-recent-searches"]);
@@ -164,13 +170,17 @@ describe("useRecentSearches", () => {
       expect(recentSearches.value).toEqual([]);
     });
 
-    it("persists empty state to localStorage", () => {
+    it("persists empty state to localStorage", async () => {
       const { addRecentSearch, clearRecentSearches } = useRecentSearches();
 
       addRecentSearch("a", 1);
+      await nextTick();
+      await nextTick();
       mockStorage.setItem.mockClear();
 
       clearRecentSearches();
+      await nextTick();
+      await nextTick();
 
       const saved = JSON.parse(storageMap["tracepilot-recent-searches"]);
       expect(saved).toEqual([]);

--- a/apps/desktop/src/__tests__/stores/sessionTabs.test.ts
+++ b/apps/desktop/src/__tests__/stores/sessionTabs.test.ts
@@ -1,0 +1,76 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { useSessionTabsStore } from "../../stores/sessionTabs";
+
+// ── localStorage mock ─────────────────────────────────────────
+let storageMap: Record<string, string> = {};
+
+const mockStorage = {
+  getItem: vi.fn((key: string) => storageMap[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storageMap[key] = value;
+  }),
+};
+
+beforeEach(() => {
+  storageMap = {};
+  vi.stubGlobal("localStorage", mockStorage);
+  setActivePinia(createPinia());
+});
+
+describe("useSessionTabsStore", () => {
+  it("initializes with empty tabs when storage is empty", () => {
+    const store = useSessionTabsStore();
+    expect(store.tabs).toEqual([]);
+    expect(store.activeTabId).toBeNull();
+  });
+
+  it("loads from localStorage on init", () => {
+    storageMap["tracepilot:session-tabs"] = JSON.stringify({
+      tabs: [{ sessionId: "s1", label: "Session 1", activeSubTab: "overview" }],
+      activeId: "s1",
+    });
+
+    const store = useSessionTabsStore();
+    expect(store.tabs).toHaveLength(1);
+    expect(store.tabs[0].sessionId).toBe("s1");
+    expect(store.activeTabId).toBe("s1");
+  });
+
+  it("persists to localStorage when opening a tab", async () => {
+    const store = useSessionTabsStore();
+    store.openTab("s2", "New Session");
+
+    // Wait for usePersistedRef's async watch
+    await nextTick();
+    await nextTick();
+
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      "tracepilot:session-tabs",
+      expect.stringContaining('"sessionId":"s2"'),
+    );
+
+    const saved = JSON.parse(storageMap["tracepilot:session-tabs"]);
+    expect(saved.tabs).toHaveLength(1);
+    expect(saved.activeId).toBe("s2");
+  });
+
+  it("persists to localStorage when closing a tab", async () => {
+    storageMap["tracepilot:session-tabs"] = JSON.stringify({
+      tabs: [{ sessionId: "s1", label: "S1", activeSubTab: "overview" }],
+      activeId: "s1",
+    });
+
+    const store = useSessionTabsStore();
+    expect(store.tabs).toHaveLength(1);
+
+    store.closeTab("s1");
+    await nextTick();
+    await nextTick();
+
+    const saved = JSON.parse(storageMap["tracepilot:session-tabs"]);
+    expect(saved.tabs).toEqual([]);
+    expect(saved.activeId).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/SearchPalette.vue
+++ b/apps/desktop/src/components/SearchPalette.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { type SearchResult, formatNumberFull } from "@tracepilot/types";
-import { formatDuration } from "@tracepilot/types";
+import { formatDuration, formatNumberFull, type SearchResult } from "@tracepilot/types";
 import { nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import SearchPaletteResults from "@/components/search/SearchPaletteResults.vue";

--- a/apps/desktop/src/components/mcp/McpToolList.vue
+++ b/apps/desktop/src/components/mcp/McpToolList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type McpTool, formatNumberFull } from "@tracepilot/types";
+import { formatNumberFull, type McpTool } from "@tracepilot/types";
 import { computed, ref } from "vue";
 
 import { formatCompactNumber } from "@/utils/numberFormatting";

--- a/apps/desktop/src/composables/useMcpServerDetail.ts
+++ b/apps/desktop/src/composables/useMcpServerDetail.ts
@@ -1,4 +1,10 @@
-import { type McpServerConfig, type McpServerDetail, formatDate, formatTokens, formatDuration } from "@tracepilot/types";
+import {
+  formatDate,
+  formatDuration,
+  formatTokens,
+  type McpServerConfig,
+  type McpServerDetail,
+} from "@tracepilot/types";
 import { useToast } from "@tracepilot/ui";
 import { computed, type InjectionKey, inject, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";

--- a/apps/desktop/src/composables/useRecentSearches.ts
+++ b/apps/desktop/src/composables/useRecentSearches.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { usePersistedRef } from "@tracepilot/ui";
 import { logWarn } from "@/utils/logger";
 
 export interface RecentSearch {
@@ -17,27 +17,6 @@ export interface UseRecentSearchesOptions {
 const DEFAULT_MAX_ITEMS = 10;
 const DEFAULT_STORAGE_KEY = "tracepilot-recent-searches";
 
-function loadFromStorage(key: string, max: number): RecentSearch[] {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.slice(0, max) : [];
-  } catch (e) {
-    logWarn("[useRecentSearches] Failed to load from localStorage:", e);
-    return [];
-  }
-}
-
-function saveToStorage(key: string, searches: RecentSearch[], max: number) {
-  try {
-    localStorage.setItem(key, JSON.stringify(searches.slice(0, max)));
-  } catch (e) {
-    // localStorage full or unavailable
-    logWarn("[useRecentSearches] Failed to save to localStorage:", e);
-  }
-}
-
 /**
  * Composable for managing recent search history with localStorage persistence.
  *
@@ -48,26 +27,32 @@ export function useRecentSearches(options: UseRecentSearchesOptions = {}) {
   const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
   const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
 
-  const recentSearches = ref<RecentSearch[]>(loadFromStorage(storageKey, maxItems));
+  const recentSearches = usePersistedRef<RecentSearch[]>(storageKey, [], {
+    onParseError: (e) => logWarn("[useRecentSearches] Failed to load from localStorage:", e),
+    serializer: {
+      read: (raw) => {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.slice(0, maxItems) : [];
+      },
+      write: (val) => JSON.stringify(val),
+    },
+  });
 
   /** Add or promote a search to the top of the recent list. */
   function addRecentSearch(query: string, resultCount: number) {
     const existing = recentSearches.value.filter((s) => s.query !== query);
     existing.unshift({ query, timestamp: Date.now(), resultCount });
     recentSearches.value = existing.slice(0, maxItems);
-    saveToStorage(storageKey, recentSearches.value, maxItems);
   }
 
   /** Remove a specific search from the recent list. */
   function removeRecentSearch(query: string) {
     recentSearches.value = recentSearches.value.filter((s) => s.query !== query);
-    saveToStorage(storageKey, recentSearches.value, maxItems);
   }
 
   /** Clear all recent searches. */
   function clearRecentSearches() {
     recentSearches.value = [];
-    saveToStorage(storageKey, [], maxItems);
   }
 
   return {

--- a/apps/desktop/src/composables/useRecentSearches.ts
+++ b/apps/desktop/src/composables/useRecentSearches.ts
@@ -1,4 +1,5 @@
 import { usePersistedRef } from "@tracepilot/ui";
+import { STORAGE_KEYS } from "@/config/storageKeys";
 import { logWarn } from "@/utils/logger";
 
 export interface RecentSearch {
@@ -10,12 +11,12 @@ export interface RecentSearch {
 export interface UseRecentSearchesOptions {
   /** Maximum number of recent searches to keep. Defaults to 10. */
   maxItems?: number;
-  /** localStorage key to persist recent searches. Defaults to `'tracepilot-recent-searches'`. */
+  /** localStorage key to persist recent searches. Defaults to `STORAGE_KEYS.recentSearches`. */
   storageKey?: string;
 }
 
 const DEFAULT_MAX_ITEMS = 10;
-const DEFAULT_STORAGE_KEY = "tracepilot-recent-searches";
+const DEFAULT_STORAGE_KEY = STORAGE_KEYS.recentSearches;
 
 /**
  * Composable for managing recent search history with localStorage persistence.
@@ -31,8 +32,12 @@ export function useRecentSearches(options: UseRecentSearchesOptions = {}) {
     onParseError: (e) => logWarn("[useRecentSearches] Failed to load from localStorage:", e),
     serializer: {
       read: (raw) => {
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed.slice(0, maxItems) : [];
+        try {
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed) ? parsed.slice(0, maxItems) : [];
+        } catch {
+          return [];
+        }
       },
       write: (val) => JSON.stringify(val),
     },

--- a/apps/desktop/src/config/storageKeys.ts
+++ b/apps/desktop/src/config/storageKeys.ts
@@ -39,6 +39,8 @@ export const STORAGE_KEYS = Object.freeze({
   sdkSettings: "tracepilot:sdk-settings",
   /** Open session tabs + active tab id. */
   sessionTabs: "tracepilot:session-tabs",
+  /** Recent search history. */
+  recentSearches: "tracepilot-recent-searches",
   /** Alert history ring buffer (up to 100 entries). */
   alerts: "tracepilot:alert-history",
 } as const);

--- a/apps/desktop/src/stores/sessionTabs.ts
+++ b/apps/desktop/src/stores/sessionTabs.ts
@@ -34,11 +34,15 @@ export const useSessionTabsStore = defineStore("sessionTabs", () => {
     {
       serializer: {
         read: (raw) => {
-          const parsed = JSON.parse(raw);
-          return {
-            tabs: Array.isArray(parsed.tabs) ? parsed.tabs : [],
-            activeId: parsed.activeId ?? null,
-          };
+          try {
+            const parsed = JSON.parse(raw);
+            return {
+              tabs: Array.isArray(parsed?.tabs) ? parsed.tabs : [],
+              activeId: parsed?.activeId ?? null,
+            };
+          } catch {
+            return { tabs: [], activeId: null };
+          }
         },
         write: (val) => JSON.stringify(val),
       },
@@ -194,6 +198,7 @@ export const useSessionTabsStore = defineStore("sessionTabs", () => {
   }
 
   return {
+    persisted,
     tabs,
     activeTabId,
     activeTab,

--- a/apps/desktop/src/stores/sessionTabs.ts
+++ b/apps/desktop/src/stores/sessionTabs.ts
@@ -4,8 +4,10 @@
  * Tracks which sessions are open as tabs, which tab is active, and
  * persists tab state to localStorage for session continuity across reloads.
  */
+
+import { usePersistedRef } from "@tracepilot/ui";
 import { defineStore } from "pinia";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { STORAGE_KEYS } from "@/config/storageKeys";
 
 export interface SessionTab {
@@ -25,37 +27,37 @@ const MAX_TABS = 20;
 /** Default sub-tab for newly opened sessions */
 const DEFAULT_SUB_TAB = "overview";
 
-function loadPersistedTabs(): { tabs: SessionTab[]; activeId: string | null } {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      return {
-        tabs: Array.isArray(parsed.tabs) ? parsed.tabs : [],
-        activeId: parsed.activeId ?? null,
-      };
-    }
-  } catch {
-    /* ignore corrupt data */
-  }
-  return { tabs: [], activeId: null };
-}
-
-function persistTabs(tabs: SessionTab[], activeId: string | null) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ tabs, activeId }));
-  } catch {
-    /* quota exceeded — best effort */
-  }
-}
-
 export const useSessionTabsStore = defineStore("sessionTabs", () => {
-  const persisted = loadPersistedTabs();
-  const tabs = ref<SessionTab[]>(persisted.tabs);
-  const activeTabId = ref<string | null>(persisted.activeId);
+  const persisted = usePersistedRef<{ tabs: SessionTab[]; activeId: string | null }>(
+    STORAGE_KEY,
+    { tabs: [], activeId: null },
+    {
+      serializer: {
+        read: (raw) => {
+          const parsed = JSON.parse(raw);
+          return {
+            tabs: Array.isArray(parsed.tabs) ? parsed.tabs : [],
+            activeId: parsed.activeId ?? null,
+          };
+        },
+        write: (val) => JSON.stringify(val),
+      },
+    },
+  );
 
-  // Auto-persist on changes
-  watch([tabs, activeTabId], () => persistTabs(tabs.value, activeTabId.value), { deep: true });
+  const tabs = computed({
+    get: () => persisted.value.tabs,
+    set: (v) => {
+      persisted.value.tabs = v;
+    },
+  });
+
+  const activeTabId = computed({
+    get: () => persisted.value.activeId,
+    set: (v) => {
+      persisted.value.activeId = v;
+    },
+  });
 
   const activeTab = computed(
     () => tabs.value.find((t) => t.sessionId === activeTabId.value) ?? null,

--- a/apps/desktop/src/views/skills/SkillsManagerView.vue
+++ b/apps/desktop/src/views/skills/SkillsManagerView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type SkillImportResult, formatNumberFull } from "@tracepilot/types";
+import { formatNumberFull, type SkillImportResult } from "@tracepilot/types";
 import { PageHeader, PageShell, useConfirmDialog } from "@tracepilot/ui";
 import { computed, onMounted, ref } from "vue";
 import SkillCard from "@/components/skills/SkillCard.vue";

--- a/crates/tracepilot-orchestrator/src/config_injector/copilot_config.rs
+++ b/crates/tracepilot-orchestrator/src/config_injector/copilot_config.rs
@@ -175,7 +175,6 @@ pub fn read_copilot_config(copilot_home: &Path) -> Result<CopilotConfig> {
 pub fn write_copilot_config(copilot_home: &Path, config: &serde_json::Value) -> Result<()> {
     let cp = CopilotPaths::from_home(copilot_home);
     let settings_path = cp.settings_json();
-    let temp_path = settings_path.with_file_name(format!(".{}.tmp", SETTINGS_FILE));
 
     // Load the existing settings.json so unknown keys survive the
     // round-trip. If it's missing we start from `{}`. If it's present but
@@ -216,12 +215,7 @@ pub fn write_copilot_config(copilot_home: &Path, config: &serde_json::Value) -> 
         merged.insert(k.clone(), v.clone());
     }
 
-    let content = serde_json::to_string_pretty(&serde_json::Value::Object(merged))?;
-    if let Some(parent) = settings_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(&temp_path, &content)?;
-    std::fs::rename(&temp_path, &settings_path)?;
+    crate::json_io::atomic_json_write(&settings_path, &serde_json::Value::Object(merged))?;
     Ok(())
 }
 

--- a/crates/tracepilot-orchestrator/src/json_io.rs
+++ b/crates/tracepilot-orchestrator/src/json_io.rs
@@ -28,6 +28,9 @@ pub fn atomic_json_write<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     {
         if path.exists() {
             let bak = path.with_extension("json.bak");
+            if bak.exists() {
+                let _: std::io::Result<()> = std::fs::remove_file(&bak);
+            }
             std::fs::rename(path, &bak).inspect_err(|_e| {
                 // best-effort: clean up the tmp so we don't leak it; primary error still propagates.
                 let _: std::io::Result<()> = std::fs::remove_file(&tmp);


### PR DESCRIPTION
## Summary

This PR addresses three independent instances of technical debt by adopting shared utilities and improving robustness.

### Fix 1: Copilot Config shared atomic write
- **What**: Replaced manual JSON serialization and file rename logic in write_copilot_config with the atomic_json_write shared helper.
- **Why**: Eliminates duplicated logic and fixes a bug on Windows where std::fs::rename fails if the target exists.
- **Evidence**: 1 inline implementation -> 1 shared helper.

### Fix 2: Search History usePersistedRef
- **What**: Replaced manual JSON localStorage serialization in useRecentSearches with the @tracepilot/ui usePersistedRef shared helper.
- **Why**: Handles parsing safely, watches for mutations, and reduces boilerplate.
- **Evidence**: 2 manual load/save methods -> 1 shared helper.

### Fix 3: Session Tabs usePersistedRef
- **What**: Replaced manual watch-based persistence in useSessionTabsStore with the usePersistedRef shared helper.
- **Why**: CLEANER state management and better handling of corrupted data.
- **Evidence**: 2 manual load/save methods and 1 watch -> 1 shared helper.

### Verification
- cargo clippy -p tracepilot-orchestrator -- -D warnings (Exit: 0)
- cargo test -p tracepilot-orchestrator (Exit: 0)
- pnpm --filter @tracepilot/desktop typecheck (Exit: 0)
- pnpm --filter @tracepilot/desktop test run (Exit: 0)