### PR TITLE
🎨 Palette: Add aria-hidden to decorative close button icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Decorative Unicode Characters in Buttons
+**Learning:** Screen readers often announce raw unicode symbols like '✕' or '×' literally (e.g., "multiply" or "times") even when the parent button has an `aria-label`.
+**Action:** Always wrap purely decorative unicode characters inside interactive elements with `<span aria-hidden="true">` to prevent confusing screen reader announcements.

--- a/apps/desktop/src/components/mcp/McpAddServerModal.vue
+++ b/apps/desktop/src/components/mcp/McpAddServerModal.vue
@@ -35,7 +35,7 @@ const {
               </div>
               <span id="add-server-title">Add MCP Server</span>
             </div>
-            <button class="modal-close" aria-label="Close" @click="emit('close')">✕</button>
+            <button class="modal-close" aria-label="Close" @click="emit('close')"><span aria-hidden="true">✕</span></button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/search/SearchActiveFilters.vue
+++ b/apps/desktop/src/components/search/SearchActiveFilters.vue
@@ -37,19 +37,19 @@ const emit = defineEmits<{
         />
         <span v-if="chip.mode === 'exclude'" class="filter-chip-prefix">NOT</span>
         {{ contentTypeConfig[chip.type]?.label ?? chip.type }}
-        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="repository" class="filter-chip filter-chip-neutral">
         Repo: {{ repository }}
-        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="toolName" class="filter-chip filter-chip-neutral">
         Tool: {{ toolName }}
-        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="sessionId" class="filter-chip filter-chip-include">
         Session: {{ sessionDisplayName }}
-        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <button v-if="activeFilterCount > 1" class="filter-chip-clear-all" @click="$emit('clear-all')">
         Clear all

--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,7 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button class="syntax-help-close" aria-label="Close" @click="$emit('close')"><span aria-hidden="true">✕</span></button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">

--- a/apps/desktop/src/components/todoDependencyGraph/TodoDepDetailSlideover.vue
+++ b/apps/desktop/src/components/todoDependencyGraph/TodoDepDetailSlideover.vue
@@ -18,7 +18,7 @@ const ctx = useTodoDependencyGraphContext();
           {{ ctx.selectedTodo.value.status.replace("_", " ") }}
         </span>
       </div>
-      <button class="close-detail" @click="ctx.closeDetail" aria-label="Close detail panel">✕</button>
+      <button class="close-detail" @click="ctx.closeDetail" aria-label="Close detail panel"><span aria-hidden="true">✕</span></button>
     </div>
     <div class="detail-panel-body">
       <div class="detail-section">


### PR DESCRIPTION
💡 What: Wrapped purely decorative Unicode '✕' and '×' characters in `<span aria-hidden="true">` inside various application close buttons. Also added a missing `aria-label="Close"` to the SearchSyntaxHelpModal button.
🎯 Why: Screen readers often announce raw unicode symbols literally (e.g., "multiply" or "times") even when the parent button has an `aria-label`. Hiding the decorative inner span forces the screen reader to read the aria-label correctly, making the interface more accessible.
📸 Before/After: Visual presentation remains identical, but the DOM structure is optimized for screen readers.
♿ Accessibility: Ensures consistent and proper semantic naming for critical close operations across modals and search filter chips.

---
*PR created automatically by Jules for task [5384923431880608661](https://jules.google.com/task/5384923431880608661) started by @MattShelton04*