### PR TITLE
🎨 Palette: Add `aria-label` and `aria-hidden` to raw unicode icon buttons

### DIFF
--- a/apps/desktop/src/ChildApp.vue
+++ b/apps/desktop/src/ChildApp.vue
@@ -99,7 +99,9 @@ async function closeWindow() {
       <!-- Compact title bar -->
       <div class="child-titlebar">
         <span class="child-titlebar-label">{{ sessionLabel }}</span>
-        <button class="child-titlebar-close" title="Close window" @click="closeWindow">×</button>
+        <button class="child-titlebar-close" title="Close window" aria-label="Close window" @click="closeWindow">
+          <span aria-hidden="true">×</span>
+        </button>
       </div>
 
       <!-- Content -->

--- a/apps/desktop/src/components/conversation/SdkSteeringPanel.vue
+++ b/apps/desktop/src/components/conversation/SdkSteeringPanel.vue
@@ -51,7 +51,9 @@ provide(SdkSteeringKey, ctx);
         <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm-.75 3.75a.75.75 0 011.5 0v3.5a.75.75 0 01-1.5 0v-3.5zM8 11a1 1 0 110 2 1 1 0 010-2z"/>
       </svg>
       <span class="cb-error-text">{{ ctx.inlineError }}</span>
-      <button class="cb-error-dismiss" title="Dismiss">✕</button>
+      <button class="cb-error-dismiss" title="Dismiss" aria-label="Dismiss">
+        <span aria-hidden="true">✕</span>
+      </button>
     </div>
 
     <SdkSteeringLinkPrompt v-if="!ctx.isLinked" />

--- a/apps/desktop/src/components/layout/AlertCenterDrawer.vue
+++ b/apps/desktop/src/components/layout/AlertCenterDrawer.vue
@@ -94,7 +94,7 @@ function handleClose() {
               aria-label="Close alert center"
               @click="handleClose"
             >
-              ×
+              <span aria-hidden="true">×</span>
             </button>
           </div>
         </div>
@@ -127,9 +127,10 @@ function handleClose() {
             <button
               class="alert-item-dismiss"
               title="Dismiss"
+              aria-label="Dismiss alert"
               @click.stop="alertsStore.dismiss(alert.id)"
             >
-              ×
+              <span aria-hidden="true">×</span>
             </button>
           </div>
         </div>

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -227,7 +227,7 @@ async function handleVersionClick() {
               aria-label="Dismiss update notification"
               @click="dismissUpdate"
             >
-              ×
+              <span aria-hidden="true">×</span>
             </button>
           </div>
           <div class="sidebar-update-actions">

--- a/apps/desktop/src/views/mcp/McpManagerView.vue
+++ b/apps/desktop/src/views/mcp/McpManagerView.vue
@@ -181,7 +181,9 @@ async function handleImport() {
     <!-- Error -->
     <div v-if="store.error" class="error-banner">
       <span>{{ store.error }}</span>
-      <button class="error-dismiss" @click="store.clearError()">×</button>
+      <button class="error-dismiss" aria-label="Dismiss error" @click="store.clearError()">
+        <span aria-hidden="true">×</span>
+      </button>
     </div>
 
     <!-- Loading -->

--- a/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
+++ b/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
@@ -69,7 +69,9 @@ const tabNavItems = computed(() =>
             <code>COPILOT_AUTO_UPDATE=false</code> to prevent.
             We don't recommend disabling auto-update and suggest reinjecting after every update.
           </span>
-          <button class="warning-banner-close" title="Dismiss" @click="dismissWarning()">✕</button>
+          <button class="warning-banner-close" title="Dismiss" aria-label="Dismiss warning" @click="dismissWarning()">
+            <span aria-hidden="true">✕</span>
+          </button>
         </div>
       </Transition>
 

--- a/apps/desktop/src/views/skills/SkillsManagerView.vue
+++ b/apps/desktop/src/views/skills/SkillsManagerView.vue
@@ -195,7 +195,9 @@ async function handleDeleteSkill(dir: string) {
         <div class="modal">
           <div class="modal__header">
             <h3 class="modal__title">New Skill</h3>
-            <button class="modal__close" @click="showNewSkillModal = false">✕</button>
+            <button class="modal__close" aria-label="Close modal" @click="showNewSkillModal = false">
+              <span aria-hidden="true">✕</span>
+            </button>
           </div>
           <div class="modal__body">
             <label class="modal__label">Name</label>


### PR DESCRIPTION
## 💡 What
Added `aria-hidden="true"` to purely decorative unicode characters (`✕`, `×`) used inside close/dismiss buttons across 7 Vue components, and ensured each parent button has an explicit `aria-label` describing its action.

## 🎯 Why
Screen readers naturally read raw characters aloud (e.g., announcing `✕` as "multiply" or "times"). This leads to confusing auditory experiences for users relying on assistive technology when interacting with dismissable UI elements like alerts, banners, sidebars, and modals.

## 📸 Before/After
* **Before:** `<button class="cb-error-dismiss" title="Dismiss">✕</button>`
* **After:** `<button class="cb-error-dismiss" title="Dismiss" aria-label="Dismiss"><span aria-hidden="true">✕</span></button>`

## ♿ Accessibility
This change ensures that screen readers will now cleanly announce the button's action (e.g., "Dismiss, button") instead of vocalizing decorative mathematical symbols, improving the experience for visually impaired users.

---
*PR created automatically by Jules for task [18416986737783675290](https://jules.google.com/task/18416986737783675290) started by @MattShelton04*