### PR TITLE
🎨 Palette: Accessible icon buttons in WorktreeList

### DIFF
--- a/apps/desktop/src/components/worktree/WorktreeList.vue
+++ b/apps/desktop/src/components/worktree/WorktreeList.vue
@@ -162,19 +162,21 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
         <button
           class="icon-btn"
           :title="wt.isMainWorktree ? 'Cannot lock main worktree' : wt.isLocked ? 'Unlock Worktree' : 'Lock Worktree'"
+          :aria-label="wt.isMainWorktree ? 'Cannot lock main worktree' : wt.isLocked ? 'Unlock Worktree' : 'Lock Worktree'"
           :disabled="wt.isMainWorktree"
           @click="wt.isLocked ? emit('unlock', wt) : emit('lock', wt)"
         >
-          <svg v-if="wt.isLocked" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 5-5 5 5 0 0 1 5 5" /></svg>
-          <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
+          <svg v-if="wt.isLocked" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 5-5 5 5 0 0 1 5 5" /></svg>
+          <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
         </button>
         <button
           class="icon-btn icon-btn--danger"
           :title="wt.isMainWorktree ? 'Cannot remove main worktree' : wt.isLocked ? 'Unlock to remove' : 'Remove'"
+          :aria-label="wt.isMainWorktree ? 'Cannot remove main worktree' : wt.isLocked ? 'Unlock to remove' : 'Remove'"
           :disabled="wt.isMainWorktree || wt.isLocked"
           @click="emit('delete', wt)"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
         </button>
       </div>
     </div>


### PR DESCRIPTION
### 💡 What
Added dynamically bound `aria-label`s to the lock/unlock and remove icon-only buttons in the `WorktreeList.vue` component. I also added `aria-hidden="true"` to the inner decorative SVGs inside these buttons.

### 🎯 Why
These buttons previously only relied on the `title` attribute for tooltip text, which is an anti-pattern for pure accessibility and often insufficient or poorly supported across different screen readers and devices. A true `aria-label` provides a reliable semantic label. By hiding the inner SVG icons with `aria-hidden="true"`, we also ensure screen readers don't attempt to confusingly announce the graphical element alongside the new label.

### 📸 Before/After
*N/A - Purely semantic HTML changes, no visual layout changes occurred.*

### ♿ Accessibility
Significant improvement for users utilizing assistive technologies (like VoiceOver or NVDA) who navigate worktrees. They will now hear precise, actionable descriptions ("Lock Worktree", "Remove", "Unlock to remove", etc.) instead of ambiguous or silent buttons.

---
*PR created automatically by Jules for task [4884178491232870270](https://jules.google.com/task/4884178491232870270) started by @MattShelton04*