### PR TITLE
Prepare Copilot pricing for usage-based billing

### DIFF
--- a/apps/desktop/src/__tests__/views/analytics-views.test.ts
+++ b/apps/desktop/src/__tests__/views/analytics-views.test.ts
@@ -178,8 +178,8 @@ describe("AnalyticsDashboardView", () => {
     expect(wrapper.text()).toContain("10"); // totalSessions
     expect(wrapper.text()).toContain("2.5M"); // totalTokens
     expect(wrapper.text()).toContain("$1.60"); // copilotCost
-    expect(wrapper.text()).toContain("Copilot Cost");
-    expect(wrapper.text()).toContain("Wholesale Cost");
+    expect(wrapper.text()).toContain("Legacy Copilot Cost");
+    expect(wrapper.text()).toContain("Direct API Estimate");
   });
 
   it("renders duration stats section", async () => {

--- a/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
@@ -132,7 +132,7 @@ const { chartData: costChart } = useLineAreaChartData({
     </SectionPanel>
 
     <!-- Cost Trend -->
-    <SectionPanel title="Cost Trend">
+    <SectionPanel title="Legacy Cost Trend">
       <LineAreaChart
         v-if="costChart"
         :chart-data="costChart"

--- a/apps/desktop/src/components/analytics/AnalyticsStatsGrids.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsStatsGrids.vue
@@ -14,8 +14,8 @@ defineProps<{
   <div class="grid-4 mb-4">
     <StatCard :value="formatNumberFull(data.totalSessions)" label="Total Sessions" />
     <StatCard :value="formatNumber(data.totalTokens)" label="Total Tokens" :gradient="true" />
-    <StatCard :value="formatCost(copilotCost)" label="Copilot Cost" color="warning" />
-    <StatCard :value="formatCost(totalWholesaleCost)" label="Wholesale Cost" color="done" tooltip="Estimated cost if this usage went through direct API access instead of GitHub Copilot, based on per-model token pricing configured in Settings." />
+    <StatCard :value="formatCost(copilotCost)" label="Legacy Copilot Cost" color="warning" />
+    <StatCard :value="formatCost(totalWholesaleCost)" label="Direct API Estimate" color="done" tooltip="Local token-rate estimate. Defaults mirror GitHub's published Copilot usage rates for documented models; Settings overrides can intentionally diverge." />
   </div>
 
   <!-- Incident Stats -->

--- a/apps/desktop/src/components/metrics/MetricsModelTable.vue
+++ b/apps/desktop/src/components/metrics/MetricsModelTable.vue
@@ -13,8 +13,9 @@ const modelColumns = computed(() => {
   const cols = [
     { key: "name", label: "Model", align: "left" as const },
     { key: "requests", label: "Requests", align: "right" as const },
-    { key: "copilotCost", label: "Copilot Cost", align: "right" as const },
-    { key: "wholesaleCost", label: "Wholesale Cost", align: "right" as const },
+    { key: "copilotCost", label: "Legacy Copilot", align: "right" as const },
+    { key: "usageBasedCost", label: "GitHub Usage", align: "right" as const },
+    { key: "wholesaleCost", label: "Direct API", align: "right" as const },
     { key: "inputTokens", label: "Input Tokens", align: "right" as const },
     { key: "outputTokens", label: "Output Tokens", align: "right" as const },
   ];
@@ -68,6 +69,11 @@ const modelColumns = computed(() => {
     </template>
     <template #cell-copilotCost="{ value }">
       <span class="text-[var(--warning-fg)]">{{ formatCost(value as number) }}</span>
+    </template>
+    <template #cell-usageBasedCost="{ value }">
+      <span :class="value != null ? 'text-[var(--done-fg)]' : 'text-[var(--text-placeholder)]'">
+        {{ value != null ? formatCost(value as number) : '—' }}
+      </span>
     </template>
     <template #cell-wholesaleCost="{ value }">
       <span :class="value != null ? 'text-[var(--done-fg)]' : 'text-[var(--text-placeholder)]'">

--- a/apps/desktop/src/components/metrics/MetricsSessionActivity.vue
+++ b/apps/desktop/src/components/metrics/MetricsSessionActivity.vue
@@ -51,9 +51,37 @@ function segmentWholesaleCost(seg: SessionSegment): number {
       m.usage?.inputTokens ?? 0,
       m.usage?.cacheReadTokens ?? 0,
       m.usage?.outputTokens ?? 0,
+      m.usage?.cacheWriteTokens ?? 0,
     );
     return sum + (cost ?? 0);
   }, 0);
+}
+
+function segmentUsageBasedCost(seg: SessionSegment): number | null {
+  if (!seg.modelMetrics) return null;
+  let total = 0;
+  for (const [name, m] of Object.entries(seg.modelMetrics)) {
+    const cost = prefs.computeUsageBasedCost(
+      name,
+      m.usage?.inputTokens ?? 0,
+      m.usage?.cacheReadTokens ?? 0,
+      m.usage?.outputTokens ?? 0,
+      m.usage?.cacheWriteTokens ?? 0,
+    );
+    if (cost == null) return null;
+    total += cost;
+  }
+  return total;
+}
+
+function modelUsageBasedCost(name: string, m: ModelMetricDetail): number | null {
+  return prefs.computeUsageBasedCost(
+    name,
+    m.usage?.inputTokens ?? 0,
+    m.usage?.cacheReadTokens ?? 0,
+    m.usage?.outputTokens ?? 0,
+    m.usage?.cacheWriteTokens ?? 0,
+  );
 }
 </script>
 
@@ -104,8 +132,11 @@ function segmentWholesaleCost(seg: SessionSegment): number {
               <span v-if="(m.requests?.cost ?? 0) > 0" class="cost-pill amber-text" title="Copilot Cost">
                 {{ formatCost((m.requests?.cost ?? 0) * prefs.costPerPremiumRequest) }}
               </span>
-              <span class="cost-pill emerald-text" title="Wholesale Cost">
-                {{ formatCost(prefs.computeWholesaleCost(name as string, m.usage?.inputTokens ?? 0, m.usage?.cacheReadTokens ?? 0, m.usage?.outputTokens ?? 0) || 0) }}
+              <span class="cost-pill emerald-text" title="Direct API estimate">
+                {{ formatCost(prefs.computeWholesaleCost(name as string, m.usage?.inputTokens ?? 0, m.usage?.cacheReadTokens ?? 0, m.usage?.outputTokens ?? 0, m.usage?.cacheWriteTokens ?? 0) || 0) }}
+              </span>
+              <span class="cost-pill blue-text" title="GitHub Copilot usage estimate">
+                {{ modelUsageBasedCost(name as string, m) != null ? formatCost(modelUsageBasedCost(name as string, m)!) : '—' }}
               </span>
             </div>
           </div>
@@ -115,8 +146,11 @@ function segmentWholesaleCost(seg: SessionSegment): number {
           <span v-if="segmentCopilotCost(seg) > 0" class="cost-pill amber-text" title="Copilot Cost">
             Copilot {{ formatCost(segmentCopilotCost(seg)) }}
           </span>
-          <span class="cost-pill emerald-text" title="Wholesale Cost">
-            Wholesale {{ formatCost(segmentWholesaleCost(seg)) }}
+          <span class="cost-pill emerald-text" title="Direct API estimate">
+            Direct API {{ formatCost(segmentWholesaleCost(seg)) }}
+          </span>
+          <span class="cost-pill blue-text" title="GitHub Copilot usage estimate">
+            GitHub usage {{ segmentUsageBasedCost(seg) != null ? formatCost(segmentUsageBasedCost(seg) as number) : '—' }}
           </span>
         </div>
         <div class="activity-tile-footer">
@@ -361,4 +395,5 @@ function segmentWholesaleCost(seg: SessionSegment): number {
 
 .amber-text { color: var(--warning-fg); }
 .emerald-text { color: var(--success-fg); }
+.blue-text { color: var(--accent-fg); }
 </style>

--- a/apps/desktop/src/components/metrics/MetricsStatCards.vue
+++ b/apps/desktop/src/components/metrics/MetricsStatCards.vue
@@ -6,21 +6,55 @@ defineProps<{
   metrics: ShutdownMetrics;
   totalRequests: number;
   copilotCost: number;
+  totalUsageBasedCost: number;
+  hasUsageBasedUnknowns: boolean;
   totalWholesaleCost: number;
+  june2026PreviewDelta: number;
+  observedAiuCost: number | null;
   totalTokens: number;
 }>();
+
+function formatSignedCost(value: number): string {
+  const formatted = formatCost(Math.abs(value));
+  if (value === 0) return formatted;
+  return `${value > 0 ? "+" : "-"}${formatted}`;
+}
 </script>
 
 <template>
   <div class="grid-4 mb-6">
     <StatCard :value="totalRequests" label="Total Requests" color="accent" />
     <StatCard :value="metrics.totalPremiumRequests?.toFixed(1) ?? '—'" label="Premium Requests" color="accent" />
-    <StatCard :value="formatCost(copilotCost)" label="Copilot Cost" color="warning" />
-    <StatCard :value="formatCost(totalWholesaleCost)" label="Wholesale Cost" color="done" tooltip="Estimated cost if this usage went through direct API access instead of GitHub Copilot, based on per-model token pricing configured in Settings." />
+    <StatCard :value="formatCost(copilotCost)" label="Legacy Copilot" color="warning" tooltip="Legacy premium-request estimate: premium requests × local cost per premium request." />
+    <StatCard :value="hasUsageBasedUnknowns ? '—' : formatCost(totalUsageBasedCost)" label="GitHub Copilot (usage)" color="done" tooltip="June 2026 usage-based estimate using GitHub Copilot token rates. Unknown models are not silently priced." />
   </div>
 
-  <div class="grid-2 mb-6">
+  <div class="grid-4 mb-6">
+    <StatCard :value="formatCost(totalWholesaleCost)" label="Direct API (estimate)" color="done" tooltip="Local token-rate estimate. Defaults mirror GitHub's published Copilot usage rates for documented models; Settings overrides can intentionally diverge." />
+    <StatCard
+      v-if="!hasUsageBasedUnknowns && (totalUsageBasedCost > 0 || copilotCost > 0)"
+      :value="formatSignedCost(june2026PreviewDelta)"
+      label="Est. change after Jun 2026"
+      :color="june2026PreviewDelta >= 0 ? 'warning' : 'done'"
+      tooltip="GitHub Copilot usage estimate minus the legacy premium-request estimate. Positive means usage-based costs more than legacy."
+    />
     <StatCard :value="formatNumber(totalTokens)" label="Total Tokens" :gradient="true" />
     <StatCard :value="formatDuration(metrics.totalApiDurationMs)" label="API Duration" color="done" />
   </div>
+
+  <div v-if="observedAiuCost != null" class="grid-2 mb-6">
+    <StatCard :value="formatCost(observedAiuCost)" label="Observed AI Credits" color="accent" tooltip="Observed totalNanoAiu converted as nano AI Credits at 1 AI Credit = $0.01. Treat as telemetry until real-session billing semantics are confirmed." />
+  </div>
+
+  <p class="cost-legend mb-6">
+    Legacy = premium-request billing. GitHub Copilot (usage) = post-Jun-2026 token billing. Direct API = same token-rate defaults with local override support.
+  </p>
 </template>
+
+<style scoped>
+.cost-legend {
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+</style>

--- a/apps/desktop/src/components/metrics/MetricsStatCards.vue
+++ b/apps/desktop/src/components/metrics/MetricsStatCards.vue
@@ -47,7 +47,7 @@ function formatSignedCost(value: number): string {
   </div>
 
   <p class="cost-legend mb-6">
-    Legacy = premium-request billing. GitHub Copilot (usage) = post-Jun-2026 token billing. Direct API = same token-rate defaults with local override support.
+    Legacy: premium requests · Copilot usage: token billing · Direct API: local token-rate estimate.
   </p>
 </template>
 

--- a/apps/desktop/src/components/modelComparison/ModelCharts.vue
+++ b/apps/desktop/src/components/modelComparison/ModelCharts.vue
@@ -162,7 +162,7 @@ const ctx = useModelComparisonContext();
               fill="var(--text-tertiary)"
               font-family="Inter, sans-serif"
               transform="rotate(-90, 14, 135)"
-            >Wholesale Cost ($)</text>
+            >Direct API ($)</text>
             <!-- Scale labels -->
             <text
               :x="SCATTER_PAD.left - 8"

--- a/apps/desktop/src/components/modelComparison/ModelLeaderboard.vue
+++ b/apps/desktop/src/components/modelComparison/ModelLeaderboard.vue
@@ -13,15 +13,15 @@ const ctx = useModelComparisonContext();
         <div class="cost-toggle">
           <button
             :class="['toggle-btn', { active: ctx.costMode === 'wholesale' }]"
-            @click="ctx.costMode = 'wholesale'"
+           @click="ctx.costMode = 'wholesale'"
           >
-            Wholesale
+            Direct API
           </button>
           <button
             :class="['toggle-btn', { active: ctx.costMode === 'copilot' }]"
             @click="ctx.costMode = 'copilot'"
           >
-            Copilot
+            Legacy Copilot
           </button>
           <button
             :class="['toggle-btn', { active: ctx.costMode === 'both' }]"
@@ -61,8 +61,6 @@ const ctx = useModelComparisonContext();
           <col class="col-output" />
           <col class="col-cached" />
           <col class="col-share" />
-          <col class="col-prem-req" />
-          <col class="col-cache-hit" />
           <col v-if="ctx.costMode !== 'copilot'" class="col-cost" />
           <col v-if="ctx.costMode !== 'wholesale'" class="col-cost" />
         </colgroup>
@@ -81,30 +79,24 @@ const ctx = useModelComparisonContext();
               Output <span class="sort-arrow">{{ ctx.sortArrow('outputTokens') }}</span>
             </th>
             <th class="sort-header" @click="ctx.toggleSort('cacheReadTokens')">
-              Cached <span class="sort-arrow">{{ ctx.sortArrow('cacheReadTokens') }}</span>
+              Cache <span class="sort-arrow">{{ ctx.sortArrow('cacheReadTokens') }}</span>
             </th>
             <th class="sort-header" @click="ctx.toggleSort('percentage')">
               Share <span class="sort-arrow">{{ ctx.sortArrow('percentage') }}</span>
-            </th>
-            <th class="sort-header" @click="ctx.toggleSort('premiumRequests')">
-              Prem. Req. <span class="sort-arrow">{{ ctx.sortArrow('premiumRequests') }}</span>
-            </th>
-            <th class="sort-header" @click="ctx.toggleSort('cacheHitRate')">
-              Cache Hit <span class="sort-arrow">{{ ctx.sortArrow('cacheHitRate') }}</span>
             </th>
             <th
               v-if="ctx.costMode !== 'copilot'"
               class="sort-header"
               @click="ctx.toggleSort('cost')"
             >
-              W. Cost <span class="sort-arrow">{{ ctx.sortArrow('cost') }}</span>
+              API $ <span class="sort-arrow">{{ ctx.sortArrow('cost') }}</span>
             </th>
             <th
               v-if="ctx.costMode !== 'wholesale'"
               class="sort-header"
               @click="ctx.toggleSort('copilotCost')"
             >
-              CP Cost <span class="sort-arrow">{{ ctx.sortArrow('copilotCost') }}</span>
+              Copilot $ <span class="sort-arrow">{{ ctx.sortArrow('copilotCost') }}</span>
             </th>
           </tr>
         </thead>
@@ -119,7 +111,7 @@ const ctx = useModelComparisonContext();
             <td class="num-cell">{{ ctx.fmtNorm(row.tokens) }}</td>
             <td class="num-cell">{{ ctx.fmtNorm(row.inputTokens) }}</td>
             <td class="num-cell">{{ ctx.fmtNorm(row.outputTokens) }}</td>
-            <td class="num-cell">{{ ctx.fmtNorm(row.cacheReadTokens) }}</td>
+            <td class="num-cell">{{ ctx.fmtNorm(row.cacheReadTokens) }} ({{ formatPercent(row.cacheHitRate) }})</td>
             <td class="num-cell">
               <div class="inline-progress">
                 <span>{{ formatPercent(row.percentage) }}</span>
@@ -130,14 +122,6 @@ const ctx = useModelComparisonContext();
                   />
                 </div>
               </div>
-            </td>
-            <td class="num-cell">
-              {{ ctx.fmtNorm(row.premiumRequests) }}
-            </td>
-            <td class="num-cell">
-              <span :class="{ 'best-cell': row.model === ctx.modelRows[ctx.bestCacheIdx]?.model }">
-                {{ formatPercent(row.cacheHitRate) }}
-              </span>
             </td>
             <td v-if="ctx.costMode !== 'copilot'" class="num-cell">
               <span :class="{ 'best-cell': row.model === ctx.modelRows[ctx.bestCostIdx]?.model }">

--- a/apps/desktop/src/components/modelComparison/ModelStatsGrid.vue
+++ b/apps/desktop/src/components/modelComparison/ModelStatsGrid.vue
@@ -10,8 +10,8 @@ const ctx = useModelComparisonContext();
   <div class="grid-4 mb-4">
     <StatCard :value="ctx.modelCount" label="Models Used" />
     <StatCard :value="formatNumber(ctx.totalTokens)" label="Total Tokens" color="done" />
-    <StatCard :value="formatCost(ctx.totalCost)" label="Wholesale Cost" color="success" />
-    <StatCard :value="formatCost(ctx.totalCopilotCost)" label="Copilot Cost" color="warning" />
+    <StatCard :value="formatCost(ctx.totalCost)" label="Direct API Estimate" color="success" />
+    <StatCard :value="formatCost(ctx.totalCopilotCost)" label="Legacy Copilot Cost" color="warning" />
   </div>
 
   <!-- Model Cards Row -->
@@ -27,7 +27,7 @@ const ctx = useModelComparisonContext();
           <div class="model-card-stat-value">{{ formatNumber(row.tokens) }}</div>
         </div>
         <div>
-          <div class="model-card-stat-label">Wholesale Cost</div>
+          <div class="model-card-stat-label">Direct API</div>
           <div class="model-card-stat-value">{{ formatCost(row.cost) }}</div>
         </div>
         <div>

--- a/apps/desktop/src/components/settings/SettingsPricing.vue
+++ b/apps/desktop/src/components/settings/SettingsPricing.vue
@@ -8,6 +8,7 @@ const preferences = usePreferencesStore();
 const newModelName = ref("");
 const newInputPerM = ref(0);
 const newCachedInputPerM = ref(0);
+const newCacheWritePerM = ref(0);
 const newOutputPerM = ref(0);
 const newPremiumRequests = ref(1);
 
@@ -17,14 +18,41 @@ function addModelPrice() {
     model: newModelName.value.trim(),
     inputPerM: newInputPerM.value,
     cachedInputPerM: newCachedInputPerM.value,
+    cacheWritePerM: newCacheWritePerM.value,
     outputPerM: newOutputPerM.value,
     premiumRequests: newPremiumRequests.value,
+    status: "user-override",
+    sourceLabel: "Local settings override",
   });
   newModelName.value = "";
   newInputPerM.value = 0;
   newCachedInputPerM.value = 0;
+  newCacheWritePerM.value = 0;
   newOutputPerM.value = 0;
   newPremiumRequests.value = 1;
+}
+
+function sourceLabel(model: string): string {
+  const metadata = preferences.getPricingMetadata(model, "provider-wholesale");
+  return metadata?.sourceLabel ?? "Local settings override";
+}
+
+function effectiveLabel(model: string): string {
+  const metadata = preferences.getPricingMetadata(model, "provider-wholesale");
+  return metadata?.effectiveFrom ?? "always";
+}
+
+function statusLabel(model: string): string {
+  const metadata = preferences.getPricingMetadata(model, "provider-wholesale");
+  return metadata?.status ?? "estimated";
+}
+
+function sourceSummary(model: string): string {
+  return `${statusLabel(model)} · ${effectiveLabel(model)}`;
+}
+
+function sourceTooltip(model: string): string {
+  return `${sourceLabel(model)}\nStatus: ${statusLabel(model)}\nEffective: ${effectiveLabel(model)}`;
 }
 </script>
 
@@ -36,7 +64,7 @@ function addModelPrice() {
         <div class="setting-info">
           <div class="setting-label">Cost per premium request</div>
           <div class="setting-description">
-            GitHub Copilot charges per premium request. Cost = premiumRequests × this rate.
+            Legacy Copilot estimate for premium-request sessions. Usage-based billing uses token rates below and official GitHub Copilot rates where available.
           </div>
         </div>
         <div class="setting-control-group">
@@ -54,9 +82,9 @@ function addModelPrice() {
       </div>
     </SectionPanel>
 
-    <div class="pricing-subsection-title">Model Wholesale Prices</div>
+    <div class="pricing-subsection-title">Model Pricing Overrides</div>
     <p class="pricing-description">
-      API prices ($ per 1M tokens) used to compute what sessions would cost through direct API access vs. Copilot premium requests.
+      Local direct-API/provider prices ($ per 1M tokens) used for configurable estimates. Defaults mirror GitHub Copilot's published token rates for documented models; edits here intentionally override that local estimate.
     </p>
 
     <SectionPanel>
@@ -65,12 +93,14 @@ function addModelPrice() {
           <thead>
             <tr>
               <th class="text-left">Model</th>
-              <th>Input / 1M</th>
-              <th>Cached / 1M</th>
-              <th>Output / 1M</th>
-              <th>Premium Req.</th>
-              <th class="pricing-col-action"></th>
-            </tr>
+               <th>Input / 1M</th>
+               <th>Cached / 1M</th>
+               <th>Cache Write / 1M</th>
+               <th>Output / 1M</th>
+               <th>Premium Req.</th>
+               <th>Source</th>
+               <th class="pricing-col-action"></th>
+             </tr>
           </thead>
           <tbody>
             <tr v-for="(price, idx) in preferences.modelWholesalePrices" :key="price.model">
@@ -100,6 +130,17 @@ function addModelPrice() {
               <td class="text-center">
                 <FormInput
                   type="number"
+                  :model-value="price.cacheWritePerM ?? 0"
+                  @update:model-value="preferences.modelWholesalePrices[idx].cacheWritePerM = Number($event)"
+                  step="0.001"
+                  min="0"
+                  class="pricing-input"
+                  :aria-label="`${price.model} cache write price per 1M tokens`"
+                />
+              </td>
+              <td class="text-center">
+                <FormInput
+                  type="number"
                   :model-value="price.outputPerM"
                   @update:model-value="preferences.modelWholesalePrices[idx].outputPerM = Number($event)"
                   step="0.01"
@@ -118,6 +159,10 @@ function addModelPrice() {
                   class="pricing-input"
                   :aria-label="`${price.model} premium requests`"
                 />
+              </td>
+              <td class="pricing-meta-cell" :title="sourceTooltip(price.model)">
+                <span class="pricing-source-label">{{ sourceLabel(price.model) }}</span>
+                <span class="pricing-source-meta">{{ sourceSummary(price.model) }}</span>
               </td>
               <td class="text-center">
                 <button class="pricing-remove-btn" @click="preferences.removeWholesalePrice(price.model)" :title="`Remove ${price.model}`" :aria-label="`Remove pricing for ${price.model}`">&times;</button>
@@ -156,6 +201,16 @@ function addModelPrice() {
               <td class="text-center">
                 <FormInput
                   type="number"
+                  v-model="newCacheWritePerM"
+                  step="0.001"
+                  min="0"
+                  class="pricing-input"
+                  aria-label="New model cache write price per 1M tokens"
+                />
+              </td>
+              <td class="text-center">
+                <FormInput
+                  type="number"
                   v-model="newOutputPerM"
                   step="0.01"
                   min="0"
@@ -172,6 +227,10 @@ function addModelPrice() {
                   class="pricing-input"
                   aria-label="New model premium requests"
                 />
+              </td>
+              <td class="pricing-meta-cell" title="Local settings override&#10;Status: user-override&#10;Effective: always">
+                <span class="pricing-source-label">Local settings override</span>
+                <span class="pricing-source-meta">user-override · always</span>
               </td>
               <td class="text-center">
                 <button class="pricing-add-btn" @click="addModelPrice" :disabled="!newModelName.trim()" title="Add model" aria-label="Add model pricing entry">+</button>
@@ -285,5 +344,26 @@ function addModelPrice() {
   width: 140px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
+}
+
+.pricing-meta-cell {
+  max-width: 190px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+}
+
+.pricing-source-label,
+.pricing-source-meta {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pricing-source-label {
+  color: var(--text-secondary);
+  font-weight: 600;
 }
 </style>

--- a/apps/desktop/src/composables/__tests__/useModelComparison.test.ts
+++ b/apps/desktop/src/composables/__tests__/useModelComparison.test.ts
@@ -186,7 +186,7 @@ describe("useModelComparison", () => {
     expect(comp.compareB).toBe("y");
     expect(comp.compareMetrics.length).toBe(9);
     expect(comp.compareMetrics.map((m) => m.label)).toContain("Total Tokens");
-    expect(comp.compareMetrics.map((m) => m.label)).toContain("Wholesale Cost");
+    expect(comp.compareMetrics.map((m) => m.label)).toContain("Direct API Cost");
   });
 
   it("radar + scatter helpers produce valid coordinates", () => {

--- a/apps/desktop/src/composables/__tests__/useSessionMetrics.test.ts
+++ b/apps/desktop/src/composables/__tests__/useSessionMetrics.test.ts
@@ -103,8 +103,8 @@ describe("useSessionMetrics", () => {
       // model-b cost: (100 + 50 + 200) * 0.2 = 70.0
       expect(result).toBe(73.5);
       expect(computeWholesaleCost).toHaveBeenCalledTimes(2);
-      expect(computeWholesaleCost).toHaveBeenCalledWith("model-a", 10, 5, 20);
-      expect(computeWholesaleCost).toHaveBeenCalledWith("model-b", 100, 50, 200);
+      expect(computeWholesaleCost).toHaveBeenCalledWith("model-a", 10, 5, 20, 0);
+      expect(computeWholesaleCost).toHaveBeenCalledWith("model-b", 100, 50, 200, 0);
     });
 
     it("should default to 0 for missing token counts", () => {
@@ -124,9 +124,9 @@ describe("useSessionMetrics", () => {
 
       expect(result).toBe(40); // 15 + 0 + 25
       expect(computeWholesaleCost).toHaveBeenCalledTimes(3);
-      expect(computeWholesaleCost).toHaveBeenCalledWith("model-c", 15, 0, 0);
-      expect(computeWholesaleCost).toHaveBeenCalledWith("model-d", 0, 0, 0);
-      expect(computeWholesaleCost).toHaveBeenCalledWith("model-e", 0, 0, 25);
+      expect(computeWholesaleCost).toHaveBeenCalledWith("model-c", 15, 0, 0, 0);
+      expect(computeWholesaleCost).toHaveBeenCalledWith("model-d", 0, 0, 0, 0);
+      expect(computeWholesaleCost).toHaveBeenCalledWith("model-e", 0, 0, 25, 0);
     });
 
     it("should treat a null return from computeWholesaleCost as 0", () => {

--- a/apps/desktop/src/composables/useMetricsTabData.ts
+++ b/apps/desktop/src/composables/useMetricsTabData.ts
@@ -9,6 +9,8 @@ export interface MetricsModelEntry {
   name: string;
   requests: number;
   copilotCost: number;
+  usageBasedCost: number | null;
+  usageBasedStatus: string;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -29,22 +31,33 @@ export function useMetricsTabData(
         const inputTokens = data.usage?.inputTokens ?? 0;
         const outputTokens = data.usage?.outputTokens ?? 0;
         const cacheReadTokens = data.usage?.cacheReadTokens ?? 0;
+        const cacheWriteTokens = data.usage?.cacheWriteTokens ?? 0;
         const reasoningTokens = data.usage?.reasoningTokens ?? null;
         const wholesaleCost = prefs.computeWholesaleCost(
           name,
           inputTokens,
           cacheReadTokens,
           outputTokens,
+          cacheWriteTokens,
+        );
+        const usageBased = prefs.computeUsageBasedCostBreakdown(
+          name,
+          inputTokens,
+          cacheReadTokens,
+          outputTokens,
+          cacheWriteTokens,
         );
         const premiumRequests = data.requests?.cost ?? 0;
         return {
           name,
           requests: data.requests?.count ?? 0,
           copilotCost: premiumRequests * prefs.costPerPremiumRequest,
+          usageBasedCost: usageBased.totalCost,
+          usageBasedStatus: usageBased.status,
           inputTokens,
           outputTokens,
           cacheReadTokens,
-          cacheWriteTokens: data.usage?.cacheWriteTokens ?? 0,
+          cacheWriteTokens,
           reasoningTokens,
           totalTokens: inputTokens + outputTokens,
           wholesaleCost,
@@ -86,6 +99,22 @@ export function useMetricsTabData(
     return total;
   });
 
+  const totalUsageBasedCost = computed(() => {
+    let total = 0;
+    for (const m of modelEntries.value) {
+      if (m.usageBasedCost !== null) total += m.usageBasedCost;
+    }
+    return total;
+  });
+
+  const hasUsageBasedUnknowns = computed(() =>
+    modelEntries.value.some((m) => m.usageBasedCost === null || m.usageBasedStatus !== "priced"),
+  );
+
+  const june2026PreviewDelta = computed(() => totalUsageBasedCost.value - copilotCost.value);
+
+  const observedAiuCost = computed(() => prefs.getObservedAiuCost(metrics.value?.totalNanoAiu));
+
   const cacheHitRatio = computed(() =>
     totalInputTokens.value > 0 ? totalCacheReadTokens.value / totalInputTokens.value : 0,
   );
@@ -101,6 +130,10 @@ export function useMetricsTabData(
     hasTokenBudget,
     copilotCost,
     totalWholesaleCost,
+    totalUsageBasedCost,
+    hasUsageBasedUnknowns,
+    june2026PreviewDelta,
+    observedAiuCost,
     cacheHitRatio,
   };
 }

--- a/apps/desktop/src/composables/useModelComparison.ts
+++ b/apps/desktop/src/composables/useModelComparison.ts
@@ -133,7 +133,7 @@ function buildCompareMetrics(
       ...formatModelDelta(a.cacheHitRate, b.cacheHitRate, true),
     },
     {
-      label: "Wholesale Cost",
+      label: "Direct API Cost",
       valueA: fmtNorm(a.cost, true),
       valueB: fmtNorm(b.cost, true),
       ...formatModelDelta(a.cost ?? 0, b.cost ?? 0, false),

--- a/apps/desktop/src/composables/useSessionComparison.ts
+++ b/apps/desktop/src/composables/useSessionComparison.ts
@@ -277,7 +277,7 @@ export function useSessionComparison() {
       row("Duration", durA, durB, (v) => formatDuration(v) || "0s", false),
       row("Turns", turnsA, turnsB, String, false),
       row(`Total Tokens${suffix}`, tokA / divA, tokB / divB, fmtN, false),
-      row(`Wholesale Cost${suffix}`, wcA / divA, wcB / divB, formatCost, false),
+      row(`Direct API Cost${suffix}`, wcA / divA, wcB / divB, formatCost, false),
       row(`Copilot Cost${suffix}`, ccA / divA, ccB / divB, formatCost, false),
       row(`Tool Calls${suffix}`, tcA / divA, tcB / divB, fmtInt, false),
       row("Success Rate", srA, srB, formatRate, true),

--- a/apps/desktop/src/composables/useSessionMetrics.ts
+++ b/apps/desktop/src/composables/useSessionMetrics.ts
@@ -49,6 +49,7 @@ export function wholesaleCost(
     input: number,
     cache: number,
     output: number,
+    cacheWrite?: number,
   ) => number | null,
 ): number {
   if (!m?.modelMetrics) return 0;
@@ -58,6 +59,7 @@ export function wholesaleCost(
       mm.usage?.inputTokens ?? 0,
       mm.usage?.cacheReadTokens ?? 0,
       mm.usage?.outputTokens ?? 0,
+      mm.usage?.cacheWriteTokens ?? 0,
     );
     return sum + (cost ?? 0);
   }, 0);

--- a/apps/desktop/src/stores/preferences/__tests__/pricing.test.ts
+++ b/apps/desktop/src/stores/preferences/__tests__/pricing.test.ts
@@ -18,7 +18,7 @@ describe("createPricingSlice", () => {
     ).toBeUndefined();
   });
 
-  it("getWholesalePrice matches by longest-first substring", () => {
+  it("getWholesalePrice matches by longest-first prefix", () => {
     const slice = createPricingSlice();
     slice.modelWholesalePrices.value = [
       { model: "gpt-4", inputPerM: 1, cachedInputPerM: 0.1, outputPerM: 2, premiumRequests: 1 },
@@ -34,6 +34,12 @@ describe("createPricingSlice", () => {
     expect(match?.model).toBe("gpt-4-turbo");
   });
 
+  it("getWholesalePrice matches explicit aliases without arbitrary substring fallback", () => {
+    const slice = createPricingSlice();
+    expect(slice.getWholesalePrice("Claude Sonnet 4.6")?.model).toBe("claude-sonnet-4.6");
+    expect(slice.getWholesalePrice("not-claude-sonnet-4.6-but-contains-it")).toBeUndefined();
+  });
+
   it("computeWholesaleCost subtracts cache reads from input tokens", () => {
     const slice = createPricingSlice();
     slice.modelWholesalePrices.value = [
@@ -42,6 +48,67 @@ describe("createPricingSlice", () => {
     // 1M input, 500k cached, 1M output → 500k*10 + 500k*1 + 1M*20 = 5 + 0.5 + 20 = 25.5
     const cost = slice.computeWholesaleCost("test", 1_000_000, 500_000, 1_000_000);
     expect(cost).toBeCloseTo(25.5);
+  });
+
+  it("computeWholesaleCost includes cache write price when configured", () => {
+    const slice = createPricingSlice();
+    slice.modelWholesalePrices.value = [
+      {
+        model: "test",
+        inputPerM: 10,
+        cachedInputPerM: 1,
+        cacheWritePerM: 2,
+        outputPerM: 20,
+        premiumRequests: 1,
+      },
+    ];
+    const cost = slice.computeWholesaleCost("test", 1_000_000, 500_000, 1_000_000, 250_000);
+    expect(cost).toBeCloseTo(26);
+  });
+
+  it("computeUsageBasedCost uses official GitHub rates and returns null for unknown models", () => {
+    const slice = createPricingSlice();
+    expect(
+      slice.computeUsageBasedCost(
+        "claude-sonnet-4.6",
+        1_000_000,
+        400_000,
+        200_000,
+        100_000,
+        "2026-06-01",
+      ),
+    ).toBeCloseTo(5.295);
+    expect(slice.computeUsageBasedCost("unknown-model", 1, 0, 1, 0, "2026-06-01")).toBeNull();
+  });
+
+  it("computeUsageBasedCost respects effective dates", () => {
+    const slice = createPricingSlice();
+    expect(slice.computeUsageBasedCost("gpt-5.4", 1_000_000, 0, 0, 0, "2026-05-31")).toBeNull();
+    expect(slice.computeUsageBasedCost("gpt-5.4", 1_000_000, 0, 0, 0, "2026-06-01")).toBe(2.5);
+  });
+
+  it("computeUsageBasedCost previews June 2026 rates when no date is supplied", () => {
+    const slice = createPricingSlice();
+    expect(slice.computeUsageBasedCost("gpt-5.4", 1_000_000, 0, 0)).toBe(2.5);
+  });
+
+  it("default local token-rate estimates mirror GitHub usage rates for documented models", () => {
+    const slice = createPricingSlice();
+    expect(slice.computeWholesaleCost("gpt-5.4-mini", 1_000_000, 0, 1_000_000)).toBeCloseTo(5.25);
+    expect(slice.computeUsageBasedCost("gpt-5.4-mini", 1_000_000, 0, 1_000_000)).toBeCloseTo(5.25);
+  });
+
+  it("local wholesale overrides take precedence over bundled defaults", () => {
+    const slice = createPricingSlice();
+    slice.modelWholesalePrices.value = [
+      { model: "gpt-5.5", inputPerM: 1, cachedInputPerM: 0.1, outputPerM: 2, premiumRequests: 1 },
+    ];
+    expect(slice.computeWholesaleCost("GPT-5.5", 1_000_000, 0, 1_000_000)).toBe(3);
+  });
+
+  it("converts observed nano AIU to USD using AI Credit units", () => {
+    const slice = createPricingSlice();
+    expect(slice.getObservedAiuCost(1_000_000_000)).toBe(0.01);
   });
 
   it("computeWholesaleCost returns null when the model is unknown", () => {

--- a/apps/desktop/src/stores/preferences/pricing.ts
+++ b/apps/desktop/src/stores/preferences/pricing.ts
@@ -8,13 +8,23 @@
 
 import type {
   ModelPriceEntry,
+  PricingComparisonBreakdown,
+  PricingRegistryEntry,
   RichRenderableToolName,
+  ShutdownMetrics,
+  TokenCostBreakdown,
   ToolRenderingPreferences,
 } from "@tracepilot/types";
 import {
+  calculateObservedAiuCost,
+  calculatePricingComparison,
+  calculateTokenCost,
   DEFAULT_COST_PER_PREMIUM_REQUEST,
   DEFAULT_TOOL_RENDERING_PREFS,
   getDefaultWholesalePrices,
+  modelPriceEntriesToPricingRegistry,
+  modelPriceEntryToPricingEntry,
+  resolvePricingEntry,
 } from "@tracepilot/types";
 import { ref } from "vue";
 
@@ -34,14 +44,20 @@ export function createPricingSlice() {
     toolOverrides: { ...DEFAULT_TOOL_RENDERING_PREFS.toolOverrides },
   });
 
-  /** Look up wholesale price for a model name (fuzzy match on prefix). */
+  function userPricingRegistry(): PricingRegistryEntry[] {
+    return modelPriceEntriesToPricingRegistry(modelWholesalePrices.value);
+  }
+
+  /** Look up local wholesale/provider price for a model name. */
   function getWholesalePrice(modelName: string): ModelPriceEntry | undefined {
-    const lower = modelName.toLowerCase();
-    const sorted = [...modelWholesalePrices.value].sort((a, b) => b.model.length - a.model.length);
-    return (
-      sorted.find((p) => lower.includes(p.model.toLowerCase())) ??
-      sorted.find((p) => lower.startsWith(p.model.toLowerCase().split("-").slice(0, 2).join("-")))
-    );
+    const match = resolvePricingEntry(modelName, {
+      billingProvider: "provider-wholesale",
+      pricingKind: "usage-token-rate",
+      rateMode: "latest",
+      userOverrides: userPricingRegistry(),
+    });
+    if (!match) return undefined;
+    return modelWholesalePrices.value.find((price) => price.model === match.model);
   }
 
   /** Compute wholesale cost for a model given token usage. */
@@ -50,15 +66,107 @@ export function createPricingSlice() {
     inputTokens: number,
     cacheReadTokens: number,
     outputTokens: number,
+    cacheWriteTokens = 0,
   ): number | null {
-    const price = getWholesalePrice(modelName);
-    if (!price) return null;
-    const nonCachedInput = Math.max(inputTokens - cacheReadTokens, 0);
-    return (
-      (nonCachedInput / 1_000_000) * price.inputPerM +
-      (cacheReadTokens / 1_000_000) * price.cachedInputPerM +
-      (outputTokens / 1_000_000) * price.outputPerM
+    const breakdown = computeWholesaleCostBreakdown(
+      modelName,
+      inputTokens,
+      cacheReadTokens,
+      outputTokens,
+      cacheWriteTokens,
     );
+    return breakdown.totalCost;
+  }
+
+  function computeWholesaleCostBreakdown(
+    modelName: string,
+    inputTokens: number,
+    cacheReadTokens: number,
+    outputTokens: number,
+    cacheWriteTokens = 0,
+  ): TokenCostBreakdown {
+    return calculateTokenCost(
+      modelName,
+      { inputTokens, cacheReadTokens, outputTokens, cacheWriteTokens },
+      {
+        billingProvider: "provider-wholesale",
+        pricingKind: "usage-token-rate",
+        rateMode: "latest",
+        userOverrides: userPricingRegistry(),
+      },
+    );
+  }
+
+  function computeUsageBasedCostBreakdown(
+    modelName: string,
+    inputTokens: number,
+    cacheReadTokens: number,
+    outputTokens: number,
+    cacheWriteTokens = 0,
+    at?: string | Date | null,
+  ): TokenCostBreakdown {
+    return calculateTokenCost(
+      modelName,
+      { inputTokens, cacheReadTokens, outputTokens, cacheWriteTokens },
+      {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at,
+      },
+    );
+  }
+
+  function computeUsageBasedCost(
+    modelName: string,
+    inputTokens: number,
+    cacheReadTokens: number,
+    outputTokens: number,
+    cacheWriteTokens = 0,
+    at?: string | Date | null,
+  ): number | null {
+    return computeUsageBasedCostBreakdown(
+      modelName,
+      inputTokens,
+      cacheReadTokens,
+      outputTokens,
+      cacheWriteTokens,
+      at,
+    ).totalCost;
+  }
+
+  function computeCostComparison(
+    metrics: ShutdownMetrics,
+    at?: string | Date | null,
+  ): PricingComparisonBreakdown {
+    return calculatePricingComparison(
+      metrics,
+      costPerPremiumRequest.value,
+      userPricingRegistry(),
+      at,
+    );
+  }
+
+  function getObservedAiuCost(totalNanoAiu: number | null | undefined): number | null {
+    return calculateObservedAiuCost(totalNanoAiu);
+  }
+
+  function getPricingMetadata(
+    modelName: string,
+    billingProvider: PricingRegistryEntry["billingProvider"] = "provider-wholesale",
+  ): PricingRegistryEntry | undefined {
+    const localPrice = modelWholesalePrices.value.find((price) => price.model === modelName);
+    if (localPrice?.source || localPrice?.status || localPrice?.sourceLabel) {
+      return modelPriceEntryToPricingEntry(localPrice, {
+        billingProvider,
+        status: localPrice.status ?? "user-override",
+        sourceLabel: localPrice.sourceLabel ?? "Local settings override",
+      });
+    }
+    return resolvePricingEntry(modelName, {
+      billingProvider,
+      pricingKind: "usage-token-rate",
+      rateMode: "latest",
+    });
   }
 
   function addWholesalePrice(price: ModelPriceEntry) {
@@ -105,6 +213,12 @@ export function createPricingSlice() {
     toolRendering,
     getWholesalePrice,
     computeWholesaleCost,
+    computeWholesaleCostBreakdown,
+    computeUsageBasedCost,
+    computeUsageBasedCostBreakdown,
+    computeCostComparison,
+    getObservedAiuCost,
+    getPricingMetadata,
     addWholesalePrice,
     removeWholesalePrice,
     resetWholesalePrices,

--- a/apps/desktop/src/styles/features/model-comparison.css
+++ b/apps/desktop/src/styles/features/model-comparison.css
@@ -93,6 +93,19 @@
   table-layout: fixed;
   width: 100%;
 }
+
+.model-comparison-feature .matrix-table th:first-child,
+.model-comparison-feature .matrix-table td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--canvas-default);
+}
+
+.model-comparison-feature .matrix-table th:first-child {
+  z-index: 2;
+}
+
 .model-comparison-feature .matrix-table td,
 .model-comparison-feature .compare-table td {
   overflow: hidden;
@@ -297,11 +310,11 @@
 }
 
 .model-comparison-feature .col-model {
-  width: 18%;
+  width: 22%;
 }
 
 .model-comparison-feature .col-total {
-  width: 11%;
+  width: 12%;
 }
 
 .model-comparison-feature .col-input {
@@ -309,27 +322,19 @@
 }
 
 .model-comparison-feature .col-output {
-  width: 9%;
+  width: 11%;
 }
 
 .model-comparison-feature .col-cached {
-  width: 9%;
+  width: 16%;
 }
 
 .model-comparison-feature .col-share {
-  width: 13%;
-}
-
-.model-comparison-feature .col-prem-req {
-  width: 8%;
-}
-
-.model-comparison-feature .col-cache-hit {
-  width: 8%;
+  width: 14%;
 }
 
 .model-comparison-feature .col-cost {
-  width: 8%;
+  width: 7%;
 }
 
 .model-comparison-feature .col-quarter {

--- a/apps/desktop/src/views/tabs/MetricsTab.vue
+++ b/apps/desktop/src/views/tabs/MetricsTab.vue
@@ -36,6 +36,10 @@ const {
   hasTokenBudget,
   copilotCost,
   totalWholesaleCost,
+  totalUsageBasedCost,
+  hasUsageBasedUnknowns,
+  june2026PreviewDelta,
+  observedAiuCost,
   cacheHitRatio,
 } = useMetricsTabData(metrics, prefs);
 </script>
@@ -58,7 +62,11 @@ const {
         :metrics="metrics"
         :total-requests="totalRequests"
         :copilot-cost="copilotCost"
+        :total-usage-based-cost="totalUsageBasedCost"
+        :has-usage-based-unknowns="hasUsageBasedUnknowns"
         :total-wholesale-cost="totalWholesaleCost"
+        :june2026-preview-delta="june2026PreviewDelta"
+        :observed-aiu-cost="observedAiuCost"
         :total-tokens="totalTokens"
       />
 

--- a/crates/tracepilot-orchestrator/src/models.rs
+++ b/crates/tracepilot-orchestrator/src/models.rs
@@ -55,7 +55,7 @@ pub const MODEL_REGISTRY: &[ModelMetadata] = &[
         input_per_m: 5.0,
         cached_input_per_m: 0.5,
         output_per_m: 25.0,
-        premium_requests: 7.5,
+        premium_requests: 15.0,
     },
     ModelMetadata {
         id: "gpt-5.5",
@@ -65,6 +65,15 @@ pub const MODEL_REGISTRY: &[ModelMetadata] = &[
         cached_input_per_m: 0.5,
         output_per_m: 30.0,
         premium_requests: 7.5,
+    },
+    ModelMetadata {
+        id: "goldeneye",
+        name: "Goldeneye",
+        tier: "premium",
+        input_per_m: 1.25,
+        cached_input_per_m: 0.125,
+        output_per_m: 10.0,
+        premium_requests: 1.0,
     },
     ModelMetadata {
         id: "claude-opus-4.6",
@@ -109,6 +118,24 @@ pub const MODEL_REGISTRY: &[ModelMetadata] = &[
         input_per_m: 3.0,
         cached_input_per_m: 0.3,
         output_per_m: 16.0,
+        premium_requests: 1.0,
+    },
+    ModelMetadata {
+        id: "gemini-2.5-pro",
+        name: "Gemini 2.5 Pro",
+        tier: "standard",
+        input_per_m: 1.25,
+        cached_input_per_m: 0.125,
+        output_per_m: 10.0,
+        premium_requests: 1.0,
+    },
+    ModelMetadata {
+        id: "gemini-3.1-pro",
+        name: "Gemini 3.1 Pro",
+        tier: "standard",
+        input_per_m: 2.0,
+        cached_input_per_m: 0.2,
+        output_per_m: 12.0,
         premium_requests: 1.0,
     },
     ModelMetadata {
@@ -184,6 +211,42 @@ pub const MODEL_REGISTRY: &[ModelMetadata] = &[
         premium_requests: 0.33,
     },
     ModelMetadata {
+        id: "gpt-5.4-nano",
+        name: "GPT-5.4 Nano",
+        tier: "fast",
+        input_per_m: 0.2,
+        cached_input_per_m: 0.02,
+        output_per_m: 1.25,
+        premium_requests: 0.33,
+    },
+    ModelMetadata {
+        id: "gemini-3-flash",
+        name: "Gemini 3 Flash",
+        tier: "fast",
+        input_per_m: 0.5,
+        cached_input_per_m: 0.05,
+        output_per_m: 3.0,
+        premium_requests: 0.33,
+    },
+    ModelMetadata {
+        id: "grok-code-fast-1",
+        name: "Grok Code Fast 1",
+        tier: "fast",
+        input_per_m: 0.2,
+        cached_input_per_m: 0.02,
+        output_per_m: 1.5,
+        premium_requests: 0.25,
+    },
+    ModelMetadata {
+        id: "raptor-mini",
+        name: "Raptor Mini",
+        tier: "fast",
+        input_per_m: 0.25,
+        cached_input_per_m: 0.025,
+        output_per_m: 2.0,
+        premium_requests: 0.0,
+    },
+    ModelMetadata {
         id: "gpt-5.1-codex-mini",
         name: "GPT-5.1 Codex Mini",
         tier: "fast",
@@ -251,7 +314,7 @@ mod tests {
         for model in MODEL_REGISTRY {
             assert!(ids.insert(model.id), "duplicate model id: {}", model.id);
         }
-        assert_eq!(MODEL_REGISTRY.len(), 21);
+        assert_eq!(MODEL_REGISTRY.len(), 28);
     }
 
     #[test]

--- a/crates/tracepilot-tauri-bindings/src/config/defaults.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/defaults.rs
@@ -12,6 +12,7 @@ struct PricingDataFile {
     sources: PricingDataSources,
     aliases: HashMap<String, Vec<String>>,
     github_copilot_usage: Vec<UsagePricingData>,
+    annual_legacy_multipliers: Vec<LegacyMultiplierData>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,6 +38,13 @@ struct UsagePricingData {
     cached_input_per_m: f64,
     cache_write_per_m: Option<f64>,
     output_per_m: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyMultiplierData {
+    model: String,
+    current_premium_requests: Option<f64>,
 }
 
 fn pricing_source_label(source: &PricingSourceData) -> String {
@@ -102,6 +110,15 @@ pub(crate) fn default_model_prices() -> Vec<ModelPriceEntry> {
         .iter()
         .map(|entry| (entry.model.as_str(), entry))
         .collect();
+    let current_multipliers: HashMap<&str, f64> = pricing_data
+        .annual_legacy_multipliers
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .current_premium_requests
+                .map(|premium_requests| (entry.model.as_str(), premium_requests))
+        })
+        .collect();
     let github_source = &pricing_data.sources.github_copilot_usage;
     let legacy_source = &pricing_data.sources.trace_pilot_legacy_provider_estimate;
 
@@ -134,7 +151,10 @@ pub(crate) fn default_model_prices() -> Vec<ModelPriceEntry> {
                 cache_write_per_m: official.and_then(|rates| rates.cache_write_per_m),
                 output_per_m: official.map_or(entry.output_per_m, |rates| rates.output_per_m),
                 reasoning_per_m: None,
-                premium_requests: entry.premium_requests,
+                premium_requests: current_multipliers
+                    .get(entry.model)
+                    .copied()
+                    .unwrap_or(entry.premium_requests),
                 source: Some("provider-wholesale".to_string()),
                 pricing_kind: None,
                 effective_from: None,

--- a/crates/tracepilot-tauri-bindings/src/config/defaults.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/defaults.rs
@@ -13,6 +13,7 @@ struct PricingDataFile {
     aliases: HashMap<String, Vec<String>>,
     github_copilot_usage: Vec<UsagePricingData>,
     annual_legacy_multipliers: Vec<LegacyMultiplierData>,
+    current_premium_request_defaults: Vec<CurrentPremiumRequestData>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -45,6 +46,13 @@ struct UsagePricingData {
 struct LegacyMultiplierData {
     model: String,
     current_premium_requests: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CurrentPremiumRequestData {
+    model: String,
+    current_premium_requests: f64,
 }
 
 fn pricing_source_label(source: &PricingSourceData) -> String {
@@ -118,6 +126,12 @@ pub(crate) fn default_model_prices() -> Vec<ModelPriceEntry> {
                 .current_premium_requests
                 .map(|premium_requests| (entry.model.as_str(), premium_requests))
         })
+        .chain(
+            pricing_data
+                .current_premium_request_defaults
+                .iter()
+                .map(|entry| (entry.model.as_str(), entry.current_premium_requests)),
+        )
         .collect();
     let github_source = &pricing_data.sources.github_copilot_usage;
     let legacy_source = &pricing_data.sources.trace_pilot_legacy_provider_estimate;

--- a/crates/tracepilot-tauri-bindings/src/config/defaults.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/defaults.rs
@@ -1,6 +1,51 @@
 //! Serde `default = "..."` helper functions shared across sub-configs.
 
 use super::ModelPriceEntry;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+const PRICING_DATA_JSON: &str = include_str!("../../../../packages/types/src/pricing-data.json");
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PricingDataFile {
+    sources: PricingDataSources,
+    aliases: HashMap<String, Vec<String>>,
+    github_copilot_usage: Vec<UsagePricingData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PricingDataSources {
+    github_copilot_usage: PricingSourceData,
+    trace_pilot_legacy_provider_estimate: PricingSourceData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PricingSourceData {
+    label: String,
+    url: Option<String>,
+    verified_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UsagePricingData {
+    model: String,
+    input_per_m: f64,
+    cached_input_per_m: f64,
+    cache_write_per_m: Option<f64>,
+    output_per_m: f64,
+}
+
+fn pricing_source_label(source: &PricingSourceData) -> String {
+    format!("{} (verified {})", source.label, source.verified_at)
+}
+
+fn pricing_data() -> PricingDataFile {
+    serde_json::from_str(PRICING_DATA_JSON).expect("embedded pricing-data.json should parse")
+}
 
 pub(super) fn default_true() -> bool {
     true
@@ -51,14 +96,60 @@ pub(super) fn default_alert_scope() -> String {
 }
 
 pub(crate) fn default_model_prices() -> Vec<ModelPriceEntry> {
+    let pricing_data = pricing_data();
+    let official_rates: HashMap<&str, &UsagePricingData> = pricing_data
+        .github_copilot_usage
+        .iter()
+        .map(|entry| (entry.model.as_str(), entry))
+        .collect();
+    let github_source = &pricing_data.sources.github_copilot_usage;
+    let legacy_source = &pricing_data.sources.trace_pilot_legacy_provider_estimate;
+
     tracepilot_orchestrator::models::default_model_pricing()
         .into_iter()
-        .map(|entry| ModelPriceEntry {
-            model: entry.model.to_string(),
-            input_per_m: entry.input_per_m,
-            cached_input_per_m: entry.cached_input_per_m,
-            output_per_m: entry.output_per_m,
-            premium_requests: entry.premium_requests,
+        .map(|entry| {
+            let official = official_rates.get(entry.model);
+            let source_label = if official.is_some() {
+                format!(
+                    "{}; local default mirrors GitHub's published token rates",
+                    pricing_source_label(github_source)
+                )
+            } else {
+                format!(
+                    "{}; model not listed on GitHub pricing page",
+                    pricing_source_label(legacy_source)
+                )
+            };
+
+            ModelPriceEntry {
+                model: entry.model.to_string(),
+                aliases: pricing_data
+                    .aliases
+                    .get(entry.model)
+                    .cloned()
+                    .unwrap_or_default(),
+                input_per_m: official.map_or(entry.input_per_m, |rates| rates.input_per_m),
+                cached_input_per_m: official
+                    .map_or(entry.cached_input_per_m, |rates| rates.cached_input_per_m),
+                cache_write_per_m: official.and_then(|rates| rates.cache_write_per_m),
+                output_per_m: official.map_or(entry.output_per_m, |rates| rates.output_per_m),
+                reasoning_per_m: None,
+                premium_requests: entry.premium_requests,
+                source: Some("provider-wholesale".to_string()),
+                pricing_kind: None,
+                effective_from: None,
+                effective_to: None,
+                source_label: Some(source_label),
+                source_url: official.and_then(|_| github_source.url.clone()),
+                status: Some(
+                    if official.is_some() {
+                        "official"
+                    } else {
+                        "estimated"
+                    }
+                    .to_string(),
+                ),
+            }
         })
         .collect()
 }

--- a/crates/tracepilot-tauri-bindings/src/config/pricing.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/pricing.rs
@@ -26,8 +26,28 @@ impl Default for PricingConfig {
 #[serde(rename_all = "camelCase")]
 pub struct ModelPriceEntry {
     pub model: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     pub input_per_m: f64,
     pub cached_input_per_m: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_per_m: Option<f64>,
     pub output_per_m: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_per_m: Option<f64>,
     pub premium_requests: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
 }

--- a/crates/tracepilot-tauri-bindings/src/config/tests.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/tests.rs
@@ -126,6 +126,7 @@ fn default_pricing_uses_shared_published_token_rates() {
     assert_eq!(gpt_54_mini.input_per_m, 0.75);
     assert_eq!(gpt_54_mini.cached_input_per_m, 0.075);
     assert_eq!(gpt_54_mini.output_per_m, 4.5);
+    assert_eq!(gpt_54_mini.premium_requests, 0.33);
     assert_eq!(gpt_54_mini.source.as_deref(), Some("provider-wholesale"));
     assert_eq!(gpt_54_mini.status.as_deref(), Some("official"));
 }

--- a/crates/tracepilot-tauri-bindings/src/config/tests.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/tests.rs
@@ -71,6 +71,66 @@ fn deserialize_missing_optional_sections_uses_defaults() {
 }
 
 #[test]
+fn pricing_model_entries_roundtrip_optional_metadata() {
+    let toml = r#"
+        version = 8
+
+        [paths]
+        copilotHome = "/custom/copilot"
+        tracepilotHome = "/custom/tracepilot"
+        indexDbPath = "/custom/tracepilot/index.db"
+        sessionStateDir = "/custom/copilot/session-state"
+
+        [pricing]
+        costPerPremiumRequest = 0.04
+
+        [[pricing.models]]
+        model = "custom-model"
+        aliases = ["Custom Model"]
+        inputPerM = 1.0
+        cachedInputPerM = 0.1
+        cacheWritePerM = 0.2
+        outputPerM = 2.0
+        reasoningPerM = 3.0
+        premiumRequests = 1.0
+        source = "user"
+        pricingKind = "usage-token-rate"
+        effectiveFrom = "2026-06-01"
+        sourceLabel = "Local settings override"
+        status = "user-override"
+    "#;
+
+    let config: TracePilotConfig = toml::from_str(toml).expect("parse pricing metadata");
+    let model = config.pricing.models.first().expect("pricing model");
+    assert_eq!(model.aliases, vec!["Custom Model".to_string()]);
+    assert_eq!(model.cache_write_per_m, Some(0.2));
+    assert_eq!(model.reasoning_per_m, Some(3.0));
+    assert_eq!(model.source.as_deref(), Some("user"));
+    assert_eq!(model.effective_from.as_deref(), Some("2026-06-01"));
+
+    let serialized = toml::to_string_pretty(&config).expect("serialize pricing metadata");
+    assert!(serialized.contains("cacheWritePerM = 0.2"));
+    assert!(serialized.contains("sourceLabel = \"Local settings override\""));
+}
+
+#[test]
+fn default_pricing_uses_shared_published_token_rates() {
+    let config = TracePilotConfig::default();
+    let gpt_54_mini = config
+        .pricing
+        .models
+        .iter()
+        .find(|entry| entry.model == "gpt-5.4-mini")
+        .expect("gpt-5.4-mini default price");
+
+    assert_eq!(gpt_54_mini.input_per_m, 0.75);
+    assert_eq!(gpt_54_mini.cached_input_per_m, 0.075);
+    assert_eq!(gpt_54_mini.output_per_m, 4.5);
+    assert_eq!(gpt_54_mini.source.as_deref(), Some("provider-wholesale"));
+    assert_eq!(gpt_54_mini.status.as_deref(), Some("official"));
+}
+
+#[test]
 fn deserialize_v1_config_and_migrate() {
     let v1_toml = r#"
         version = 1

--- a/docs/pricing-model.md
+++ b/docs/pricing-model.md
@@ -1,0 +1,61 @@
+# Copilot pricing model refresh
+
+TracePilot's pricing model is moving from a single premium-request estimate plus configurable wholesale token rates to a small, typed pricing registry backed by versioned pricing data. It can compare legacy premium-request billing, GitHub usage-based token billing, local token-rate estimates, and observed AI Credit telemetry when present.
+
+## Source assumptions
+
+- GitHub announced that all Copilot plans transition to usage-based billing on **June 1, 2026**. Premium request units are replaced by GitHub AI Credits, and usage is calculated from token consumption including input, output, and cached tokens using the listed API rates for each model. Source: [GitHub Blog, "GitHub Copilot is moving to usage-based billing"](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/).
+- GitHub's Copilot models/pricing reference states that model prices are listed **per 1 million tokens**, and **1 GitHub AI Credit = $0.01 USD**. It also distinguishes input, cached input, output, and Anthropic cache-write costs. Source: [Models and pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing).
+- GitHub's usage-based billing docs state that Copilot CLI usage consumes AI Credits, while code completions and Next Edit suggestions remain included and are not billed in AI Credits. Sources: [Usage-based billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals) and [Usage-based billing for organizations and enterprises](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises).
+- Annual Copilot Pro/Pro+ subscribers who remain on request-based billing after June 1, 2026 keep premium-request billing but receive changed model multipliers. These multipliers do **not** apply to usage-based billing. Source: [Model multipliers for annual plans staying on request-based billing](https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans).
+
+## Model
+
+TracePilot now treats prices as effective-dated registry entries. A rate can describe:
+
+- the model id and aliases used by Copilot events, GitHub docs, or provider APIs;
+- the billing provider/source (`github-copilot`, `provider-wholesale`, or `user`);
+- the pricing kind (`legacy-premium-request`, `usage-token-rate`, or `observed-nano-aiu`);
+- token rates for input, cached input, cache write, output, and reasoning where known;
+- premium-request multipliers where applicable;
+- currency/unit, effective dates, source label/URL, and confidence/status.
+
+The shipped registry is read-only and generated from `packages/types/src/pricing-data.json`, which contains the source URLs, verification date, effective date, aliases, token rates, and annual-plan multipliers. User edits in `pricing.models` remain local overrides and are layered above defaults without mutating the shipped registry.
+
+## Historical sessions and switchover
+
+TracePilot preserves old sessions by keeping the premium-request estimate available as **Legacy Copilot**. Usage-based estimates are calculated from token usage and GitHub's official model rates, effective from **2026-06-01** by default. For historical analysis, TracePilot can evaluate:
+
+- **session-time rates**, using the rates effective at the session or segment timestamp;
+- **latest rates**, re-pricing older usage with the newest registry entries;
+- **comparison/preview**, showing old-vs-new estimates and the delta around the June 2026 switchover.
+
+The current UI focuses on comparison/preview for individual session metrics while keeping the lower-level rate engine ready for broader selectable modes later.
+
+## Cost surfaces
+
+- **Legacy Copilot**: `premiumRequests * costPerPremiumRequest`. This is retained for pre-switchover sessions and annual-plan users that remain request-billed.
+- **GitHub Copilot (usage)**: token usage multiplied by GitHub Copilot model rates. This is the forward-looking estimate for monthly plans after June 1, 2026.
+- **Direct API (estimate)**: configurable local token rates, preserving TracePilot's previous provider/direct-API estimate workflow. Defaults for models listed on GitHub's pricing page are derived from the same `pricing-data.json` rows as GitHub Copilot usage estimates, so the two estimates align by default. They only diverge when a user overrides local rates or when a model is not present in GitHub's published usage table and TracePilot falls back to a clearly marked legacy estimate.
+- **Observed AI Credits**: shown when `totalNanoAiu` exists. TracePilot treats it as observed telemetry and does not silently substitute it for calculated costs unless the units are explicit enough to display.
+
+Unknown models or missing prices are surfaced as unknown instead of falling back to a possibly wrong model price. After June 2026, no code change should be needed for the estimate path: the shipped effective date already exists, and sessions with `totalNanoAiu` can additionally show observed AI Credit telemetry when the CLI emits it.
+
+## Pricing updates
+
+Pricing updates should be made in `packages/types/src/pricing-data.json`, not in calculator code. That keeps source attribution, effective dates, aliases, GitHub Copilot usage rates, and default local token-rate estimates in one auditable place. The TypeScript registry derives:
+
+- `github-copilot` usage entries with the June 1, 2026 effective date;
+- `provider-wholesale` defaults that mirror those same published token rates for documented models;
+- clearly marked legacy estimates for models not present on GitHub's published pricing page;
+- annual-plan premium-request multipliers from the separate GitHub multiplier reference.
+
+Local settings remain explicit user overrides for the Direct API estimate and are persisted in TracePilot's existing config file. Effective-date editing is intentionally display-only in this MVP; a future refresh command can update the JSON data file from GitHub's pricing page without changing calculation logic.
+
+## Alias handling
+
+Copilot event model names may not match GitHub documentation or provider names exactly. TracePilot normalizes model names and uses explicit aliases from the registry before falling back to conservative exact/prefix matching. This avoids fragile substring-only matching and makes unknown models visible.
+
+## Future opportunities
+
+The registry enables budget burn-down, included-credit utilization, model-switch recommendations, per-segment cost attribution, forecast views using latest vs session-time rates, and reconciliation between observed AIU telemetry and TracePilot's token-rate estimate.

--- a/docs/pricing-model.md
+++ b/docs/pricing-model.md
@@ -20,7 +20,7 @@ TracePilot now treats prices as effective-dated registry entries. A rate can des
 - premium-request multipliers where applicable;
 - currency/unit, effective dates, source label/URL, and confidence/status.
 
-The shipped registry is read-only and generated from `packages/types/src/pricing-data.json`, which contains the source URLs, verification date, effective date, aliases, token rates, current premium-request multipliers, and June 2026 annual-plan multipliers. User edits in `pricing.models` remain local overrides and are layered above defaults without mutating the shipped registry.
+The shipped registry is read-only and generated from `packages/types/src/pricing-data.json`, which contains the source URLs, verification date, effective date, aliases, token rates, current premium-request multipliers, and June 2026 annual-plan multipliers. For models missing from GitHub's annual multiplier table, TracePilot records the current fallback multiplier in `currentPremiumRequestDefaults` so launch/settings defaults still come from the shared pricing data file instead of calculator code. User edits in `pricing.models` remain local overrides and are layered above defaults without mutating the shipped registry.
 
 ## Historical sessions and switchover
 

--- a/docs/pricing-model.md
+++ b/docs/pricing-model.md
@@ -7,7 +7,7 @@ TracePilot's pricing model is moving from a single premium-request estimate plus
 - GitHub announced that all Copilot plans transition to usage-based billing on **June 1, 2026**. Premium request units are replaced by GitHub AI Credits, and usage is calculated from token consumption including input, output, and cached tokens using the listed API rates for each model. Source: [GitHub Blog, "GitHub Copilot is moving to usage-based billing"](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/).
 - GitHub's Copilot models/pricing reference states that model prices are listed **per 1 million tokens**, and **1 GitHub AI Credit = $0.01 USD**. It also distinguishes input, cached input, output, and Anthropic cache-write costs. Source: [Models and pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing).
 - GitHub's usage-based billing docs state that Copilot CLI usage consumes AI Credits, while code completions and Next Edit suggestions remain included and are not billed in AI Credits. Sources: [Usage-based billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals) and [Usage-based billing for organizations and enterprises](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises).
-- Annual Copilot Pro/Pro+ subscribers who remain on request-based billing after June 1, 2026 keep premium-request billing but receive changed model multipliers. These multipliers do **not** apply to usage-based billing. Source: [Model multipliers for annual plans staying on request-based billing](https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans).
+- Annual Copilot Pro/Pro+ subscribers who remain on request-based billing after June 1, 2026 keep premium-request billing but receive changed model multipliers. These multipliers do **not** apply to usage-based billing. TracePilot records both the current multiplier and the June 2026 annual-plan multiplier in the pricing data file so launcher/default settings do not drift from the preview registry. Source: [Model multipliers for annual plans staying on request-based billing](https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans).
 
 ## Model
 
@@ -20,7 +20,7 @@ TracePilot now treats prices as effective-dated registry entries. A rate can des
 - premium-request multipliers where applicable;
 - currency/unit, effective dates, source label/URL, and confidence/status.
 
-The shipped registry is read-only and generated from `packages/types/src/pricing-data.json`, which contains the source URLs, verification date, effective date, aliases, token rates, and annual-plan multipliers. User edits in `pricing.models` remain local overrides and are layered above defaults without mutating the shipped registry.
+The shipped registry is read-only and generated from `packages/types/src/pricing-data.json`, which contains the source URLs, verification date, effective date, aliases, token rates, current premium-request multipliers, and June 2026 annual-plan multipliers. User edits in `pricing.models` remain local overrides and are layered above defaults without mutating the shipped registry.
 
 ## Historical sessions and switchover
 
@@ -47,6 +47,7 @@ Pricing updates should be made in `packages/types/src/pricing-data.json`, not in
 
 - `github-copilot` usage entries with the June 1, 2026 effective date;
 - `provider-wholesale` defaults that mirror those same published token rates for documented models;
+- current premium-request multipliers used by launch/settings defaults;
 - clearly marked legacy estimates for models not present on GitHub's published pricing page;
 - annual-plan premium-request multipliers from the separate GitHub multiplier reference.
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -5,14 +5,27 @@
 //
 // Note: default values for these types live in `defaults.ts`.
 
-/** Per-model wholesale pricing entry */
+import type { PricingKind, PricingProvider, PricingStatus } from "./pricing.js";
+
+/** Per-model pricing entry persisted in local settings. Defaults mirror the shipped registry; user edits override it locally. */
 export interface ModelPriceEntry {
   model: string;
+  aliases?: string[];
   inputPerM: number;
   cachedInputPerM: number;
+  cacheWritePerM?: number;
   outputPerM: number;
+  reasoningPerM?: number;
   /** Premium request multiplier (e.g. 1x, 3x, 0.33x). 0 = free tier. */
   premiumRequests: number;
+  /** Optional provenance for display. Local settings entries are applied as direct-API/provider rates. */
+  source?: PricingProvider;
+  pricingKind?: PricingKind;
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
+  status?: PricingStatus;
 }
 
 /** TracePilot application configuration — persisted in config.toml */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -132,6 +132,40 @@ export {
   TRACEPILOT_HOME_PLACEHOLDER,
   TRACEPILOT_INDEX_DB_PLACEHOLDER,
 } from "./paths.js";
+export type {
+  CostBreakdownStatus,
+  PricingComparisonBreakdown,
+  PricingKind,
+  PricingLookupOptions,
+  PricingProvider,
+  PricingRateMode,
+  PricingRegistryEntry,
+  PricingStatus,
+  PricingUnit,
+  TokenCostBreakdown,
+  TokenRateSet,
+  TokenUsageForCost,
+} from "./pricing.js";
+// ── pricing.js ──────────────────────────────────────────────────────
+export {
+  AI_CREDIT_USD,
+  calculateMetricsTokenCost,
+  calculateObservedAiuCost,
+  calculatePricingComparison,
+  calculateTokenCost,
+  GITHUB_ANNUAL_LEGACY_MULTIPLIERS,
+  GITHUB_COPILOT_USAGE_PRICING,
+  GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+  modelPriceEntriesToPricingRegistry,
+  modelPriceEntryToPricingEntry,
+  NANO_AIU_PER_AI_CREDIT,
+  normalizeModelName,
+  PRICING_REGISTRY,
+  PRICING_REGISTRY_VERSION,
+  PROVIDER_WHOLESALE_PRICING,
+  resolvePricingEntry,
+  sumTokenCosts,
+} from "./pricing.js";
 
 // ── replay.js ──────────────────────────────────────────────────────
 export type { ReplayState, ReplayStep } from "./replay.js";

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ModelPriceEntry } from "./config.js";
-import pricingData from "./pricing-data.json";
+import pricingData from "./pricing-data.json" with { type: "json" };
 
 // ─── Tier ────────────────────────────────────────────────────────────
 

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ModelPriceEntry } from "./config.js";
+import pricingData from "./pricing-data.json";
 
 // ─── Tier ────────────────────────────────────────────────────────────
 
@@ -32,6 +33,39 @@ export interface ModelDefinition {
   outputPerM: number;
   /** Premium-request multiplier (e.g. 1×, 3×, 0.33×). 0 = free tier. */
   premiumRequests: number;
+}
+
+interface UsagePricingData {
+  model: string;
+  inputPerM: number;
+  cachedInputPerM: number;
+  cacheWritePerM?: number;
+  outputPerM: number;
+}
+
+interface PricingDataFile {
+  sources: {
+    githubCopilotUsage: {
+      label: string;
+      url?: string;
+      verifiedAt: string;
+    };
+    tracePilotLegacyProviderEstimate: {
+      label: string;
+      verifiedAt: string;
+    };
+  };
+  aliases: Record<string, string[]>;
+  githubCopilotUsage: UsagePricingData[];
+}
+
+const PRICING_DATA = pricingData as PricingDataFile;
+const OFFICIAL_TOKEN_RATES_BY_MODEL = new Map(
+  PRICING_DATA.githubCopilotUsage.map((entry) => [entry.model, entry]),
+);
+
+function pricingSourceLabel(source: { label: string; verifiedAt: string }): string {
+  return `${source.label} (verified ${source.verifiedAt})`;
 }
 
 // ─── Registry ────────────────────────────────────────────────────────
@@ -275,13 +309,40 @@ export function getTierLabel(tier: ModelTier): string {
 
 /** Derive default wholesale prices from the registry. */
 export function getDefaultWholesalePrices(): ModelPriceEntry[] {
-  return MODEL_REGISTRY.map(({ id, inputPerM, cachedInputPerM, outputPerM, premiumRequests }) => ({
-    model: id,
-    inputPerM,
-    cachedInputPerM,
-    outputPerM,
-    premiumRequests,
-  }));
+  return MODEL_REGISTRY.map(({ id, inputPerM, cachedInputPerM, outputPerM, premiumRequests }) => {
+    const officialRates = OFFICIAL_TOKEN_RATES_BY_MODEL.get(id);
+    if (officialRates) {
+      return {
+        model: id,
+        aliases: PRICING_DATA.aliases[id],
+        inputPerM: officialRates.inputPerM,
+        cachedInputPerM: officialRates.cachedInputPerM,
+        cacheWritePerM: officialRates.cacheWritePerM,
+        outputPerM: officialRates.outputPerM,
+        premiumRequests,
+        source: "provider-wholesale",
+        sourceLabel: `${pricingSourceLabel(
+          PRICING_DATA.sources.githubCopilotUsage,
+        )}; local default mirrors GitHub's published token rates`,
+        sourceUrl: PRICING_DATA.sources.githubCopilotUsage.url,
+        status: "official",
+      };
+    }
+    return {
+      model: id,
+      aliases: PRICING_DATA.aliases[id],
+      inputPerM,
+      cachedInputPerM,
+      cacheWritePerM: 0,
+      outputPerM,
+      premiumRequests,
+      source: "provider-wholesale",
+      sourceLabel: `${pricingSourceLabel(
+        PRICING_DATA.sources.tracePilotLegacyProviderEstimate,
+      )}; model not listed on GitHub pricing page`,
+      status: "estimated",
+    };
+  });
 }
 
 // ─── Well-known defaults ─────────────────────────────────────────────

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -54,10 +54,15 @@ interface PricingDataFile {
       label: string;
       verifiedAt: string;
     };
+    tracePilotCurrentPremiumRequests: {
+      label: string;
+      verifiedAt: string;
+    };
   };
   aliases: Record<string, string[]>;
   githubCopilotUsage: UsagePricingData[];
   annualLegacyMultipliers: { model: string; currentPremiumRequests?: number }[];
+  currentPremiumRequestDefaults: { model: string; currentPremiumRequests: number }[];
 }
 
 const PRICING_DATA = pricingData as PricingDataFile;
@@ -65,9 +70,10 @@ const OFFICIAL_TOKEN_RATES_BY_MODEL = new Map(
   PRICING_DATA.githubCopilotUsage.map((entry) => [entry.model, entry]),
 );
 const CURRENT_PREMIUM_REQUESTS_BY_MODEL = new Map(
-  PRICING_DATA.annualLegacyMultipliers
-    .filter((entry) => entry.currentPremiumRequests != null)
-    .map((entry) => [entry.model, entry.currentPremiumRequests as number]),
+  [
+    ...PRICING_DATA.annualLegacyMultipliers.filter((entry) => entry.currentPremiumRequests != null),
+    ...PRICING_DATA.currentPremiumRequestDefaults,
+  ].map((entry) => [entry.model, entry.currentPremiumRequests as number]),
 );
 
 function pricingSourceLabel(source: { label: string; verifiedAt: string }): string {

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -57,11 +57,17 @@ interface PricingDataFile {
   };
   aliases: Record<string, string[]>;
   githubCopilotUsage: UsagePricingData[];
+  annualLegacyMultipliers: { model: string; currentPremiumRequests?: number }[];
 }
 
 const PRICING_DATA = pricingData as PricingDataFile;
 const OFFICIAL_TOKEN_RATES_BY_MODEL = new Map(
   PRICING_DATA.githubCopilotUsage.map((entry) => [entry.model, entry]),
+);
+const CURRENT_PREMIUM_REQUESTS_BY_MODEL = new Map(
+  PRICING_DATA.annualLegacyMultipliers
+    .filter((entry) => entry.currentPremiumRequests != null)
+    .map((entry) => [entry.model, entry.currentPremiumRequests as number]),
 );
 
 function pricingSourceLabel(source: { label: string; verifiedAt: string }): string {
@@ -77,7 +83,7 @@ function pricingSourceLabel(source: { label: string; verifiedAt: string }): stri
  * Keep in sync with `crates/tracepilot-orchestrator/src/launcher.rs →
  * available_models()`.
  */
-export const MODEL_REGISTRY: readonly ModelDefinition[] = [
+const MODEL_REGISTRY_BASE: readonly ModelDefinition[] = [
   // ── Premium ──
   {
     id: "claude-opus-4.7",
@@ -96,6 +102,15 @@ export const MODEL_REGISTRY: readonly ModelDefinition[] = [
     cachedInputPerM: 0.5,
     outputPerM: 30.0,
     premiumRequests: 7.5,
+  },
+  {
+    id: "goldeneye",
+    name: "Goldeneye",
+    tier: "premium",
+    inputPerM: 1.25,
+    cachedInputPerM: 0.125,
+    outputPerM: 10.0,
+    premiumRequests: 1,
   },
   {
     id: "claude-opus-4.6",
@@ -159,6 +174,24 @@ export const MODEL_REGISTRY: readonly ModelDefinition[] = [
     inputPerM: 3.0,
     cachedInputPerM: 0.3,
     outputPerM: 16.0,
+    premiumRequests: 1,
+  },
+  {
+    id: "gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    tier: "standard",
+    inputPerM: 1.25,
+    cachedInputPerM: 0.125,
+    outputPerM: 10.0,
+    premiumRequests: 1,
+  },
+  {
+    id: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro",
+    tier: "standard",
+    inputPerM: 2.0,
+    cachedInputPerM: 0.2,
+    outputPerM: 12.0,
     premiumRequests: 1,
   },
   {
@@ -244,6 +277,42 @@ export const MODEL_REGISTRY: readonly ModelDefinition[] = [
     premiumRequests: 0.33,
   },
   {
+    id: "gpt-5.4-nano",
+    name: "GPT-5.4 Nano",
+    tier: "fast",
+    inputPerM: 0.2,
+    cachedInputPerM: 0.02,
+    outputPerM: 1.25,
+    premiumRequests: 0.33,
+  },
+  {
+    id: "gemini-3-flash",
+    name: "Gemini 3 Flash",
+    tier: "fast",
+    inputPerM: 0.5,
+    cachedInputPerM: 0.05,
+    outputPerM: 3.0,
+    premiumRequests: 0.33,
+  },
+  {
+    id: "grok-code-fast-1",
+    name: "Grok Code Fast 1",
+    tier: "fast",
+    inputPerM: 0.2,
+    cachedInputPerM: 0.02,
+    outputPerM: 1.5,
+    premiumRequests: 0.25,
+  },
+  {
+    id: "raptor-mini",
+    name: "Raptor Mini",
+    tier: "fast",
+    inputPerM: 0.25,
+    cachedInputPerM: 0.025,
+    outputPerM: 2.0,
+    premiumRequests: 0,
+  },
+  {
     id: "gpt-5.1-codex-mini",
     name: "GPT-5.1 Codex Mini",
     tier: "fast",
@@ -271,6 +340,11 @@ export const MODEL_REGISTRY: readonly ModelDefinition[] = [
     premiumRequests: 0,
   },
 ];
+
+export const MODEL_REGISTRY: readonly ModelDefinition[] = MODEL_REGISTRY_BASE.map((model) => ({
+  ...model,
+  premiumRequests: CURRENT_PREMIUM_REQUESTS_BY_MODEL.get(model.id) ?? model.premiumRequests,
+}));
 
 // ─── Derived helpers ─────────────────────────────────────────────────
 

--- a/packages/types/src/pricing-data.json
+++ b/packages/types/src/pricing-data.json
@@ -1,0 +1,259 @@
+{
+  "version": "github-copilot-usage-2026-05-04",
+  "sources": {
+    "githubCopilotUsage": {
+      "label": "GitHub Copilot models and pricing",
+      "url": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+      "verifiedAt": "2026-05-04",
+      "effectiveFrom": "2026-06-01"
+    },
+    "annualLegacyMultipliers": {
+      "label": "GitHub annual-plan premium request multipliers",
+      "url": "https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans",
+      "verifiedAt": "2026-05-04",
+      "effectiveFrom": "2026-06-01"
+    },
+    "tracePilotLegacyProviderEstimate": {
+      "label": "TracePilot legacy provider estimate",
+      "verifiedAt": "2026-05-04"
+    }
+  },
+  "aliases": {
+    "claude-haiku-4.5": ["Claude Haiku 4.5"],
+    "claude-opus-4.5": ["Claude Opus 4.5"],
+    "claude-opus-4.6": ["Claude Opus 4.6"],
+    "claude-opus-4.6-fast": ["Claude Opus 4.6 Fast"],
+    "claude-opus-4.7": ["Claude Opus 4.7"],
+    "claude-sonnet-4": ["Claude Sonnet 4"],
+    "claude-sonnet-4.5": ["Claude Sonnet 4.5"],
+    "claude-sonnet-4.6": ["Claude Sonnet 4.6"],
+    "gemini-2.5-pro": ["Gemini 2.5 Pro"],
+    "gemini-3-flash": ["Gemini 3 Flash"],
+    "gemini-3-pro-preview": ["Gemini 3 Pro", "gemini-3-pro"],
+    "gemini-3.1-pro": ["Gemini 3.1 Pro"],
+    "goldeneye": ["Goldeneye"],
+    "gpt-4.1": ["GPT-4.1"],
+    "gpt-4o": ["GPT-4o"],
+    "gpt-4o-mini": ["GPT-4o mini"],
+    "gpt-5-mini": ["GPT-5 mini"],
+    "gpt-5.1": ["GPT-5.1"],
+    "gpt-5.1-codex": ["GPT-5.1-Codex", "GPT-5.1 Codex"],
+    "gpt-5.1-codex-max": ["GPT-5.1-Codex-Max", "GPT-5.1 Codex Max"],
+    "gpt-5.1-codex-mini": ["GPT-5.1-Codex-Mini", "GPT-5.1 Codex Mini"],
+    "gpt-5.2": ["GPT-5.2"],
+    "gpt-5.2-codex": ["GPT-5.2-Codex", "GPT-5.2 Codex"],
+    "gpt-5.3-codex": ["GPT-5.3-Codex", "GPT-5.3 Codex"],
+    "gpt-5.4": ["GPT-5.4"],
+    "gpt-5.4-mini": ["GPT-5.4 mini"],
+    "gpt-5.4-nano": ["GPT-5.4 nano"],
+    "gpt-5.5": ["GPT-5.5"],
+    "grok-code-fast-1": ["Grok Code Fast 1"],
+    "raptor-mini": ["Raptor mini"]
+  },
+  "githubCopilotUsage": [
+    {
+      "model": "gpt-4.1",
+      "displayName": "GPT-4.1",
+      "inputPerM": 2,
+      "cachedInputPerM": 0.5,
+      "cacheWritePerM": 0,
+      "outputPerM": 8
+    },
+    {
+      "model": "gpt-5-mini",
+      "displayName": "GPT-5 mini",
+      "inputPerM": 0.25,
+      "cachedInputPerM": 0.025,
+      "cacheWritePerM": 0,
+      "outputPerM": 2
+    },
+    {
+      "model": "gpt-5.2",
+      "displayName": "GPT-5.2",
+      "inputPerM": 1.75,
+      "cachedInputPerM": 0.175,
+      "cacheWritePerM": 0,
+      "outputPerM": 14
+    },
+    {
+      "model": "gpt-5.2-codex",
+      "displayName": "GPT-5.2-Codex",
+      "inputPerM": 1.75,
+      "cachedInputPerM": 0.175,
+      "cacheWritePerM": 0,
+      "outputPerM": 14
+    },
+    {
+      "model": "gpt-5.3-codex",
+      "displayName": "GPT-5.3-Codex",
+      "inputPerM": 1.75,
+      "cachedInputPerM": 0.175,
+      "cacheWritePerM": 0,
+      "outputPerM": 14
+    },
+    {
+      "model": "gpt-5.4",
+      "displayName": "GPT-5.4",
+      "inputPerM": 2.5,
+      "cachedInputPerM": 0.25,
+      "cacheWritePerM": 0,
+      "outputPerM": 15
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "displayName": "GPT-5.4 mini",
+      "inputPerM": 0.75,
+      "cachedInputPerM": 0.075,
+      "cacheWritePerM": 0,
+      "outputPerM": 4.5
+    },
+    {
+      "model": "gpt-5.4-nano",
+      "displayName": "GPT-5.4 nano",
+      "inputPerM": 0.2,
+      "cachedInputPerM": 0.02,
+      "cacheWritePerM": 0,
+      "outputPerM": 1.25
+    },
+    {
+      "model": "gpt-5.5",
+      "displayName": "GPT-5.5",
+      "inputPerM": 5,
+      "cachedInputPerM": 0.5,
+      "cacheWritePerM": 0,
+      "outputPerM": 30
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "displayName": "Claude Haiku 4.5",
+      "inputPerM": 1,
+      "cachedInputPerM": 0.1,
+      "cacheWritePerM": 1.25,
+      "outputPerM": 5
+    },
+    {
+      "model": "claude-sonnet-4",
+      "displayName": "Claude Sonnet 4",
+      "inputPerM": 3,
+      "cachedInputPerM": 0.3,
+      "cacheWritePerM": 3.75,
+      "outputPerM": 15
+    },
+    {
+      "model": "claude-sonnet-4.5",
+      "displayName": "Claude Sonnet 4.5",
+      "inputPerM": 3,
+      "cachedInputPerM": 0.3,
+      "cacheWritePerM": 3.75,
+      "outputPerM": 15
+    },
+    {
+      "model": "claude-sonnet-4.6",
+      "displayName": "Claude Sonnet 4.6",
+      "inputPerM": 3,
+      "cachedInputPerM": 0.3,
+      "cacheWritePerM": 3.75,
+      "outputPerM": 15
+    },
+    {
+      "model": "claude-opus-4.5",
+      "displayName": "Claude Opus 4.5",
+      "inputPerM": 5,
+      "cachedInputPerM": 0.5,
+      "cacheWritePerM": 6.25,
+      "outputPerM": 25
+    },
+    {
+      "model": "claude-opus-4.6",
+      "displayName": "Claude Opus 4.6",
+      "inputPerM": 5,
+      "cachedInputPerM": 0.5,
+      "cacheWritePerM": 6.25,
+      "outputPerM": 25
+    },
+    {
+      "model": "claude-opus-4.7",
+      "displayName": "Claude Opus 4.7",
+      "inputPerM": 5,
+      "cachedInputPerM": 0.5,
+      "cacheWritePerM": 6.25,
+      "outputPerM": 25
+    },
+    {
+      "model": "gemini-2.5-pro",
+      "displayName": "Gemini 2.5 Pro",
+      "inputPerM": 1.25,
+      "cachedInputPerM": 0.125,
+      "cacheWritePerM": 0,
+      "outputPerM": 10
+    },
+    {
+      "model": "gemini-3-flash",
+      "displayName": "Gemini 3 Flash",
+      "inputPerM": 0.5,
+      "cachedInputPerM": 0.05,
+      "cacheWritePerM": 0,
+      "outputPerM": 3
+    },
+    {
+      "model": "gemini-3.1-pro",
+      "displayName": "Gemini 3.1 Pro",
+      "inputPerM": 2,
+      "cachedInputPerM": 0.2,
+      "cacheWritePerM": 0,
+      "outputPerM": 12
+    },
+    {
+      "model": "grok-code-fast-1",
+      "displayName": "Grok Code Fast 1",
+      "inputPerM": 0.2,
+      "cachedInputPerM": 0.02,
+      "cacheWritePerM": 0,
+      "outputPerM": 1.5
+    },
+    {
+      "model": "raptor-mini",
+      "displayName": "Raptor mini",
+      "inputPerM": 0.25,
+      "cachedInputPerM": 0.025,
+      "cacheWritePerM": 0,
+      "outputPerM": 2
+    },
+    {
+      "model": "goldeneye",
+      "displayName": "Goldeneye",
+      "inputPerM": 1.25,
+      "cachedInputPerM": 0.125,
+      "cacheWritePerM": 0,
+      "outputPerM": 10
+    }
+  ],
+  "annualLegacyMultipliers": [
+    { "model": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5", "premiumRequests": 0.33 },
+    { "model": "claude-opus-4.5", "displayName": "Claude Opus 4.5", "premiumRequests": 15 },
+    { "model": "claude-opus-4.6", "displayName": "Claude Opus 4.6", "premiumRequests": 27 },
+    { "model": "claude-opus-4.7", "displayName": "Claude Opus 4.7", "premiumRequests": 27 },
+    { "model": "claude-sonnet-4", "displayName": "Claude Sonnet 4", "premiumRequests": 1 },
+    { "model": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5", "premiumRequests": 6 },
+    { "model": "claude-sonnet-4.6", "displayName": "Claude Sonnet 4.6", "premiumRequests": 9 },
+    { "model": "gemini-2.5-pro", "displayName": "Gemini 2.5 Pro", "premiumRequests": 1 },
+    { "model": "gemini-3-flash", "displayName": "Gemini 3 Flash", "premiumRequests": 0.33 },
+    { "model": "gemini-3-pro-preview", "displayName": "Gemini 3 Pro", "premiumRequests": 6 },
+    { "model": "gemini-3.1-pro", "displayName": "Gemini 3.1 Pro", "premiumRequests": 6 },
+    { "model": "gpt-4o", "displayName": "GPT-4o", "premiumRequests": 0.33 },
+    { "model": "gpt-4o-mini", "displayName": "GPT-4o mini", "premiumRequests": 0.33 },
+    { "model": "gpt-4.1", "displayName": "GPT-4.1", "premiumRequests": 1 },
+    { "model": "gpt-5.1", "displayName": "GPT-5.1", "premiumRequests": 3 },
+    { "model": "gpt-5.1-codex", "displayName": "GPT-5.1-Codex", "premiumRequests": 3 },
+    { "model": "gpt-5.1-codex-mini", "displayName": "GPT-5.1-Codex-Mini", "premiumRequests": 0.33 },
+    { "model": "gpt-5.1-codex-max", "displayName": "GPT-5.1-Codex-Max", "premiumRequests": 3 },
+    { "model": "gpt-5.2", "displayName": "GPT-5.2", "premiumRequests": 3 },
+    { "model": "gpt-5.2-codex", "displayName": "GPT-5.2-Codex", "premiumRequests": 3 },
+    { "model": "gpt-5.3-codex", "displayName": "GPT-5.3-Codex", "premiumRequests": 6 },
+    { "model": "gpt-5.4", "displayName": "GPT-5.4", "premiumRequests": 6 },
+    { "model": "gpt-5.4-mini", "displayName": "GPT-5.4 mini", "premiumRequests": 6 },
+    { "model": "gpt-5-mini", "displayName": "GPT-5 mini", "premiumRequests": 0.33 },
+    { "model": "grok-code-fast-1", "displayName": "Grok Code Fast 1", "premiumRequests": 0.33 },
+    { "model": "raptor-mini", "displayName": "Raptor mini", "premiumRequests": 0.33 }
+  ]
+}

--- a/packages/types/src/pricing-data.json
+++ b/packages/types/src/pricing-data.json
@@ -229,31 +229,161 @@
     }
   ],
   "annualLegacyMultipliers": [
-    { "model": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5", "premiumRequests": 0.33 },
-    { "model": "claude-opus-4.5", "displayName": "Claude Opus 4.5", "premiumRequests": 15 },
-    { "model": "claude-opus-4.6", "displayName": "Claude Opus 4.6", "premiumRequests": 27 },
-    { "model": "claude-opus-4.7", "displayName": "Claude Opus 4.7", "premiumRequests": 27 },
-    { "model": "claude-sonnet-4", "displayName": "Claude Sonnet 4", "premiumRequests": 1 },
-    { "model": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5", "premiumRequests": 6 },
-    { "model": "claude-sonnet-4.6", "displayName": "Claude Sonnet 4.6", "premiumRequests": 9 },
-    { "model": "gemini-2.5-pro", "displayName": "Gemini 2.5 Pro", "premiumRequests": 1 },
-    { "model": "gemini-3-flash", "displayName": "Gemini 3 Flash", "premiumRequests": 0.33 },
-    { "model": "gemini-3-pro-preview", "displayName": "Gemini 3 Pro", "premiumRequests": 6 },
-    { "model": "gemini-3.1-pro", "displayName": "Gemini 3.1 Pro", "premiumRequests": 6 },
-    { "model": "gpt-4o", "displayName": "GPT-4o", "premiumRequests": 0.33 },
-    { "model": "gpt-4o-mini", "displayName": "GPT-4o mini", "premiumRequests": 0.33 },
-    { "model": "gpt-4.1", "displayName": "GPT-4.1", "premiumRequests": 1 },
-    { "model": "gpt-5.1", "displayName": "GPT-5.1", "premiumRequests": 3 },
-    { "model": "gpt-5.1-codex", "displayName": "GPT-5.1-Codex", "premiumRequests": 3 },
-    { "model": "gpt-5.1-codex-mini", "displayName": "GPT-5.1-Codex-Mini", "premiumRequests": 0.33 },
-    { "model": "gpt-5.1-codex-max", "displayName": "GPT-5.1-Codex-Max", "premiumRequests": 3 },
-    { "model": "gpt-5.2", "displayName": "GPT-5.2", "premiumRequests": 3 },
-    { "model": "gpt-5.2-codex", "displayName": "GPT-5.2-Codex", "premiumRequests": 3 },
-    { "model": "gpt-5.3-codex", "displayName": "GPT-5.3-Codex", "premiumRequests": 6 },
-    { "model": "gpt-5.4", "displayName": "GPT-5.4", "premiumRequests": 6 },
-    { "model": "gpt-5.4-mini", "displayName": "GPT-5.4 mini", "premiumRequests": 6 },
-    { "model": "gpt-5-mini", "displayName": "GPT-5 mini", "premiumRequests": 0.33 },
-    { "model": "grok-code-fast-1", "displayName": "Grok Code Fast 1", "premiumRequests": 0.33 },
-    { "model": "raptor-mini", "displayName": "Raptor mini", "premiumRequests": 0.33 }
+    {
+      "model": "claude-haiku-4.5",
+      "displayName": "Claude Haiku 4.5",
+      "currentPremiumRequests": 0.33,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "claude-opus-4.5",
+      "displayName": "Claude Opus 4.5",
+      "currentPremiumRequests": 3,
+      "premiumRequests": 15
+    },
+    {
+      "model": "claude-opus-4.6",
+      "displayName": "Claude Opus 4.6",
+      "currentPremiumRequests": 3,
+      "premiumRequests": 27
+    },
+    {
+      "model": "claude-opus-4.7",
+      "displayName": "Claude Opus 4.7",
+      "currentPremiumRequests": 15,
+      "premiumRequests": 27
+    },
+    {
+      "model": "claude-sonnet-4",
+      "displayName": "Claude Sonnet 4",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 1
+    },
+    {
+      "model": "claude-sonnet-4.5",
+      "displayName": "Claude Sonnet 4.5",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 6
+    },
+    {
+      "model": "claude-sonnet-4.6",
+      "displayName": "Claude Sonnet 4.6",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 9
+    },
+    {
+      "model": "gemini-2.5-pro",
+      "displayName": "Gemini 2.5 Pro",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 1
+    },
+    {
+      "model": "gemini-3-flash",
+      "displayName": "Gemini 3 Flash",
+      "currentPremiumRequests": 0.33,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "gemini-3-pro-preview",
+      "displayName": "Gemini 3 Pro",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 6
+    },
+    {
+      "model": "gemini-3.1-pro",
+      "displayName": "Gemini 3.1 Pro",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 6
+    },
+    {
+      "model": "gpt-4o",
+      "displayName": "GPT-4o",
+      "currentPremiumRequests": 0,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "gpt-4o-mini",
+      "displayName": "GPT-4o mini",
+      "currentPremiumRequests": 0,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "gpt-4.1",
+      "displayName": "GPT-4.1",
+      "currentPremiumRequests": 0,
+      "premiumRequests": 1
+    },
+    {
+      "model": "gpt-5.1",
+      "displayName": "GPT-5.1",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 3
+    },
+    {
+      "model": "gpt-5.1-codex",
+      "displayName": "GPT-5.1-Codex",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 3
+    },
+    {
+      "model": "gpt-5.1-codex-mini",
+      "displayName": "GPT-5.1-Codex-Mini",
+      "currentPremiumRequests": 0.33,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "gpt-5.1-codex-max",
+      "displayName": "GPT-5.1-Codex-Max",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 3
+    },
+    {
+      "model": "gpt-5.2",
+      "displayName": "GPT-5.2",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 3
+    },
+    {
+      "model": "gpt-5.2-codex",
+      "displayName": "GPT-5.2-Codex",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 3
+    },
+    {
+      "model": "gpt-5.3-codex",
+      "displayName": "GPT-5.3-Codex",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 6
+    },
+    {
+      "model": "gpt-5.4",
+      "displayName": "GPT-5.4",
+      "currentPremiumRequests": 1,
+      "premiumRequests": 6
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "displayName": "GPT-5.4 mini",
+      "currentPremiumRequests": 0.33,
+      "premiumRequests": 6
+    },
+    {
+      "model": "gpt-5-mini",
+      "displayName": "GPT-5 mini",
+      "currentPremiumRequests": 0,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "grok-code-fast-1",
+      "displayName": "Grok Code Fast 1",
+      "currentPremiumRequests": 0.25,
+      "premiumRequests": 0.33
+    },
+    {
+      "model": "raptor-mini",
+      "displayName": "Raptor mini",
+      "currentPremiumRequests": 0,
+      "premiumRequests": 0.33
+    }
   ]
 }

--- a/packages/types/src/pricing-data.json
+++ b/packages/types/src/pricing-data.json
@@ -16,6 +16,10 @@
     "tracePilotLegacyProviderEstimate": {
       "label": "TracePilot legacy provider estimate",
       "verifiedAt": "2026-05-04"
+    },
+    "tracePilotCurrentPremiumRequests": {
+      "label": "TracePilot current premium request defaults",
+      "verifiedAt": "2026-05-04"
     }
   },
   "aliases": {
@@ -384,6 +388,28 @@
       "displayName": "Raptor mini",
       "currentPremiumRequests": 0,
       "premiumRequests": 0.33
+    }
+  ],
+  "currentPremiumRequestDefaults": [
+    {
+      "model": "claude-opus-4.6-fast",
+      "displayName": "Claude Opus 4.6 Fast",
+      "currentPremiumRequests": 30
+    },
+    {
+      "model": "gpt-5.5",
+      "displayName": "GPT-5.5",
+      "currentPremiumRequests": 7.5
+    },
+    {
+      "model": "gpt-5.4-nano",
+      "displayName": "GPT-5.4 nano",
+      "currentPremiumRequests": 0.33
+    },
+    {
+      "model": "goldeneye",
+      "displayName": "Goldeneye",
+      "currentPremiumRequests": 1
     }
   ]
 }

--- a/packages/types/src/pricing-registry.ts
+++ b/packages/types/src/pricing-registry.ts
@@ -1,0 +1,130 @@
+import { MODEL_REGISTRY } from "./models.js";
+import type { PricingRegistryEntry, TokenRateSet } from "./pricing.js";
+import pricingData from "./pricing-data.json";
+
+interface PricingSourceData {
+  label: string;
+  url?: string;
+  verifiedAt: string;
+  effectiveFrom?: string;
+}
+
+interface UsagePricingData extends TokenRateSet {
+  model: string;
+  displayName: string;
+}
+
+interface LegacyMultiplierData {
+  model: string;
+  displayName: string;
+  premiumRequests: number;
+}
+
+interface PricingDataFile {
+  version: string;
+  sources: {
+    githubCopilotUsage: PricingSourceData;
+    annualLegacyMultipliers: PricingSourceData;
+    tracePilotLegacyProviderEstimate: PricingSourceData;
+  };
+  aliases: Record<string, string[]>;
+  githubCopilotUsage: UsagePricingData[];
+  annualLegacyMultipliers: LegacyMultiplierData[];
+}
+
+const DATA = pricingData as PricingDataFile;
+const GITHUB_USAGE_SOURCE = DATA.sources.githubCopilotUsage;
+const ANNUAL_MULTIPLIERS_SOURCE = DATA.sources.annualLegacyMultipliers;
+const LEGACY_PROVIDER_SOURCE = DATA.sources.tracePilotLegacyProviderEstimate;
+
+export const PRICING_REGISTRY_VERSION = DATA.version;
+export const GITHUB_USAGE_BILLING_EFFECTIVE_FROM =
+  GITHUB_USAGE_SOURCE.effectiveFrom ?? "2026-06-01";
+
+function sourceLabel(source: PricingSourceData): string {
+  return `${source.label} (verified ${source.verifiedAt})`;
+}
+
+function githubUsageEntry(row: UsagePricingData): PricingRegistryEntry {
+  return {
+    model: row.model,
+    displayName: row.displayName,
+    aliases: DATA.aliases[row.model],
+    billingProvider: "github-copilot",
+    pricingKind: "usage-token-rate",
+    rates: {
+      inputPerM: row.inputPerM,
+      cachedInputPerM: row.cachedInputPerM,
+      cacheWritePerM: row.cacheWritePerM,
+      outputPerM: row.outputPerM,
+    },
+    currency: "USD",
+    unit: "per-1m-tokens",
+    effectiveFrom: GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+    sourceLabel: sourceLabel(GITHUB_USAGE_SOURCE),
+    sourceUrl: GITHUB_USAGE_SOURCE.url,
+    status: "official",
+  };
+}
+
+function providerMirrorEntry(row: UsagePricingData): PricingRegistryEntry {
+  return {
+    ...githubUsageEntry(row),
+    billingProvider: "provider-wholesale",
+    effectiveFrom: undefined,
+    sourceLabel: `${sourceLabel(GITHUB_USAGE_SOURCE)}; local default mirrors GitHub's published token rates`,
+  };
+}
+
+function legacyMultiplierEntry(row: LegacyMultiplierData): PricingRegistryEntry {
+  return {
+    model: row.model,
+    displayName: row.displayName,
+    aliases: DATA.aliases[row.model],
+    billingProvider: "github-copilot",
+    pricingKind: "legacy-premium-request",
+    premiumRequests: row.premiumRequests,
+    currency: "USD",
+    unit: "premium-request",
+    effectiveFrom: ANNUAL_MULTIPLIERS_SOURCE.effectiveFrom,
+    sourceLabel: sourceLabel(ANNUAL_MULTIPLIERS_SOURCE),
+    sourceUrl: ANNUAL_MULTIPLIERS_SOURCE.url,
+    status: "official",
+  };
+}
+
+const documentedUsageModels = new Set(DATA.githubCopilotUsage.map((entry) => entry.model));
+
+export const GITHUB_COPILOT_USAGE_PRICING: readonly PricingRegistryEntry[] =
+  DATA.githubCopilotUsage.map(githubUsageEntry);
+
+export const GITHUB_ANNUAL_LEGACY_MULTIPLIERS: readonly PricingRegistryEntry[] =
+  DATA.annualLegacyMultipliers.map(legacyMultiplierEntry);
+
+export const PROVIDER_WHOLESALE_PRICING: readonly PricingRegistryEntry[] = [
+  ...DATA.githubCopilotUsage.map(providerMirrorEntry),
+  ...MODEL_REGISTRY.filter((model) => !documentedUsageModels.has(model.id)).map((model) => ({
+    model: model.id,
+    displayName: model.name,
+    aliases: DATA.aliases[model.id],
+    billingProvider: "provider-wholesale" as const,
+    pricingKind: "usage-token-rate" as const,
+    rates: {
+      inputPerM: model.inputPerM,
+      cachedInputPerM: model.cachedInputPerM,
+      outputPerM: model.outputPerM,
+      cacheWritePerM: 0,
+    },
+    premiumRequests: model.premiumRequests,
+    currency: "USD" as const,
+    unit: "per-1m-tokens" as const,
+    sourceLabel: `${sourceLabel(LEGACY_PROVIDER_SOURCE)}; model not listed on GitHub pricing page`,
+    status: "estimated" as const,
+  })),
+];
+
+export const PRICING_REGISTRY: readonly PricingRegistryEntry[] = [
+  ...PROVIDER_WHOLESALE_PRICING,
+  ...GITHUB_COPILOT_USAGE_PRICING,
+  ...GITHUB_ANNUAL_LEGACY_MULTIPLIERS,
+];

--- a/packages/types/src/pricing-registry.ts
+++ b/packages/types/src/pricing-registry.ts
@@ -1,6 +1,6 @@
 import { MODEL_REGISTRY } from "./models.js";
 import type { PricingRegistryEntry, TokenRateSet } from "./pricing.js";
-import pricingData from "./pricing-data.json";
+import pricingData from "./pricing-data.json" with { type: "json" };
 
 interface PricingSourceData {
   label: string;

--- a/packages/types/src/pricing.ts
+++ b/packages/types/src/pricing.ts
@@ -1,0 +1,330 @@
+import type { ModelPriceEntry } from "./config.js";
+import { GITHUB_USAGE_BILLING_EFFECTIVE_FROM, PRICING_REGISTRY } from "./pricing-registry.js";
+import type { ModelMetricDetail, ShutdownMetrics } from "./session.js";
+
+export const AI_CREDIT_USD = 0.01;
+export const NANO_AIU_PER_AI_CREDIT = 1_000_000_000;
+export {
+  GITHUB_ANNUAL_LEGACY_MULTIPLIERS,
+  GITHUB_COPILOT_USAGE_PRICING,
+  GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+  PRICING_REGISTRY,
+  PRICING_REGISTRY_VERSION,
+  PROVIDER_WHOLESALE_PRICING,
+} from "./pricing-registry.js";
+
+export type PricingProvider = "github-copilot" | "provider-wholesale" | "user";
+export type PricingKind = "legacy-premium-request" | "usage-token-rate" | "observed-nano-aiu";
+export type PricingStatus = "official" | "estimated" | "user-override" | "deprecated";
+export type PricingUnit = "per-1m-tokens" | "premium-request" | "nano-aiu";
+export type PricingRateMode = "session-time" | "latest";
+
+export interface TokenRateSet {
+  inputPerM: number;
+  cachedInputPerM: number;
+  outputPerM: number;
+  cacheWritePerM?: number;
+  reasoningPerM?: number;
+}
+
+export interface PricingRegistryEntry {
+  model: string;
+  displayName?: string;
+  aliases?: string[];
+  billingProvider: PricingProvider;
+  pricingKind: PricingKind;
+  rates?: TokenRateSet;
+  premiumRequests?: number;
+  currency: "USD";
+  unit: PricingUnit;
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  sourceLabel: string;
+  sourceUrl?: string;
+  status: PricingStatus;
+}
+
+export interface TokenUsageForCost {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheReadTokens?: number | null;
+  cacheWriteTokens?: number | null;
+  reasoningTokens?: number | null;
+}
+
+export interface PricingLookupOptions {
+  billingProvider?: PricingProvider;
+  pricingKind?: PricingKind;
+  at?: string | Date | null;
+  rateMode?: PricingRateMode;
+  userOverrides?: readonly PricingRegistryEntry[];
+}
+
+export type CostBreakdownStatus = "priced" | "unknown-model" | "missing-rate";
+
+export interface TokenCostBreakdown {
+  status: CostBreakdownStatus;
+  model: string;
+  matchedModel?: string;
+  entry?: PricingRegistryEntry;
+  inputCost: number;
+  cachedInputCost: number;
+  cacheWriteCost: number;
+  outputCost: number;
+  reasoningCost: number;
+  totalCost: number | null;
+  aiCredits: number | null;
+  warnings: string[];
+}
+
+export interface PricingComparisonBreakdown {
+  legacyCopilotCost: number;
+  usageBasedCopilot: TokenCostBreakdown;
+  wholesaleProvider: TokenCostBreakdown;
+  june2026PreviewDelta: number | null;
+}
+
+export function normalizeModelName(modelName: string): string {
+  return modelName
+    .trim()
+    .replace(/^models\//i, "")
+    .replace(/[_\s]+/g, "-")
+    .replace(/--+/g, "-")
+    .toLowerCase();
+}
+
+function parseEffectiveDate(value?: string | Date | null): number | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function isEffective(entry: PricingRegistryEntry, at: string | Date | null | undefined): boolean {
+  const atTime = parseEffectiveDate(at);
+  if (atTime == null) return true;
+  const from = parseEffectiveDate(entry.effectiveFrom);
+  const to = parseEffectiveDate(entry.effectiveTo);
+  return (from == null || atTime >= from) && (to == null || atTime < to);
+}
+
+function entryAliases(entry: PricingRegistryEntry): string[] {
+  return [entry.model, ...(entry.aliases ?? [])].map(normalizeModelName);
+}
+
+function modelMatches(entry: PricingRegistryEntry, normalizedModel: string): boolean {
+  return entryAliases(entry).some(
+    (alias) => normalizedModel === alias || normalizedModel.startsWith(`${alias}-`),
+  );
+}
+
+function compareEffectiveFrom(a: PricingRegistryEntry, b: PricingRegistryEntry): number {
+  return (parseEffectiveDate(b.effectiveFrom) ?? 0) - (parseEffectiveDate(a.effectiveFrom) ?? 0);
+}
+
+function longestAliasLength(entry: PricingRegistryEntry): number {
+  return Math.max(...entryAliases(entry).map((alias) => alias.length));
+}
+
+export function modelPriceEntryToPricingEntry(
+  entry: ModelPriceEntry,
+  overrides?: Partial<PricingRegistryEntry>,
+): PricingRegistryEntry {
+  return {
+    model: entry.model,
+    aliases: entry.aliases,
+    billingProvider: entry.source ?? "user",
+    pricingKind: entry.pricingKind ?? "usage-token-rate",
+    rates: {
+      inputPerM: entry.inputPerM,
+      cachedInputPerM: entry.cachedInputPerM,
+      outputPerM: entry.outputPerM,
+      cacheWritePerM: entry.cacheWritePerM ?? 0,
+      reasoningPerM: entry.reasoningPerM,
+    },
+    premiumRequests: entry.premiumRequests,
+    currency: "USD",
+    unit: "per-1m-tokens",
+    effectiveFrom: entry.effectiveFrom,
+    effectiveTo: entry.effectiveTo,
+    sourceLabel: entry.sourceLabel ?? "Local user override",
+    sourceUrl: entry.sourceUrl,
+    status: entry.status ?? "user-override",
+    ...overrides,
+  };
+}
+
+export function modelPriceEntriesToPricingRegistry(
+  entries: readonly ModelPriceEntry[],
+): PricingRegistryEntry[] {
+  return entries.map((entry) =>
+    modelPriceEntryToPricingEntry(entry, {
+      billingProvider: "provider-wholesale",
+      status: "user-override",
+      sourceLabel: entry.sourceLabel ?? "Local settings override",
+    }),
+  );
+}
+
+export function resolvePricingEntry(
+  modelName: string,
+  options: PricingLookupOptions = {},
+): PricingRegistryEntry | undefined {
+  const normalizedModel = normalizeModelName(modelName);
+  const billingProvider = options.billingProvider ?? "provider-wholesale";
+  const pricingKind = options.pricingKind ?? "usage-token-rate";
+  const rateMode = options.rateMode ?? "session-time";
+  // Local direct-API/provider overrides intentionally default to latest-rate
+  // lookups in the desktop store because the persisted settings table is a
+  // mutable override list, not a historical pricing ledger.
+  const registry = [...(options.userOverrides ?? []), ...PRICING_REGISTRY];
+  const matches = registry
+    .filter(
+      (entry) =>
+        entry.billingProvider === billingProvider &&
+        entry.pricingKind === pricingKind &&
+        modelMatches(entry, normalizedModel),
+    )
+    .sort((a, b) => {
+      if (a.status === "user-override" && b.status !== "user-override") return -1;
+      if (a.status !== "user-override" && b.status === "user-override") return 1;
+      return longestAliasLength(b) - longestAliasLength(a) || compareEffectiveFrom(a, b);
+    });
+
+  if (rateMode === "latest") return matches[0];
+  return matches.find((entry) => isEffective(entry, options.at));
+}
+
+export function calculateTokenCost(
+  modelName: string,
+  usage: TokenUsageForCost,
+  options: PricingLookupOptions = {},
+): TokenCostBreakdown {
+  const entry = resolvePricingEntry(modelName, options);
+  if (!entry) {
+    return {
+      status: "unknown-model",
+      model: modelName,
+      inputCost: 0,
+      cachedInputCost: 0,
+      cacheWriteCost: 0,
+      outputCost: 0,
+      reasoningCost: 0,
+      totalCost: null,
+      aiCredits: null,
+      warnings: ["No matching price entry for model."],
+    };
+  }
+
+  if (!entry.rates) {
+    return {
+      status: "missing-rate",
+      model: modelName,
+      matchedModel: entry.model,
+      entry,
+      inputCost: 0,
+      cachedInputCost: 0,
+      cacheWriteCost: 0,
+      outputCost: 0,
+      reasoningCost: 0,
+      totalCost: null,
+      aiCredits: null,
+      warnings: ["Matched price entry does not include token rates."],
+    };
+  }
+
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const cacheReadTokens = usage.cacheReadTokens ?? 0;
+  const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
+  const reasoningTokens = usage.reasoningTokens ?? 0;
+  const nonCachedInputTokens = Math.max(inputTokens - cacheReadTokens, 0);
+  const inputCost = (nonCachedInputTokens / 1_000_000) * entry.rates.inputPerM;
+  const cachedInputCost = (cacheReadTokens / 1_000_000) * entry.rates.cachedInputPerM;
+  const cacheWriteCost = (cacheWriteTokens / 1_000_000) * (entry.rates.cacheWritePerM ?? 0);
+  const reasoningCost = (reasoningTokens / 1_000_000) * (entry.rates.reasoningPerM ?? 0);
+  const outputCost = (outputTokens / 1_000_000) * entry.rates.outputPerM;
+  const totalCost = inputCost + cachedInputCost + cacheWriteCost + outputCost + reasoningCost;
+
+  return {
+    status: "priced",
+    model: modelName,
+    matchedModel: entry.model,
+    entry,
+    inputCost,
+    cachedInputCost,
+    cacheWriteCost,
+    outputCost,
+    reasoningCost,
+    totalCost,
+    aiCredits: totalCost / AI_CREDIT_USD,
+    warnings:
+      cacheWriteTokens > 0 && entry.rates.cacheWritePerM == null
+        ? ["Cache-write tokens were present but this price entry has no cache-write rate."]
+        : [],
+  };
+}
+
+export function sumTokenCosts(costs: readonly TokenCostBreakdown[]): TokenCostBreakdown {
+  const warnings = costs.flatMap((cost) => cost.warnings);
+  const firstUnknown = costs.find((cost) => cost.status !== "priced");
+  const pricedCosts = costs.filter((cost) => cost.status === "priced");
+  const totalCost = pricedCosts.reduce((sum, cost) => sum + (cost.totalCost ?? 0), 0);
+  return {
+    status: firstUnknown ? firstUnknown.status : "priced",
+    model: "total",
+    inputCost: pricedCosts.reduce((sum, cost) => sum + cost.inputCost, 0),
+    cachedInputCost: pricedCosts.reduce((sum, cost) => sum + cost.cachedInputCost, 0),
+    cacheWriteCost: pricedCosts.reduce((sum, cost) => sum + cost.cacheWriteCost, 0),
+    outputCost: pricedCosts.reduce((sum, cost) => sum + cost.outputCost, 0),
+    reasoningCost: pricedCosts.reduce((sum, cost) => sum + cost.reasoningCost, 0),
+    totalCost: costs.length === pricedCosts.length ? totalCost : null,
+    aiCredits: costs.length === pricedCosts.length ? totalCost / AI_CREDIT_USD : null,
+    warnings,
+  };
+}
+
+export function calculateMetricsTokenCost(
+  modelMetrics: Record<string, ModelMetricDetail> | null | undefined,
+  options: PricingLookupOptions = {},
+): TokenCostBreakdown {
+  if (!modelMetrics) return sumTokenCosts([]);
+  return sumTokenCosts(
+    Object.entries(modelMetrics).map(([model, metric]) =>
+      calculateTokenCost(model, metric.usage ?? {}, options),
+    ),
+  );
+}
+
+export function calculateObservedAiuCost(totalNanoAiu: number | null | undefined): number | null {
+  if (totalNanoAiu == null) return null;
+  return (totalNanoAiu / NANO_AIU_PER_AI_CREDIT) * AI_CREDIT_USD;
+}
+
+export function calculatePricingComparison(
+  metrics: ShutdownMetrics,
+  costPerPremiumRequest: number,
+  userOverrides: readonly PricingRegistryEntry[] = [],
+  at?: string | Date | null,
+): PricingComparisonBreakdown {
+  const legacyCopilotCost = (metrics.totalPremiumRequests ?? 0) * costPerPremiumRequest;
+  const usageBasedCopilot = calculateMetricsTokenCost(metrics.modelMetrics, {
+    billingProvider: "github-copilot",
+    pricingKind: "usage-token-rate",
+    at: at ?? GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+  });
+  const wholesaleProvider = calculateMetricsTokenCost(metrics.modelMetrics, {
+    billingProvider: "provider-wholesale",
+    pricingKind: "usage-token-rate",
+    at,
+    userOverrides,
+  });
+  const june2026PreviewDelta =
+    usageBasedCopilot.totalCost == null ? null : usageBasedCopilot.totalCost - legacyCopilotCost;
+  return {
+    legacyCopilotCost,
+    usageBasedCopilot,
+    wholesaleProvider,
+    june2026PreviewDelta,
+  };
+}

--- a/packages/types/tests/pricing.test.ts
+++ b/packages/types/tests/pricing.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import type { ModelPriceEntry } from "../src/config.js";
+import {
+  calculateObservedAiuCost,
+  calculatePricingComparison,
+  calculateTokenCost,
+  GITHUB_COPILOT_USAGE_PRICING,
+  GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+  modelPriceEntriesToPricingRegistry,
+  normalizeModelName,
+  PROVIDER_WHOLESALE_PRICING,
+  resolvePricingEntry,
+} from "../src/pricing.js";
+import type { ShutdownMetrics } from "../src/session.js";
+
+describe("pricing registry", () => {
+  it("normalizes documentation names and event slugs consistently", () => {
+    expect(normalizeModelName("GPT-5.2 Codex")).toBe("gpt-5.2-codex");
+    expect(normalizeModelName("models/Claude Sonnet 4.6")).toBe("claude-sonnet-4.6");
+  });
+
+  it("matches model aliases without substring-only fallback", () => {
+    const match = resolvePricingEntry("Claude Sonnet 4.6", {
+      billingProvider: "github-copilot",
+      pricingKind: "usage-token-rate",
+      at: GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+    });
+    expect(match?.model).toBe("claude-sonnet-4.6");
+
+    const unknown = resolvePricingEntry("not-claude-sonnet-4.6-but-contains-it", {
+      billingProvider: "github-copilot",
+      pricingKind: "usage-token-rate",
+      at: GITHUB_USAGE_BILLING_EFFECTIVE_FROM,
+    });
+    expect(unknown).toBeUndefined();
+  });
+
+  it("honors effective dates for session-time lookup", () => {
+    expect(
+      resolvePricingEntry("gpt-5.4", {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at: "2026-05-31",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolvePricingEntry("gpt-5.4", {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at: "2026-06-01",
+      })?.rates?.outputPerM,
+    ).toBe(15);
+  });
+
+  it("derives provider defaults from the same published rates as GitHub usage pricing", () => {
+    for (const usageEntry of GITHUB_COPILOT_USAGE_PRICING) {
+      const providerEntry = PROVIDER_WHOLESALE_PRICING.find(
+        (entry) => entry.model === usageEntry.model,
+      );
+      expect(providerEntry?.rates).toEqual(usageEntry.rates);
+      expect(providerEntry?.sourceLabel).toContain("mirrors GitHub's published token rates");
+    }
+  });
+
+  it("calculates usage-based token cost with cache reads and cache writes", () => {
+    const cost = calculateTokenCost(
+      "claude-sonnet-4.6",
+      {
+        inputTokens: 1_000_000,
+        cacheReadTokens: 400_000,
+        cacheWriteTokens: 100_000,
+        outputTokens: 200_000,
+      },
+      {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at: "2026-06-01",
+      },
+    );
+    expect(cost.status).toBe("priced");
+    expect(cost.inputCost).toBeCloseTo(1.8);
+    expect(cost.cachedInputCost).toBeCloseTo(0.12);
+    expect(cost.cacheWriteCost).toBeCloseTo(0.375);
+    expect(cost.outputCost).toBeCloseTo(3);
+    expect(cost.totalCost).toBeCloseTo(5.295);
+  });
+
+  it("treats missing token fields as zero", () => {
+    const cost = calculateTokenCost(
+      "gpt-5.5",
+      {},
+      {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at: "2026-06-01",
+      },
+    );
+    expect(cost.status).toBe("priced");
+    expect(cost.totalCost).toBe(0);
+  });
+
+  it("returns structured unknown state for unknown models", () => {
+    const cost = calculateTokenCost(
+      "unknown-frontier-model",
+      { inputTokens: 100 },
+      {
+        billingProvider: "github-copilot",
+        pricingKind: "usage-token-rate",
+        at: "2026-06-01",
+      },
+    );
+    expect(cost.status).toBe("unknown-model");
+    expect(cost.totalCost).toBeNull();
+  });
+
+  it("lets user provider overrides take precedence over bundled wholesale rates", () => {
+    const override: ModelPriceEntry = {
+      model: "gpt-5.5",
+      inputPerM: 1,
+      cachedInputPerM: 0.5,
+      cacheWritePerM: 0,
+      outputPerM: 2,
+      premiumRequests: 1,
+    };
+    const cost = calculateTokenCost(
+      "GPT-5.5",
+      { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      {
+        billingProvider: "provider-wholesale",
+        pricingKind: "usage-token-rate",
+        userOverrides: modelPriceEntriesToPricingRegistry([override]),
+      },
+    );
+    expect(cost.entry?.status).toBe("user-override");
+    expect(cost.totalCost).toBe(3);
+  });
+
+  it("compares legacy premium requests with usage-based preview", () => {
+    const metrics: ShutdownMetrics = {
+      totalPremiumRequests: 10,
+      modelMetrics: {
+        "gpt-5.5": {
+          requests: { count: 1, cost: 10 },
+          usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+        },
+      },
+    };
+    const comparison = calculatePricingComparison(metrics, 0.04, [], "2026-06-01");
+    expect(comparison.legacyCopilotCost).toBeCloseTo(0.4);
+    expect(comparison.usageBasedCopilot.totalCost).toBeCloseTo(35);
+    expect(comparison.june2026PreviewDelta).toBeCloseTo(34.6);
+  });
+
+  it("converts observed nano AIU telemetry with explicit nano units", () => {
+    expect(calculateObservedAiuCost(1_000_000_000)).toBe(0.01);
+  });
+});

--- a/packages/types/tests/pricing.test.ts
+++ b/packages/types/tests/pricing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelPriceEntry } from "../src/config.js";
+import { getDefaultWholesalePrices, MODEL_REGISTRY } from "../src/models.js";
 import {
   calculateObservedAiuCost,
   calculatePricingComparison,
@@ -11,6 +12,7 @@ import {
   PROVIDER_WHOLESALE_PRICING,
   resolvePricingEntry,
 } from "../src/pricing.js";
+import pricingData from "../src/pricing-data.json";
 import type { ShutdownMetrics } from "../src/session.js";
 
 describe("pricing registry", () => {
@@ -59,6 +61,51 @@ describe("pricing registry", () => {
       );
       expect(providerEntry?.rates).toEqual(usageEntry.rates);
       expect(providerEntry?.sourceLabel).toContain("mirrors GitHub's published token rates");
+    }
+  });
+
+  it("keeps documented usage models in the supported model registry", () => {
+    const modelIds = new Set(MODEL_REGISTRY.map((model) => model.id));
+    for (const usageEntry of pricingData.githubCopilotUsage) {
+      expect(modelIds.has(usageEntry.model), `${usageEntry.model} should be supported`).toBe(true);
+    }
+  });
+
+  it("derives default local rates and current multipliers from pricing data", () => {
+    const defaultsByModel = new Map(
+      getDefaultWholesalePrices().map((entry) => [entry.model, entry]),
+    );
+    const modelsById = new Map(MODEL_REGISTRY.map((entry) => [entry.id, entry]));
+
+    for (const usageEntry of pricingData.githubCopilotUsage) {
+      const defaultPrice = defaultsByModel.get(usageEntry.model);
+      expect(defaultPrice?.inputPerM).toBe(usageEntry.inputPerM);
+      expect(defaultPrice?.cachedInputPerM).toBe(usageEntry.cachedInputPerM);
+      expect(defaultPrice?.cacheWritePerM).toBe(usageEntry.cacheWritePerM);
+      expect(defaultPrice?.outputPerM).toBe(usageEntry.outputPerM);
+    }
+
+    for (const multiplier of pricingData.annualLegacyMultipliers) {
+      const model = modelsById.get(multiplier.model);
+      if (!model || multiplier.currentPremiumRequests == null) continue;
+      expect(model.premiumRequests).toBe(multiplier.currentPremiumRequests);
+    }
+  });
+
+  it("prefers the most specific alias match for overlapping model prefixes", () => {
+    for (const model of [
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5.1-codex-mini",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+    ]) {
+      expect(
+        resolvePricingEntry(model, {
+          billingProvider: "provider-wholesale",
+          pricingKind: "usage-token-rate",
+        })?.model,
+      ).toBe(model);
     }
   });
 

--- a/packages/types/tests/pricing.test.ts
+++ b/packages/types/tests/pricing.test.ts
@@ -90,6 +90,18 @@ describe("pricing registry", () => {
       if (!model || multiplier.currentPremiumRequests == null) continue;
       expect(model.premiumRequests).toBe(multiplier.currentPremiumRequests);
     }
+
+    const multiplierIds = new Set([
+      ...pricingData.annualLegacyMultipliers
+        .filter((entry) => entry.currentPremiumRequests != null)
+        .map((entry) => entry.model),
+      ...pricingData.currentPremiumRequestDefaults.map((entry) => entry.model),
+    ]);
+    for (const model of MODEL_REGISTRY) {
+      expect(multiplierIds.has(model.id), `${model.id} should have pricing-data multiplier`).toBe(
+        true,
+      );
+    }
   });
 
   it("prefers the most specific alias match for overlapping model prefixes", () => {

--- a/packages/types/tests/pricing.test.ts
+++ b/packages/types/tests/pricing.test.ts
@@ -12,7 +12,7 @@ import {
   PROVIDER_WHOLESALE_PRICING,
   resolvePricingEntry,
 } from "../src/pricing.js";
-import pricingData from "../src/pricing-data.json";
+import pricingData from "../src/pricing-data.json" with { type: "json" };
 import type { ShutdownMetrics } from "../src/session.js";
 
 describe("pricing registry", () => {


### PR DESCRIPTION
## Summary
- add a versioned pricing data source for Copilot usage rates, current premium-request defaults, June 2026 annual-plan multipliers, aliases, source URLs, verification date, and effective dates
- derive GitHub Copilot usage estimates and default local Direct API/token-rate estimates from the same pricing data rows, while preserving explicit user overrides
- add structured pricing lookup/cost breakdown helpers with effective-date handling, unknown-model states, cache-write support, observed AI Credit conversion, and comparison deltas
- update metrics/settings/analytics/model comparison UI labels to distinguish Legacy Copilot, GitHub Copilot (usage), Direct API (estimate), and Observed AI Credits
- extend Rust config defaults/round-trip support for pricing provenance and shared default rates
- document the billing model, source assumptions, switchover strategy, and future update path

## Review notes
- researched GitHub's usage-based billing blog and pricing docs live; source assumptions are captured in `docs/pricing-model.md`
- Opus 4.7 review found model/default drift risks; addressed with shared current multipliers, missing documented models in TS/Rust registries, and parity tests
- Direct API defaults now align with GitHub Copilot usage rates for documented models unless a user explicitly overrides local pricing

## Validation
- `pnpm --filter @tracepilot/types test -- pricing.test.ts`
- `pnpm --filter @tracepilot/desktop test -- src/stores/preferences/__tests__/pricing.test.ts src/composables/__tests__/useSessionMetrics.test.ts src/composables/__tests__/useModelComparison.test.ts src/__tests__/views/analytics-views.test.ts src/components/modelComparison/__tests__/ModelComparisonChildren.test.ts`
- `pnpm --filter @tracepilot/types typecheck`
- `pnpm --filter @tracepilot/desktop typecheck`
- `pnpm -r typecheck`
- `pnpm exec biome check ...` on touched TS/Vue/CSS/MD files
- `cargo test -p tracepilot-orchestrator models`
- `cargo test -p tracepilot-tauri-bindings pricing`
- `node scripts\check-file-sizes.mjs`