### PR TITLE
🎨 Palette: [Accessibility] Add ARIA labels to search result header buttons

### DIFF
--- a/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
+++ b/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
@@ -37,9 +37,10 @@ const emit = defineEmits<{
       <button
         class="view-mode-btn"
         title="Clear search"
+        aria-label="Clear search"
         @click="emit('clear-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="4" y1="4" x2="12" y2="12" /><line x1="12" y1="4" x2="4" y2="12" />
         </svg>
       </button>
@@ -47,9 +48,10 @@ const emit = defineEmits<{
         v-if="hasResults"
         class="view-mode-btn"
         title="Copy all results"
+        aria-label="Copy all results"
         @click="emit('copy-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="5" y="5" width="9" height="9" rx="1" /><path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
         </svg>
       </button>
@@ -57,9 +59,10 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'flat' }"
         title="Flat list"
+        aria-label="Flat list"
         @click="emit('update:resultViewMode', 'flat')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="2" y1="4" x2="14" y2="4" /><line x1="2" y1="8" x2="14" y2="8" /><line x1="2" y1="12" x2="14" y2="12" />
         </svg>
       </button>
@@ -67,9 +70,10 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'grouped' }"
         title="Grouped by session"
+        aria-label="Grouped by session"
         @click="emit('update:resultViewMode', 'grouped')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="2" y="2" width="12" height="4" rx="1" /><rect x="2" y="10" width="12" height="4" rx="1" />
         </svg>
       </button>


### PR DESCRIPTION
**💡 What:** Added `aria-label` attributes to the icon-only buttons in `SessionSearchResultsHeader.vue` (Clear search, Copy all results, Flat list, Grouped by session). Also added `aria-hidden="true"` to the internal `<svg>` elements.

**🎯 Why:** Screen readers need text labels to announce the purpose of icon-only buttons. Without `aria-label`, these buttons are unlabelled and confusing to visually impaired users. Adding `aria-hidden="true"` to the internal SVG ensures the screen reader doesn't attempt to read the SVG internals and only reads the button's explicit label.

**📸 Before/After:**
*(No visual changes - pure structural accessibility improvements)*

**♿ Accessibility:**
Improves screen reader navigation in the Search Results header component. Screen reader users can now understand the purpose of the view-toggle and action buttons.

---
*PR created automatically by Jules for task [1234011827591619516](https://jules.google.com/task/1234011827591619516) started by @MattShelton04*