### PR TITLE
Improve analytics pricing and session UI objective display

### DIFF
--- a/apps/desktop/src/__tests__/components/layout/AppSidebar.test.ts
+++ b/apps/desktop/src/__tests__/components/layout/AppSidebar.test.ts
@@ -1,0 +1,112 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import { STORAGE_KEYS } from "@/config/storageKeys";
+
+// Mock the @tracepilot/client module so the preferences store does not try
+// to talk to Tauri during these UI tests.
+vi.mock("@tracepilot/client", async () => {
+  const { createClientMock } = await import("../../mocks/client");
+  return createClientMock();
+});
+
+// Stub heavy composables — none of them are exercised by collapse-toggle
+// behaviour, but they run synchronously inside <script setup>.
+vi.mock("@/composables/useAppVersion", () => ({
+  useAppVersion: () => ({ appVersion: ref("0.0.0-test") }),
+}));
+vi.mock("@/composables/useUpdateCheck", () => ({
+  useUpdateCheck: () => ({ updateResult: ref(null) }),
+}));
+vi.mock("@/composables/useWhatsNew", () => ({
+  useWhatsNew: () => ({ openWhatsNew: vi.fn() }),
+}));
+vi.mock("@/composables/useSidebarNav", () => ({
+  useSidebarNav: () => ({
+    visiblePrimaryNav: ref([]),
+    visibleAdvancedNav: ref([]),
+    orchestrationNav: ref([]),
+    visibleConfigNav: ref([]),
+  }),
+}));
+
+vi.mock("vue-router", async () => {
+  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  return {
+    ...actual,
+    useRoute: () => ({ meta: { sidebarId: "sessions" } }),
+  };
+});
+
+const routerLinkStub = {
+  props: ["to"],
+  template: "<a :href=\"typeof to === 'string' ? to : '#'\"><slot /></a>",
+};
+
+async function mountSidebar() {
+  // Lazy import so the vi.mock factories above are applied first.
+  const { default: AppSidebar } = await import("@/components/layout/AppSidebar.vue");
+  return mount(AppSidebar, {
+    global: {
+      stubs: {
+        "router-link": routerLinkStub,
+        LogoIcon: true,
+        SdkStatusIndicator: true,
+        Transition: false,
+      },
+    },
+  });
+}
+
+describe("AppSidebar collapse toggle", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders expanded by default and exposes a collapse toggle", async () => {
+    const wrapper = await mountSidebar();
+    const aside = wrapper.find('[data-testid="app-sidebar"]');
+    expect(aside.exists()).toBe(true);
+    expect(aside.classes()).not.toContain("collapsed");
+
+    const toggle = wrapper.find('[data-testid="sidebar-collapse-toggle"]');
+    expect(toggle.exists()).toBe(true);
+    expect(toggle.attributes("aria-pressed")).toBe("false");
+    expect(toggle.attributes("aria-label")).toBe("Collapse sidebar");
+  });
+
+  it("toggles the collapsed class and ARIA state when clicked", async () => {
+    const wrapper = await mountSidebar();
+    const toggle = wrapper.find('[data-testid="sidebar-collapse-toggle"]');
+
+    await toggle.trigger("click");
+    const aside = wrapper.find('[data-testid="app-sidebar"]');
+    expect(aside.classes()).toContain("collapsed");
+    expect(toggle.attributes("aria-pressed")).toBe("true");
+    expect(toggle.attributes("aria-label")).toBe("Expand sidebar");
+
+    await toggle.trigger("click");
+    expect(aside.classes()).not.toContain("collapsed");
+    expect(toggle.attributes("aria-pressed")).toBe("false");
+  });
+
+  it("persists the collapsed preference to localStorage", async () => {
+    const wrapper = await mountSidebar();
+    await wrapper.find('[data-testid="sidebar-collapse-toggle"]').trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(localStorage.getItem(STORAGE_KEYS.sidebarCollapsed)).toBe("true");
+  });
+
+  it("hydrates the collapsed state from localStorage on mount", async () => {
+    localStorage.setItem(STORAGE_KEYS.sidebarCollapsed, "true");
+    const wrapper = await mountSidebar();
+    const aside = wrapper.find('[data-testid="app-sidebar"]');
+    expect(aside.classes()).toContain("collapsed");
+  });
+});

--- a/apps/desktop/src/__tests__/components/layout/AppSidebar.test.ts
+++ b/apps/desktop/src/__tests__/components/layout/AppSidebar.test.ts
@@ -88,12 +88,17 @@ describe("AppSidebar collapse toggle", () => {
     await toggle.trigger("click");
     const aside = wrapper.find('[data-testid="app-sidebar"]');
     expect(aside.classes()).toContain("collapsed");
-    expect(toggle.attributes("aria-pressed")).toBe("true");
-    expect(toggle.attributes("aria-label")).toBe("Expand sidebar");
+    expect(wrapper.find('[data-testid="sidebar-collapse-toggle"]').exists()).toBe(false);
 
-    await toggle.trigger("click");
+    const expand = wrapper.find('[data-testid="sidebar-brand-expand"]');
+    expect(expand.exists()).toBe(true);
+    expect(expand.attributes("aria-label")).toBe("Expand sidebar");
+
+    await expand.trigger("click");
     expect(aside.classes()).not.toContain("collapsed");
-    expect(toggle.attributes("aria-pressed")).toBe("false");
+    expect(wrapper.find('[data-testid="sidebar-collapse-toggle"]').attributes("aria-pressed")).toBe(
+      "false",
+    );
   });
 
   it("persists the collapsed preference to localStorage", async () => {
@@ -108,5 +113,6 @@ describe("AppSidebar collapse toggle", () => {
     const wrapper = await mountSidebar();
     const aside = wrapper.find('[data-testid="app-sidebar"]');
     expect(aside.classes()).toContain("collapsed");
+    expect(wrapper.find('[data-testid="sidebar-brand-expand"]').exists()).toBe(true);
   });
 });

--- a/apps/desktop/src/__tests__/composables/useAnalyticsPage.test.ts
+++ b/apps/desktop/src/__tests__/composables/useAnalyticsPage.test.ts
@@ -13,6 +13,7 @@ const { mockGetAnalytics, mockGetToolAnalysis, mockGetCodeImpact } = vi.hoisted(
     activityPerDay: [],
     modelDistribution: [],
     costByDay: [],
+    modelUsageByDay: [],
     sessionsWithErrors: 0,
     totalRateLimits: 0,
     totalCompactions: 0,

--- a/apps/desktop/src/__tests__/stores/analytics/setup.ts
+++ b/apps/desktop/src/__tests__/stores/analytics/setup.ts
@@ -34,11 +34,22 @@ export const FIXTURE_ANALYTICS: AnalyticsData = {
       inputTokens: 250_000,
       outputTokens: 250_000,
       cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       premiumRequests: 5,
       requestCount: 50,
     },
   ],
   costByDay: [{ date: "2025-01-01", cost: 5.0 }],
+  modelUsageByDay: [
+    {
+      date: "2025-01-01",
+      model: "gpt-4",
+      inputTokens: 250_000,
+      outputTokens: 250_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  ],
   apiDurationStats: {
     avgMs: 1_000_000,
     medianMs: 900_000,

--- a/apps/desktop/src/__tests__/views/analytics-views.test.ts
+++ b/apps/desktop/src/__tests__/views/analytics-views.test.ts
@@ -1,7 +1,7 @@
 import { setupPinia } from "@tracepilot/test-utils";
-import type { AnalyticsData, CodeImpactData, ToolAnalysisData } from "@tracepilot/types";
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FIXTURE_ANALYTICS, FIXTURE_CODE_IMPACT, FIXTURE_TOOL_ANALYSIS } from "./analyticsFixtures";
 
 // ── Mock client ───────────────────────────────────────────────
 const mockGetAnalytics = vi.fn();
@@ -20,114 +20,6 @@ vi.mock("@tracepilot/client", async () => {
     getCodeImpact: (...args: unknown[]) => mockGetCodeImpact(...args),
   });
 });
-
-// ── Fixtures ──────────────────────────────────────────────────
-const FIXTURE_ANALYTICS: AnalyticsData = {
-  totalSessions: 10,
-  totalTokens: 2_500_000,
-  totalCost: 5.5,
-  totalPremiumRequests: 40,
-  tokenUsageByDay: [
-    { date: "2025-01-01", tokens: 100_000 },
-    { date: "2025-01-02", tokens: 150_000 },
-    { date: "2025-01-03", tokens: 200_000 },
-  ],
-  activityPerDay: [
-    { date: "2025-01-01", count: 3 },
-    { date: "2025-01-02", count: 4 },
-    { date: "2025-01-03", count: 3 },
-  ],
-  modelDistribution: [
-    {
-      model: "gpt-4",
-      tokens: 1_500_000,
-      percentage: 60,
-      inputTokens: 750_000,
-      outputTokens: 750_000,
-      cacheReadTokens: 0,
-      premiumRequests: 24,
-      requestCount: 180,
-    },
-    {
-      model: "claude-3",
-      tokens: 1_000_000,
-      percentage: 40,
-      inputTokens: 500_000,
-      outputTokens: 500_000,
-      cacheReadTokens: 0,
-      premiumRequests: 16,
-      requestCount: 120,
-    },
-  ],
-  costByDay: [
-    { date: "2025-01-01", cost: 1.5 },
-    { date: "2025-01-02", cost: 2.0 },
-    { date: "2025-01-03", cost: 2.0 },
-  ],
-  apiDurationStats: {
-    avgMs: 1_800_000,
-    medianMs: 1_200_000,
-    p95Ms: 5_400_000,
-    minMs: 120_000,
-    maxMs: 7_200_000,
-    totalSessionsWithDuration: 8,
-  },
-  productivityMetrics: {
-    avgTurnsPerSession: 8.5,
-    avgToolCallsPerTurn: 4.2,
-    avgTokensPerTurn: 60_489,
-    avgTokensPerApiSecond: 3_420,
-  },
-  cacheStats: {
-    totalCacheReadTokens: 300_000,
-    totalInputTokens: 1_250_000,
-    cacheHitRate: 24.0,
-    nonCachedInputTokens: 950_000,
-  },
-  sessionsWithErrors: 2,
-  totalRateLimits: 3,
-  totalCompactions: 5,
-  totalTruncations: 1,
-  incidentsByDay: [
-    { date: "2026-03-18", errors: 1, rateLimits: 1, compactions: 3, truncations: 1 },
-    { date: "2026-03-19", errors: 1, rateLimits: 2, compactions: 2, truncations: 0 },
-  ],
-};
-
-const FIXTURE_TOOL_ANALYSIS: ToolAnalysisData = {
-  totalCalls: 50,
-  successRate: 0.95,
-  avgDurationMs: 500,
-  mostUsedTool: "edit",
-  tools: [
-    { name: "edit", callCount: 30, successRate: 0.97, avgDurationMs: 400, totalDurationMs: 12_000 },
-    { name: "view", callCount: 20, successRate: 0.92, avgDurationMs: 650, totalDurationMs: 13_000 },
-  ],
-  activityHeatmap: [
-    { day: 0, hour: 10, count: 5 },
-    { day: 1, hour: 14, count: 3 },
-  ],
-};
-
-const FIXTURE_CODE_IMPACT: CodeImpactData = {
-  filesModified: 15,
-  linesAdded: 1000,
-  linesRemoved: 300,
-  netChange: 700,
-  fileTypeBreakdown: [
-    { extension: ".ts", count: 10, percentage: 66.7 },
-    { extension: ".vue", count: 5, percentage: 33.3 },
-  ],
-  mostModifiedFiles: [
-    { path: "src/index.ts", additions: 100, deletions: 30 },
-    { path: "src/App.vue", additions: 80, deletions: 20 },
-  ],
-  changesByDay: [
-    { date: "2025-01-01", additions: 200, deletions: 60 },
-    { date: "2025-01-02", additions: 300, deletions: 80 },
-    { date: "2025-01-03", additions: 500, deletions: 160 },
-  ],
-};
 
 // ── LoadingOverlay stub ───────────────────────────────────────
 const LoadingOverlayStub = {
@@ -305,6 +197,56 @@ describe("AnalyticsDashboardView", () => {
 
     expect(wrapper.text()).toContain("10");
     expect(wrapper.text()).not.toContain("API Duration");
+  });
+
+  it("renders the cost basis toggle with both options and defaults to legacy", async () => {
+    mockGetAnalytics.mockResolvedValue(FIXTURE_ANALYTICS);
+    const Component = await loadAnalyticsDashboard();
+    const wrapper = mount(Component, globalStubs);
+
+    await flushPromises();
+
+    // Panel title reflects the legacy default.
+    expect(wrapper.text()).toContain("Legacy Copilot Cost Trend");
+    expect(wrapper.text()).not.toContain("Direct API Cost Trend");
+
+    const radios = wrapper.findAll('[role="radio"]');
+    const legacyBtn = radios.find((b) => b.text().includes("Legacy Copilot"));
+    const directBtn = radios.find((b) => b.text().includes("Direct API"));
+    expect(legacyBtn).toBeTruthy();
+    expect(directBtn).toBeTruthy();
+    expect(legacyBtn!.attributes("aria-checked")).toBe("true");
+    expect(directBtn!.attributes("aria-checked")).toBe("false");
+
+    // Default chart aria label reflects the legacy basis.
+    const chartSvg = wrapper
+      .findAll("svg")
+      .find((s) => /legacy Copilot cost trend/i.test(s.attributes("aria-label") ?? ""));
+    expect(chartSvg).toBeTruthy();
+  });
+
+  it("switches the cost graph to the direct API basis when toggled", async () => {
+    mockGetAnalytics.mockResolvedValue(FIXTURE_ANALYTICS);
+    const Component = await loadAnalyticsDashboard();
+    const wrapper = mount(Component, globalStubs);
+
+    await flushPromises();
+
+    const directBtn = wrapper
+      .findAll('[role="radio"]')
+      .find((b) => b.text().includes("Direct API"));
+    expect(directBtn).toBeTruthy();
+    await directBtn!.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Direct API Cost Trend");
+    expect(wrapper.text()).not.toContain("Legacy Copilot Cost Trend");
+    expect(directBtn!.attributes("aria-checked")).toBe("true");
+
+    const chartSvg = wrapper
+      .findAll("svg")
+      .find((s) => /direct API cost trend/i.test(s.attributes("aria-label") ?? ""));
+    expect(chartSvg).toBeTruthy();
   });
 });
 

--- a/apps/desktop/src/__tests__/views/analyticsFixtures.ts
+++ b/apps/desktop/src/__tests__/views/analyticsFixtures.ts
@@ -1,0 +1,136 @@
+import type { AnalyticsData, CodeImpactData, ToolAnalysisData } from "@tracepilot/types";
+
+export const FIXTURE_ANALYTICS: AnalyticsData = {
+  totalSessions: 10,
+  totalTokens: 2_500_000,
+  totalCost: 5.5,
+  totalPremiumRequests: 40,
+  tokenUsageByDay: [
+    { date: "2025-01-01", tokens: 100_000 },
+    { date: "2025-01-02", tokens: 150_000 },
+    { date: "2025-01-03", tokens: 200_000 },
+  ],
+  activityPerDay: [
+    { date: "2025-01-01", count: 3 },
+    { date: "2025-01-02", count: 4 },
+    { date: "2025-01-03", count: 3 },
+  ],
+  modelDistribution: [
+    {
+      model: "gpt-4",
+      tokens: 1_500_000,
+      percentage: 60,
+      inputTokens: 750_000,
+      outputTokens: 750_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      premiumRequests: 24,
+      requestCount: 180,
+    },
+    {
+      model: "claude-3",
+      tokens: 1_000_000,
+      percentage: 40,
+      inputTokens: 500_000,
+      outputTokens: 500_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      premiumRequests: 16,
+      requestCount: 120,
+    },
+  ],
+  costByDay: [
+    { date: "2025-01-01", cost: 1.5 },
+    { date: "2025-01-02", cost: 2.0 },
+    { date: "2025-01-03", cost: 2.0 },
+  ],
+  modelUsageByDay: [
+    {
+      date: "2025-01-01",
+      model: "gpt-4",
+      inputTokens: 250_000,
+      outputTokens: 100_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    {
+      date: "2025-01-02",
+      model: "gpt-4",
+      inputTokens: 300_000,
+      outputTokens: 250_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    {
+      date: "2025-01-03",
+      model: "claude-3",
+      inputTokens: 500_000,
+      outputTokens: 500_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  ],
+  apiDurationStats: {
+    avgMs: 1_800_000,
+    medianMs: 1_200_000,
+    p95Ms: 5_400_000,
+    minMs: 120_000,
+    maxMs: 7_200_000,
+    totalSessionsWithDuration: 8,
+  },
+  productivityMetrics: {
+    avgTurnsPerSession: 8.5,
+    avgToolCallsPerTurn: 4.2,
+    avgTokensPerTurn: 60_489,
+    avgTokensPerApiSecond: 3_420,
+  },
+  cacheStats: {
+    totalCacheReadTokens: 300_000,
+    totalInputTokens: 1_250_000,
+    cacheHitRate: 24.0,
+    nonCachedInputTokens: 950_000,
+  },
+  sessionsWithErrors: 2,
+  totalRateLimits: 3,
+  totalCompactions: 5,
+  totalTruncations: 1,
+  incidentsByDay: [
+    { date: "2026-03-18", errors: 1, rateLimits: 1, compactions: 3, truncations: 1 },
+    { date: "2026-03-19", errors: 1, rateLimits: 2, compactions: 2, truncations: 0 },
+  ],
+};
+
+export const FIXTURE_TOOL_ANALYSIS: ToolAnalysisData = {
+  totalCalls: 50,
+  successRate: 0.95,
+  avgDurationMs: 500,
+  mostUsedTool: "edit",
+  tools: [
+    { name: "edit", callCount: 30, successRate: 0.97, avgDurationMs: 400, totalDurationMs: 12_000 },
+    { name: "view", callCount: 20, successRate: 0.92, avgDurationMs: 650, totalDurationMs: 13_000 },
+  ],
+  activityHeatmap: [
+    { day: 0, hour: 10, count: 5 },
+    { day: 1, hour: 14, count: 3 },
+  ],
+};
+
+export const FIXTURE_CODE_IMPACT: CodeImpactData = {
+  filesModified: 15,
+  linesAdded: 1000,
+  linesRemoved: 300,
+  netChange: 700,
+  fileTypeBreakdown: [
+    { extension: ".ts", count: 10, percentage: 66.7 },
+    { extension: ".vue", count: 5, percentage: 33.3 },
+  ],
+  mostModifiedFiles: [
+    { path: "src/index.ts", additions: 100, deletions: 30 },
+    { path: "src/App.vue", additions: 80, deletions: 20 },
+  ],
+  changesByDay: [
+    { date: "2025-01-01", additions: 200, deletions: 60 },
+    { date: "2025-01-02", additions: 300, deletions: 80 },
+    { date: "2025-01-03", additions: 500, deletions: 160 },
+  ],
+};

--- a/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import type { AnalyticsData } from "@tracepilot/types";
-import type { ChartLayout, ChartTooltipState, SegmentOption } from "@tracepilot/ui";
+import type { ChartLayout, ChartTooltipState } from "@tracepilot/ui";
 import {
   formatCost,
   formatDateMedium,
   formatNumber,
   formatNumberFull,
   SectionPanel,
-  SegmentedControl,
   useChartTooltip,
 } from "@tracepilot/ui";
 import { computed, ref, watch } from "vue";
@@ -67,11 +66,6 @@ watch(donutSegments, () => {
 
 // ── Cost basis toggle ─────────────────────────────────────────────
 type CostBasis = "legacy" | "directApi";
-
-const COST_BASIS_OPTIONS: SegmentOption[] = [
-  { value: "legacy", label: "Legacy Copilot" },
-  { value: "directApi", label: "Direct API" },
-];
 
 // Default to legacy to preserve existing behavior. Local component state
 // (not persisted) — matches other analytics page controls.
@@ -172,11 +166,33 @@ const tooltipFormatter = (i: number) => {
     <!-- Cost Trend -->
     <SectionPanel :title="costPanelTitle">
       <template #actions>
-        <SegmentedControl
-          v-model="costBasis"
-          :options="COST_BASIS_OPTIONS"
+        <div
+          class="cost-basis-switch"
+          role="radiogroup"
           aria-label="Cost basis"
-        />
+        >
+          <button
+            type="button"
+            class="cost-basis-option"
+            :class="{ active: costBasis === 'legacy' }"
+            role="radio"
+            :aria-checked="costBasis === 'legacy'"
+            @click="costBasis = 'legacy'"
+          >
+            Legacy Copilot
+          </button>
+          <span class="cost-basis-separator" aria-hidden="true">/</span>
+          <button
+            type="button"
+            class="cost-basis-option"
+            :class="{ active: costBasis === 'directApi' }"
+            role="radio"
+            :aria-checked="costBasis === 'directApi'"
+            @click="costBasis = 'directApi'"
+          >
+            Direct API
+          </button>
+        </div>
       </template>
       <LineAreaChart
         v-if="costChart"
@@ -272,5 +288,42 @@ const tooltipFormatter = (i: number) => {
 }
 .more-info-link:hover {
   color: var(--accent-primary);
+}
+
+.cost-basis-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+}
+
+.cost-basis-option {
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  padding: 2px 0;
+  transition: color var(--transition-fast, 0.15s);
+}
+
+.cost-basis-option:hover {
+  color: var(--text-secondary);
+}
+
+.cost-basis-option.active {
+  color: var(--text-primary);
+}
+
+.cost-basis-option:focus-visible {
+  outline: 2px solid var(--accent-emphasis);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.cost-basis-separator {
+  opacity: 0.45;
 }
 </style>

--- a/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import type { AnalyticsData } from "@tracepilot/types";
-import type { ChartLayout, ChartTooltipState } from "@tracepilot/ui";
+import type { ChartLayout, ChartTooltipState, SegmentOption } from "@tracepilot/ui";
 import {
   formatCost,
   formatDateMedium,
   formatNumber,
   formatNumberFull,
   SectionPanel,
+  SegmentedControl,
   useChartTooltip,
 } from "@tracepilot/ui";
 import { computed, ref, watch } from "vue";
@@ -14,6 +15,7 @@ import { RouterLink } from "vue-router";
 import LineAreaChart from "@/components/charts/LineAreaChart.vue";
 import { useLineAreaChartData } from "@/composables/useLineAreaChartData";
 import { usePreferencesStore } from "@/stores/preferences";
+import { buildAnalyticsCostSeries } from "@/utils/analyticsCostSeries";
 import { CHART_COLORS, DONUT_PALETTE } from "@/utils/chartColors";
 
 const props = defineProps<{
@@ -63,12 +65,36 @@ watch(donutSegments, () => {
   hoveredDonut.value = null;
 });
 
-const costPoints = computed(
-  () =>
-    props.data.costByDay.map((p) => ({
-      date: p.date,
-      cost: p.cost * prefs.costPerPremiumRequest,
-    })) ?? null,
+// ── Cost basis toggle ─────────────────────────────────────────────
+type CostBasis = "legacy" | "directApi";
+
+const COST_BASIS_OPTIONS: SegmentOption[] = [
+  { value: "legacy", label: "Legacy Copilot" },
+  { value: "directApi", label: "Direct API" },
+];
+
+// Default to legacy to preserve existing behavior. Local component state
+// (not persisted) — matches other analytics page controls.
+const costBasis = ref<CostBasis>("legacy");
+
+const isDirectApi = computed(() => costBasis.value === "directApi");
+
+const costPanelTitle = computed(() =>
+  isDirectApi.value ? "Direct API Cost Trend" : "Legacy Copilot Cost Trend",
+);
+
+const costColor = computed(() => (isDirectApi.value ? CHART_COLORS.success : CHART_COLORS.primary));
+const costColorLight = computed(() =>
+  isDirectApi.value ? CHART_COLORS.successLight : CHART_COLORS.primaryLight,
+);
+
+const costPoints = computed(() =>
+  buildAnalyticsCostSeries(
+    props.data,
+    costBasis.value,
+    prefs.costPerPremiumRequest,
+    prefs.computeWholesaleCost,
+  ),
 );
 
 const { chartData: costChart } = useLineAreaChartData({
@@ -79,6 +105,18 @@ const { chartData: costChart } = useLineAreaChartData({
   yFormatter: formatCost,
   maxFloor: 0.01,
 });
+
+const costAriaLabel = computed(
+  () =>
+    `Area chart showing daily ${
+      isDirectApi.value ? "direct API" : "legacy Copilot"
+    } cost trend over ${props.timeRangeLabel}`,
+);
+
+const tooltipFormatter = (i: number) => {
+  const point = costChart.value?.coords[i];
+  return point ? `${formatDateMedium(point.date)} — ${formatCost(point.cost)}` : "";
+};
 </script>
 
 <template>
@@ -132,7 +170,14 @@ const { chartData: costChart } = useLineAreaChartData({
     </SectionPanel>
 
     <!-- Cost Trend -->
-    <SectionPanel title="Legacy Cost Trend">
+    <SectionPanel :title="costPanelTitle">
+      <template #actions>
+        <SegmentedControl
+          v-model="costBasis"
+          :options="COST_BASIS_OPTIONS"
+          aria-label="Cost basis"
+        />
+      </template>
       <LineAreaChart
         v-if="costChart"
         :chart-data="costChart"
@@ -140,12 +185,12 @@ const { chartData: costChart } = useLineAreaChartData({
         :grid-lines="gridLines"
         :tooltip="tooltip"
         chart-id="cost"
-        :ariaLabel="`Area chart showing daily cost trend over ${timeRangeLabel}`"
-        :color="CHART_COLORS.primary"
-        :color-light="CHART_COLORS.primaryLight"
+        :ariaLabel="costAriaLabel"
+        :color="costColor"
+        :color-light="costColorLight"
         :gradient-opacity="0.35"
-        @mousemove="onChartMouseMove($event, costChart.coords, (i) => `${formatDateMedium(costChart!.coords[i].date)} — ${formatCost(costChart!.coords[i].cost)}`, 'cost', '.chart-frame')"
-        @click="onChartClick($event, costChart.coords, (i) => `${formatDateMedium(costChart!.coords[i].date)} — ${formatCost(costChart!.coords[i].cost)}`, 'cost', '.chart-frame')"
+        @mousemove="onChartMouseMove($event, costChart.coords, tooltipFormatter, 'cost', '.chart-frame')"
+        @click="onChartClick($event, costChart.coords, tooltipFormatter, 'cost', '.chart-frame')"
         @dismiss-tooltip="dismissTooltip"
       />
     </SectionPanel>

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { ConversationTurn } from "@tracepilot/types";
 import {
+  type CurrentObjective,
   LIVE_TOOL_PARTIAL_OUTPUT_KEY,
+  ObjectiveBanner,
   useConversationSections,
   useToggleSet,
 } from "@tracepilot/ui";
@@ -39,6 +41,19 @@ import SystemMessagePanel from "./SystemMessagePanel.vue";
 
 const store = useSessionDetailContext();
 const sdk = useSdkStore();
+
+type ObjectiveStatus = "running" | "completed" | "failed" | "idle";
+
+const props = withDefaults(
+  defineProps<{
+    objective?: CurrentObjective | null;
+    objectiveStatus?: ObjectiveStatus;
+  }>(),
+  {
+    objective: null,
+    objectiveStatus: "idle",
+  },
+);
 
 useRenderBudget({ key: "render.chatViewModeMs", budgetMs: 200, label: "ChatViewMode" });
 const preferences = usePreferencesStore();
@@ -129,6 +144,7 @@ provide(LIVE_TOOL_PARTIAL_OUTPUT_KEY, liveToolPartialOutputs);
 
 const emit = defineEmits<{
   messageSent: [prompt: string];
+  revealObjective: [info: { eventIndex?: number; toolCallId?: string }];
 }>();
 
 // ─── Cross-turn subagent data ─────────────────────────────────────
@@ -463,8 +479,19 @@ defineExpose({ revealEvent });
         </div>
       </div>
 
-      <!-- SDK Steering Panel (appears at bottom of chat when SDK is active) -->
-      <SdkSteeringPanel :session-id="store.sessionId" :session-cwd="store.detail?.cwd ?? undefined" @message-sent="handleSteeringMessage" />
+      <div class="cv-bottom-stack">
+        <ObjectiveBanner
+          v-if="props.objective"
+          class="cv-objective-strip"
+          scope="session"
+          :objective="props.objective"
+          :status="props.objectiveStatus"
+          @reveal="emit('revealObjective', $event)"
+        />
+
+        <!-- SDK Steering Panel (appears at bottom of chat when SDK is active) -->
+        <SdkSteeringPanel :session-id="store.sessionId" :session-cwd="store.detail?.cwd ?? undefined" @message-sent="handleSteeringMessage" />
+      </div>
     </div>
 
     <!-- Subagent panel (fixed viewport-sticky, below header) -->
@@ -527,13 +554,34 @@ defineExpose({ revealEvent });
 .cv-content {
   max-width: var(--content-max-width, 1600px);
   margin: 0 auto;
-  padding: 24px 32px 80px;
+  padding: 24px 32px 96px;
 }
 
 .cv-stream {
   display: flex;
   flex-direction: column;
   gap: 0;
+}
+
+.cv-bottom-stack {
+  position: sticky;
+  bottom: 0;
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 10px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--canvas-default, #0d1117) 0%, transparent) 0%,
+    var(--canvas-default, #0d1117) 32%
+  );
+}
+
+.cv-objective-strip {
+  width: min(720px, calc(100% - 32px));
+  margin: 0 auto;
+  box-shadow: 0 8px 24px var(--shadow-color, rgba(0, 0, 0, 0.22));
 }
 
 /* ─── Deep-link highlight animation ────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -569,12 +569,18 @@ defineExpose({ revealEvent });
   z-index: 12;
   display: flex;
   flex-direction: column;
-  background: var(--canvas-default, #0d1117);
+  align-items: center;
+  padding: 0 16px 8px;
+  pointer-events: none;
 }
 
 .cv-objective-strip {
-  width: 100%;
-  margin: 0;
+  margin: 0 0 8px;
+  pointer-events: auto;
+}
+
+.cv-bottom-stack :deep(.sdk-steering-feature) {
+  pointer-events: auto;
 }
 
 /* ─── Deep-link highlight animation ────────────────────────────── */

--- a/apps/desktop/src/components/conversation/ChatViewMode.vue
+++ b/apps/desktop/src/components/conversation/ChatViewMode.vue
@@ -569,19 +569,12 @@ defineExpose({ revealEvent });
   z-index: 12;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding-top: 10px;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--canvas-default, #0d1117) 0%, transparent) 0%,
-    var(--canvas-default, #0d1117) 32%
-  );
+  background: var(--canvas-default, #0d1117);
 }
 
 .cv-objective-strip {
-  width: min(720px, calc(100% - 32px));
-  margin: 0 auto;
-  box-shadow: 0 8px 24px var(--shadow-color, rgba(0, 0, 0, 0.22));
+  width: 100%;
+  margin: 0;
 }
 
 /* ─── Deep-link highlight animation ────────────────────────────── */

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -46,6 +46,12 @@ const dismissedVersion = useLocalStorage<string | null>(DISMISSED_KEY, null, {
   flush: "sync",
 });
 
+const isCollapsed = useLocalStorage<boolean>(STORAGE_KEYS.sidebarCollapsed, false);
+
+function toggleCollapsed() {
+  isCollapsed.value = !isCollapsed.value;
+}
+
 const hasUpdate = computed(() => {
   if (updateResult.value?.hasUpdate !== true) return false;
   return updateResult.value.latestVersion !== dismissedVersion.value;
@@ -74,13 +80,41 @@ async function handleVersionClick() {
 </script>
 
 <template>
-  <aside class="sidebar" role="navigation" aria-label="Main navigation" data-testid="app-sidebar">
+  <aside
+    class="sidebar"
+    :class="{ collapsed: isCollapsed }"
+    role="navigation"
+    aria-label="Main navigation"
+    data-testid="app-sidebar"
+  >
     <!-- Brand -->
     <div class="sidebar-brand">
       <div class="sidebar-brand-icon" aria-hidden="true">
         <LogoIcon :size="24" />
       </div>
       <span class="sidebar-brand-text">TracePilot</span>
+      <button
+        type="button"
+        class="sidebar-collapse-toggle"
+        data-testid="sidebar-collapse-toggle"
+        :aria-label="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        :aria-pressed="isCollapsed"
+        :title="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        @click="toggleCollapsed"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          aria-hidden="true"
+          :class="{ flipped: isCollapsed }"
+        >
+          <polyline points="10,3 5,8 10,13" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
     </div>
 
     <!-- Navigation -->
@@ -92,6 +126,7 @@ async function handleVersionClick() {
         :to="item.to"
         :data-nav-id="item.id"
         :data-testid="`nav-${item.id}`"
+        :title="item.label"
         class="sidebar-nav-item"
         :class="{ active: activeSidebarId === item.id }"
         @click="item.id === 'sessions' && emit('nav-sessions')"
@@ -128,6 +163,7 @@ async function handleVersionClick() {
         :to="item.to"
         :data-nav-id="item.id"
         :data-testid="`nav-${item.id}`"
+        :title="item.label"
         class="sidebar-nav-item"
         :class="{ active: activeSidebarId === item.id }"
       >
@@ -153,6 +189,7 @@ async function handleVersionClick() {
         :to="item.to"
         :data-nav-id="item.id"
         :data-testid="`nav-${item.id}`"
+        :title="item.label"
         class="sidebar-nav-item"
         :class="{ active: activeSidebarId === item.id }"
       >
@@ -178,6 +215,7 @@ async function handleVersionClick() {
           :key="item.id"
           :to="item.to"
           :data-nav-id="item.id"
+          :title="item.label"
           class="sidebar-nav-item"
           :class="{ active: activeSidebarId === item.id }"
         >
@@ -197,6 +235,7 @@ async function handleVersionClick() {
         to="/settings"
         data-nav-id="settings"
         data-testid="nav-settings"
+        title="Settings"
         class="sidebar-nav-item"
         :class="{ active: activeSidebarId === 'settings' }"
       >

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -89,18 +89,7 @@ async function handleVersionClick() {
   >
     <!-- Brand -->
     <div class="sidebar-brand">
-      <button
-        v-if="isCollapsed"
-        type="button"
-        class="sidebar-brand-icon sidebar-brand-button"
-        data-testid="sidebar-brand-expand"
-        aria-label="Expand sidebar"
-        title="Expand sidebar"
-        @click="toggleCollapsed"
-      >
-        <LogoIcon :size="24" />
-      </button>
-      <div v-else class="sidebar-brand-icon" aria-hidden="true">
+      <div class="sidebar-brand-icon" aria-hidden="true">
         <LogoIcon :size="24" />
       </div>
       <span class="sidebar-brand-text">TracePilot</span>
@@ -127,6 +116,29 @@ async function handleVersionClick() {
         </svg>
       </button>
     </div>
+
+    <!-- Collapsed-only expand handle: a clear, discoverable affordance. -->
+    <button
+      v-if="isCollapsed"
+      type="button"
+      class="sidebar-expand-handle"
+      data-testid="sidebar-brand-expand"
+      aria-label="Expand sidebar"
+      title="Expand sidebar"
+      @click="toggleCollapsed"
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.75"
+        aria-hidden="true"
+      >
+        <polyline points="6,3 11,8 6,13" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
 
     <!-- Navigation -->
     <nav class="sidebar-nav">

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -89,17 +89,29 @@ async function handleVersionClick() {
   >
     <!-- Brand -->
     <div class="sidebar-brand">
-      <div class="sidebar-brand-icon" aria-hidden="true">
+      <button
+        v-if="isCollapsed"
+        type="button"
+        class="sidebar-brand-icon sidebar-brand-button"
+        data-testid="sidebar-brand-expand"
+        aria-label="Expand sidebar"
+        title="Expand sidebar"
+        @click="toggleCollapsed"
+      >
+        <LogoIcon :size="24" />
+      </button>
+      <div v-else class="sidebar-brand-icon" aria-hidden="true">
         <LogoIcon :size="24" />
       </div>
       <span class="sidebar-brand-text">TracePilot</span>
       <button
+        v-if="!isCollapsed"
         type="button"
         class="sidebar-collapse-toggle"
         data-testid="sidebar-collapse-toggle"
-        :aria-label="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        aria-label="Collapse sidebar"
         :aria-pressed="isCollapsed"
-        :title="isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        title="Collapse sidebar"
         @click="toggleCollapsed"
       >
         <svg
@@ -110,7 +122,6 @@ async function handleVersionClick() {
           stroke="currentColor"
           stroke-width="1.5"
           aria-hidden="true"
-          :class="{ flipped: isCollapsed }"
         >
           <polyline points="10,3 5,8 10,13" stroke-linecap="round" stroke-linejoin="round" />
         </svg>

--- a/apps/desktop/src/components/modelComparison/ModelLeaderboard.vue
+++ b/apps/desktop/src/components/modelComparison/ModelLeaderboard.vue
@@ -12,8 +12,8 @@ const ctx = useModelComparisonContext();
       <div class="matrix-toggles">
         <div class="cost-toggle">
           <button
-            :class="['toggle-btn', { active: ctx.costMode === 'wholesale' }]"
-           @click="ctx.costMode = 'wholesale'"
+              :class="['toggle-btn', { active: ctx.costMode === 'wholesale' }]"
+              @click="ctx.costMode = 'wholesale'"
           >
             Direct API
           </button>
@@ -123,16 +123,22 @@ const ctx = useModelComparisonContext();
                 </div>
               </div>
             </td>
-            <td v-if="ctx.costMode !== 'copilot'" class="num-cell">
-              <span :class="{ 'best-cell': row.model === ctx.modelRows[ctx.bestCostIdx]?.model }">
+            <td v-if="ctx.costMode !== 'copilot'" class="num-cell matrix-cost-cell">
+              <span
+                class="matrix-cost-value"
+                :class="{ 'best-cell': row.model === ctx.modelRows[ctx.bestCostIdx]?.model }"
+                :title="ctx.fmtNorm(row.cost, true)"
+              >
                 {{ ctx.fmtNorm(row.cost, true) }}
               </span>
             </td>
-            <td v-if="ctx.costMode !== 'wholesale'" class="num-cell">
+            <td v-if="ctx.costMode !== 'wholesale'" class="num-cell matrix-cost-cell">
               <span
+                class="matrix-cost-value"
                 :class="{
                   'best-cell': row.model === ctx.modelRows[ctx.bestCopilotCostIdx]?.model,
                 }"
+                :title="ctx.fmtNorm(row.copilotCost, true)"
               >
                 {{ ctx.fmtNorm(row.copilotCost, true) }}
               </span>

--- a/apps/desktop/src/components/modelComparison/__tests__/ModelComparisonChildren.test.ts
+++ b/apps/desktop/src/components/modelComparison/__tests__/ModelComparisonChildren.test.ts
@@ -27,6 +27,7 @@ function makeRow(overrides: Partial<ModelRow> = {}): ModelRow {
     inputTokens: 600,
     outputTokens: 400,
     cacheReadTokens: 100,
+    cacheWriteTokens: 0,
     percentage: 50,
     premiumRequests: 2,
     cacheHitRate: 16.67,

--- a/apps/desktop/src/composables/__tests__/useModelComparison.test.ts
+++ b/apps/desktop/src/composables/__tests__/useModelComparison.test.ts
@@ -6,8 +6,8 @@ import { defineComponent } from "vue";
 // ── Mocks ──────────────────────────────────────────────────────────────
 const prefsStoreMock = {
   computeWholesaleCost: vi.fn(
-    (_model: string, input: number, _cacheRead: number, output: number) =>
-      (input + output) * 0.00001,
+    (_model: string, input: number, _cacheRead: number, output: number, cacheWrite = 0) =>
+      (input + output + cacheWrite) * 0.00001,
   ),
   costPerPremiumRequest: 0.04,
 };
@@ -56,10 +56,13 @@ function seedDistribution(
     inputTokens: number;
     outputTokens: number;
     cacheReadTokens: number;
+    cacheWriteTokens?: number;
     premiumRequests: number;
   }>,
 ) {
-  analyticsStoreMock.analytics = { modelDistribution: rows };
+  analyticsStoreMock.analytics = {
+    modelDistribution: rows.map((r) => ({ cacheWriteTokens: 0, ...r })),
+  };
 }
 
 describe("useModelComparison", () => {
@@ -231,5 +234,31 @@ describe("useModelComparison", () => {
     analyticsStoreMock.selectedRepo = "foo/bar";
     const { comp } = mountHook();
     expect(comp.pageSubtitle).toContain("in foo/bar");
+  });
+
+  it("passes cacheWriteTokens through to computeWholesaleCost (regression)", () => {
+    prefsStoreMock.computeWholesaleCost.mockClear();
+    seedDistribution([
+      {
+        model: "claude-sonnet-4.6",
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 200,
+        cacheWriteTokens: 300,
+        premiumRequests: 1,
+      },
+    ]);
+    const { comp } = mountHook();
+    // Touch the computed so it evaluates.
+    expect(comp.modelRows).toHaveLength(1);
+    expect(prefsStoreMock.computeWholesaleCost).toHaveBeenCalledWith(
+      "claude-sonnet-4.6",
+      1000,
+      200,
+      500,
+      300,
+    );
+    // Mock returns (input+output+cacheWrite) * 1e-5 = (1000+500+300)*1e-5 = 0.018
+    expect(comp.modelRows[0].cost).toBeCloseTo(0.018);
   });
 });

--- a/apps/desktop/src/composables/useModelComparison.ts
+++ b/apps/desktop/src/composables/useModelComparison.ts
@@ -58,6 +58,7 @@ export interface ModelRow {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
+  cacheWriteTokens: number;
   percentage: number;
   premiumRequests: number;
   cacheHitRate: number;
@@ -175,6 +176,7 @@ export function useModelComparison() {
         m.inputTokens,
         m.cacheReadTokens,
         m.outputTokens,
+        m.cacheWriteTokens ?? 0,
       );
       const copilotCost = premiumRequests * prefs.costPerPremiumRequest;
       return {
@@ -184,6 +186,7 @@ export function useModelComparison() {
         inputTokens: m.inputTokens,
         outputTokens: m.outputTokens,
         cacheReadTokens: m.cacheReadTokens,
+        cacheWriteTokens: m.cacheWriteTokens ?? 0,
         percentage,
         premiumRequests,
         cacheHitRate,

--- a/apps/desktop/src/config/storageKeys.ts
+++ b/apps/desktop/src/config/storageKeys.ts
@@ -43,6 +43,8 @@ export const STORAGE_KEYS = Object.freeze({
   recentSearches: "tracepilot-recent-searches",
   /** Alert history ring buffer (up to 100 entries). */
   alerts: "tracepilot:alert-history",
+  /** Whether the main sidebar is collapsed to icon-only mode. */
+  sidebarCollapsed: "tracepilot-sidebar-collapsed",
 } as const);
 
 /** Narrowed union of valid `localStorage` keys used by the desktop app. */

--- a/apps/desktop/src/styles/features/model-comparison.css
+++ b/apps/desktop/src/styles/features/model-comparison.css
@@ -95,7 +95,7 @@
 }
 
 .model-comparison-feature .matrix-table {
-  min-width: 1120px;
+  min-width: 920px;
 }
 
 .model-comparison-feature .matrix-table th:first-child,
@@ -333,31 +333,31 @@
 }
 
 .model-comparison-feature .col-model {
-  width: 244px;
+  width: 196px;
 }
 
 .model-comparison-feature .col-total {
-  width: 122px;
+  width: 92px;
 }
 
 .model-comparison-feature .col-input {
-  width: 122px;
+  width: 92px;
 }
 
 .model-comparison-feature .col-output {
-  width: 112px;
+  width: 92px;
 }
 
 .model-comparison-feature .col-cached {
-  width: 172px;
+  width: 132px;
 }
 
 .model-comparison-feature .col-share {
-  width: 170px;
+  width: 130px;
 }
 
 .model-comparison-feature .col-cost {
-  width: 116px;
+  width: 96px;
 }
 
 .model-comparison-feature .col-quarter {

--- a/apps/desktop/src/styles/features/model-comparison.css
+++ b/apps/desktop/src/styles/features/model-comparison.css
@@ -94,6 +94,10 @@
   width: 100%;
 }
 
+.model-comparison-feature .matrix-table {
+  min-width: 1120px;
+}
+
 .model-comparison-feature .matrix-table th:first-child,
 .model-comparison-feature .matrix-table td:first-child {
   position: sticky;
@@ -118,6 +122,16 @@
   user-select: none;
   white-space: nowrap;
 }
+
+.model-comparison-feature .matrix-table th:not(:first-child) {
+  text-align: right;
+}
+
+.model-comparison-feature .matrix-table th,
+.model-comparison-feature .matrix-table td {
+  vertical-align: middle;
+}
+
 .model-comparison-feature .sort-header:hover {
   color: var(--accent-fg, var(--chart-primary-light));
 }
@@ -133,6 +147,15 @@
 .model-comparison-feature .num-cell {
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+
+.model-comparison-feature .matrix-cost-cell {
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.model-comparison-feature .matrix-cost-value {
+  white-space: nowrap;
 }
 
 .model-comparison-feature .model-name-cell {
@@ -176,7 +199,7 @@
 /* ── Scrollable Sections ──────────────────────────────────── */
 .model-comparison-feature .scrollable-section {
   max-height: 500px;
-  overflow-y: auto;
+  overflow: auto;
 }
 
 /* ── Charts ───────────────────────────────────────────────── */
@@ -310,31 +333,31 @@
 }
 
 .model-comparison-feature .col-model {
-  width: 22%;
+  width: 244px;
 }
 
 .model-comparison-feature .col-total {
-  width: 12%;
+  width: 122px;
 }
 
 .model-comparison-feature .col-input {
-  width: 11%;
+  width: 122px;
 }
 
 .model-comparison-feature .col-output {
-  width: 11%;
+  width: 112px;
 }
 
 .model-comparison-feature .col-cached {
-  width: 16%;
+  width: 172px;
 }
 
 .model-comparison-feature .col-share {
-  width: 14%;
+  width: 170px;
 }
 
 .model-comparison-feature .col-cost {
-  width: 7%;
+  width: 116px;
 }
 
 .model-comparison-feature .col-quarter {

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -25,6 +25,7 @@
   overflow: hidden;
   will-change: width, min-width;
   contain: layout paint;
+  position: relative;
 }
 .sidebar-brand {
   display: flex;
@@ -73,22 +74,6 @@
   font-size: 13px;
   flex-shrink: 0;
   box-shadow: 0 2px 8px var(--accent-muted);
-}
-.sidebar-brand-button {
-  border: 0;
-  padding: 0;
-  cursor: pointer;
-  transition:
-    filter var(--transition-fast),
-    transform var(--transition-fast);
-}
-.sidebar-brand-button:hover {
-  filter: brightness(1.08);
-  transform: translateY(-1px);
-}
-.sidebar-brand-button:focus-visible {
-  outline: 2px solid var(--accent-emphasis);
-  outline-offset: 2px;
 }
 .sidebar-brand-text {
   font-size: 0.875rem;
@@ -350,30 +335,68 @@
   min-width: var(--sidebar-collapsed);
 }
 .sidebar.collapsed .sidebar-brand {
-  padding: 14px 8px 12px;
+  padding: 14px 8px 8px;
   justify-content: center;
+  position: relative;
 }
 .sidebar.collapsed .sidebar-brand-text {
   opacity: 0;
   max-width: 0;
   pointer-events: none;
 }
-.sidebar.collapsed .sidebar-brand {
-  position: relative;
+.sidebar-expand-handle {
+  position: absolute;
+  top: 16px;
+  right: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-default);
+  border-right: 0;
+  background: var(--canvas-default);
+  color: var(--text-tertiary);
+  border-radius: var(--radius-full, 999px) 0 0 var(--radius-full, 999px);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+.sidebar-expand-handle:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-emphasis);
+  background: var(--accent-subtle);
+  transform: translateX(-1px);
+}
+.sidebar-expand-handle:focus-visible {
+  outline: 2px solid var(--accent-emphasis);
+  outline-offset: 2px;
 }
 .sidebar.collapsed .sidebar-nav {
   padding: 4px 6px;
 }
 .sidebar.collapsed .sidebar-nav-item {
   justify-content: center;
-  padding: 8px 0;
+  padding: 0;
+  height: 36px;
+  width: 36px;
+  margin: 0 auto;
+  gap: 0;
 }
 .sidebar.collapsed .sidebar-nav-item > span:not(.nav-icon),
 .sidebar.collapsed .sidebar-nav-badge {
-  opacity: 0;
-  max-width: 0;
-  pointer-events: none;
-  visibility: hidden;
+  display: none;
+}
+.sidebar.collapsed .sidebar-nav-item .nav-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .sidebar.collapsed .sidebar-section-title {
   display: none;

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -20,15 +20,48 @@
   flex-direction: column;
   z-index: var(--z-sidebar);
   transition:
-    width var(--transition-slow),
-    min-width var(--transition-slow);
+    width 180ms cubic-bezier(0.2, 0, 0, 1),
+    min-width 180ms cubic-bezier(0.2, 0, 0, 1);
   overflow: hidden;
+  will-change: width, min-width;
 }
 .sidebar-brand {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 16px 16px 14px;
+}
+.sidebar-collapse-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+.sidebar-collapse-toggle:hover {
+  background: var(--neutral-subtle);
+  color: var(--text-primary);
+}
+.sidebar-collapse-toggle:focus-visible {
+  outline: 2px solid var(--accent-emphasis);
+  outline-offset: 1px;
+}
+.sidebar-collapse-toggle svg {
+  transition: transform var(--transition-fast);
+}
+.sidebar-collapse-toggle svg.flipped {
+  transform: rotate(180deg);
 }
 .sidebar-brand-icon {
   width: 28px;
@@ -48,6 +81,13 @@
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  transition:
+    opacity 120ms ease,
+    max-width 160ms cubic-bezier(0.2, 0, 0, 1),
+    transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  max-width: 120px;
 }
 .sidebar-nav {
   flex: 1;
@@ -111,6 +151,27 @@
   height: 16px;
   opacity: 0.5;
   flex-shrink: 0;
+}
+.sidebar-nav-item > span:not(.nav-icon),
+.sidebar-nav-badge,
+.sidebar-section-title {
+  white-space: nowrap;
+  overflow: hidden;
+  transition:
+    opacity 120ms ease,
+    max-width 160ms cubic-bezier(0.2, 0, 0, 1),
+    transform 160ms cubic-bezier(0.2, 0, 0, 1),
+    padding 160ms cubic-bezier(0.2, 0, 0, 1),
+    margin 160ms cubic-bezier(0.2, 0, 0, 1);
+}
+.sidebar-nav-item > span:not(.nav-icon) {
+  max-width: 150px;
+}
+.sidebar-nav-badge {
+  max-width: 56px;
+}
+.sidebar-section-title {
+  max-height: 44px;
 }
 .sidebar-nav-item.active .nav-icon {
   opacity: 0.9;
@@ -275,6 +336,78 @@
 .sidebar-version-btn:hover {
   background: var(--accent-subtle, rgba(99, 102, 241, 0.08));
   color: var(--accent-emphasis, #6366f1);
+}
+
+/* --- Sidebar collapsed (icon-only) state --- */
+.sidebar.collapsed {
+  width: var(--sidebar-collapsed);
+  min-width: var(--sidebar-collapsed);
+}
+.sidebar.collapsed .sidebar-brand {
+  padding: 12px 8px 10px;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+}
+.sidebar.collapsed .sidebar-brand-text {
+  opacity: 0;
+  max-width: 0;
+  transform: translateX(-6px);
+  pointer-events: none;
+}
+.sidebar.collapsed .sidebar-collapse-toggle {
+  margin-left: 0;
+  width: 28px;
+  height: 24px;
+  background: var(--neutral-subtle);
+  border: 1px solid var(--border-muted, rgba(255, 255, 255, 0.08));
+}
+.sidebar.collapsed .sidebar-brand {
+  position: relative;
+}
+.sidebar.collapsed .sidebar-nav {
+  padding: 4px 6px;
+}
+.sidebar.collapsed .sidebar-nav-item {
+  justify-content: center;
+  padding: 8px 0;
+}
+.sidebar.collapsed .sidebar-nav-item > span:not(.nav-icon),
+.sidebar.collapsed .sidebar-nav-badge {
+  opacity: 0;
+  max-width: 0;
+  transform: translateX(-6px);
+  pointer-events: none;
+}
+.sidebar.collapsed .sidebar-section-title {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin: 0;
+  pointer-events: none;
+}
+.sidebar.collapsed .sidebar-nav-item.active::before {
+  left: -6px;
+}
+.sidebar.collapsed .sidebar-settings-separator {
+  margin: 8px 6px;
+}
+.sidebar.collapsed .sidebar-update-notice {
+  display: none;
+}
+.sidebar.collapsed .sidebar-footer {
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 6px;
+  align-items: center;
+  justify-content: center;
+}
+.sidebar.collapsed .sidebar-version-btn {
+  font-size: 0.625rem;
+  padding: 2px 4px;
+  margin: 0;
+  text-align: center;
 }
 
 /* --- Main Content --- */

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -20,10 +20,11 @@
   flex-direction: column;
   z-index: var(--z-sidebar);
   transition:
-    width 180ms cubic-bezier(0.2, 0, 0, 1),
-    min-width 180ms cubic-bezier(0.2, 0, 0, 1);
+    width 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    min-width 160ms cubic-bezier(0.22, 1, 0.36, 1);
   overflow: hidden;
   will-change: width, min-width;
+  contain: layout paint;
 }
 .sidebar-brand {
   display: flex;
@@ -60,9 +61,6 @@
 .sidebar-collapse-toggle svg {
   transition: transform var(--transition-fast);
 }
-.sidebar-collapse-toggle svg.flipped {
-  transform: rotate(180deg);
-}
 .sidebar-brand-icon {
   width: 28px;
   height: 28px;
@@ -76,6 +74,22 @@
   flex-shrink: 0;
   box-shadow: 0 2px 8px var(--accent-muted);
 }
+.sidebar-brand-button {
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  transition:
+    filter var(--transition-fast),
+    transform var(--transition-fast);
+}
+.sidebar-brand-button:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+.sidebar-brand-button:focus-visible {
+  outline: 2px solid var(--accent-emphasis);
+  outline-offset: 2px;
+}
 .sidebar-brand-text {
   font-size: 0.875rem;
   font-weight: 700;
@@ -83,10 +97,7 @@
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
-  transition:
-    opacity 120ms ease,
-    max-width 160ms cubic-bezier(0.2, 0, 0, 1),
-    transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  transition: opacity 80ms ease;
   max-width: 120px;
 }
 .sidebar-nav {
@@ -157,12 +168,7 @@
 .sidebar-section-title {
   white-space: nowrap;
   overflow: hidden;
-  transition:
-    opacity 120ms ease,
-    max-width 160ms cubic-bezier(0.2, 0, 0, 1),
-    transform 160ms cubic-bezier(0.2, 0, 0, 1),
-    padding 160ms cubic-bezier(0.2, 0, 0, 1),
-    margin 160ms cubic-bezier(0.2, 0, 0, 1);
+  transition: opacity 80ms ease;
 }
 .sidebar-nav-item > span:not(.nav-icon) {
   max-width: 150px;
@@ -344,23 +350,13 @@
   min-width: var(--sidebar-collapsed);
 }
 .sidebar.collapsed .sidebar-brand {
-  padding: 12px 8px 10px;
+  padding: 14px 8px 12px;
   justify-content: center;
-  flex-direction: column;
-  gap: 8px;
 }
 .sidebar.collapsed .sidebar-brand-text {
   opacity: 0;
   max-width: 0;
-  transform: translateX(-6px);
   pointer-events: none;
-}
-.sidebar.collapsed .sidebar-collapse-toggle {
-  margin-left: 0;
-  width: 28px;
-  height: 24px;
-  background: var(--neutral-subtle);
-  border: 1px solid var(--border-muted, rgba(255, 255, 255, 0.08));
 }
 .sidebar.collapsed .sidebar-brand {
   position: relative;
@@ -376,16 +372,11 @@
 .sidebar.collapsed .sidebar-nav-badge {
   opacity: 0;
   max-width: 0;
-  transform: translateX(-6px);
   pointer-events: none;
+  visibility: hidden;
 }
 .sidebar.collapsed .sidebar-section-title {
-  opacity: 0;
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  margin: 0;
-  pointer-events: none;
+  display: none;
 }
 .sidebar.collapsed .sidebar-nav-item.active::before {
   left: -6px;

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -347,32 +347,34 @@
 }
 .sidebar-expand-handle {
   position: absolute;
-  top: 16px;
-  right: -13px;
+  top: 17px;
+  right: -11px;
   z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   margin: 0;
   padding: 0;
   border: 1px solid var(--border-default);
-  border-left: 0;
-  background: var(--canvas-default);
+  background: var(--canvas-subtle);
   color: var(--text-tertiary);
-  border-radius: 0 var(--radius-full, 999px) var(--radius-full, 999px) 0;
+  border-radius: var(--radius-full, 999px);
+  box-shadow: 0 0 0 2px var(--canvas-subtle);
   cursor: pointer;
   transition:
     color var(--transition-fast),
     background-color var(--transition-fast),
     border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
     transform var(--transition-fast);
 }
 .sidebar-expand-handle:hover {
   color: var(--text-primary);
   border-color: var(--accent-emphasis);
-  background: var(--accent-subtle);
+  background: color-mix(in srgb, var(--accent-emphasis) 14%, var(--canvas-subtle));
+  box-shadow: 0 0 0 2px var(--canvas-subtle);
   transform: translateX(1px);
 }
 .sidebar-expand-handle:focus-visible {

--- a/apps/desktop/src/styles/layout.css
+++ b/apps/desktop/src/styles/layout.css
@@ -333,34 +333,35 @@
 .sidebar.collapsed {
   width: var(--sidebar-collapsed);
   min-width: var(--sidebar-collapsed);
+  contain: layout;
+  overflow: visible;
 }
 .sidebar.collapsed .sidebar-brand {
   padding: 14px 8px 8px;
   justify-content: center;
+  gap: 0;
   position: relative;
 }
 .sidebar.collapsed .sidebar-brand-text {
-  opacity: 0;
-  max-width: 0;
-  pointer-events: none;
+  display: none;
 }
 .sidebar-expand-handle {
   position: absolute;
   top: 16px;
-  right: 0;
+  right: -13px;
   z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
+  width: 18px;
   height: 28px;
   margin: 0;
   padding: 0;
   border: 1px solid var(--border-default);
-  border-right: 0;
+  border-left: 0;
   background: var(--canvas-default);
   color: var(--text-tertiary);
-  border-radius: var(--radius-full, 999px) 0 0 var(--radius-full, 999px);
+  border-radius: 0 var(--radius-full, 999px) var(--radius-full, 999px) 0;
   cursor: pointer;
   transition:
     color var(--transition-fast),
@@ -372,7 +373,7 @@
   color: var(--text-primary);
   border-color: var(--accent-emphasis);
   background: var(--accent-subtle);
-  transform: translateX(-1px);
+  transform: translateX(1px);
 }
 .sidebar-expand-handle:focus-visible {
   outline: 2px solid var(--accent-emphasis);

--- a/apps/desktop/src/utils/__tests__/analyticsCostSeries.test.ts
+++ b/apps/desktop/src/utils/__tests__/analyticsCostSeries.test.ts
@@ -1,0 +1,97 @@
+import type { AnalyticsData } from "@tracepilot/types";
+import { describe, expect, it, vi } from "vitest";
+import { buildAnalyticsCostSeries } from "../analyticsCostSeries";
+
+const baseAnalytics: AnalyticsData = {
+  totalSessions: 1,
+  totalTokens: 0,
+  totalCost: 0,
+  totalPremiumRequests: 0,
+  tokenUsageByDay: [],
+  activityPerDay: [],
+  modelDistribution: [],
+  costByDay: [
+    { date: "2026-01-02", cost: 3 },
+    { date: "2026-01-01", cost: 2 },
+  ],
+  modelUsageByDay: [
+    {
+      date: "2026-01-02",
+      model: "claude-opus-4.6",
+      inputTokens: 100,
+      cacheReadTokens: 25,
+      outputTokens: 50,
+      cacheWriteTokens: 10,
+    },
+    {
+      date: "2026-01-01",
+      model: "gpt-5.4",
+      inputTokens: 80,
+      cacheReadTokens: 0,
+      outputTokens: 40,
+      cacheWriteTokens: 0,
+    },
+    {
+      date: "2026-01-02",
+      model: "unknown",
+      inputTokens: 1_000,
+      cacheReadTokens: 0,
+      outputTokens: 1_000,
+      cacheWriteTokens: 0,
+    },
+  ],
+  apiDurationStats: {
+    avgMs: 0,
+    medianMs: 0,
+    p95Ms: 0,
+    minMs: 0,
+    maxMs: 0,
+    totalSessionsWithDuration: 0,
+  },
+  productivityMetrics: {
+    avgTurnsPerSession: 0,
+    avgToolCallsPerTurn: 0,
+    avgTokensPerTurn: 0,
+    avgTokensPerApiSecond: 0,
+  },
+  cacheStats: {
+    totalCacheReadTokens: 0,
+    totalInputTokens: 0,
+    cacheHitRate: 0,
+    nonCachedInputTokens: 0,
+  },
+  sessionsWithErrors: 0,
+  totalRateLimits: 0,
+  totalCompactions: 0,
+  totalTruncations: 0,
+  incidentsByDay: [],
+};
+
+describe("buildAnalyticsCostSeries", () => {
+  it("builds the legacy Copilot series from premium requests", () => {
+    const computeWholesaleCost = vi.fn();
+    expect(buildAnalyticsCostSeries(baseAnalytics, "legacy", 0.04, computeWholesaleCost)).toEqual([
+      { date: "2026-01-02", cost: 0.12 },
+      { date: "2026-01-01", cost: 0.08 },
+    ]);
+    expect(computeWholesaleCost).not.toHaveBeenCalled();
+  });
+
+  it("builds an exact direct API series from per-day model usage", () => {
+    const computeWholesaleCost = vi.fn(
+      (model: string, input: number, cacheRead: number, output: number, cacheWrite = 0) => {
+        if (model === "unknown") return null;
+        return input + cacheRead + output + cacheWrite;
+      },
+    );
+
+    expect(
+      buildAnalyticsCostSeries(baseAnalytics, "directApi", 0.04, computeWholesaleCost),
+    ).toEqual([
+      { date: "2026-01-01", cost: 120 },
+      { date: "2026-01-02", cost: 185 },
+    ]);
+    expect(computeWholesaleCost).toHaveBeenCalledWith("claude-opus-4.6", 100, 25, 50, 10);
+    expect(computeWholesaleCost).toHaveBeenCalledWith("gpt-5.4", 80, 0, 40, 0);
+  });
+});

--- a/apps/desktop/src/utils/analyticsCostSeries.ts
+++ b/apps/desktop/src/utils/analyticsCostSeries.ts
@@ -1,0 +1,47 @@
+import type { AnalyticsData } from "@tracepilot/types";
+
+export type AnalyticsCostBasis = "legacy" | "directApi";
+
+export interface CostPoint {
+  date: string;
+  cost: number;
+}
+
+type ComputeWholesaleCost = (
+  model: string,
+  inputTokens: number,
+  cacheReadTokens: number,
+  outputTokens: number,
+  cacheWriteTokens?: number,
+) => number | null;
+
+export function buildAnalyticsCostSeries(
+  data: AnalyticsData,
+  basis: AnalyticsCostBasis,
+  costPerPremiumRequest: number,
+  computeWholesaleCost: ComputeWholesaleCost,
+): CostPoint[] {
+  if (basis === "legacy") {
+    return data.costByDay.map((p) => ({
+      date: p.date,
+      cost: p.cost * costPerPremiumRequest,
+    }));
+  }
+
+  const totalsByDate = new Map<string, number>();
+  for (const usage of data.modelUsageByDay) {
+    const cost =
+      computeWholesaleCost(
+        usage.model,
+        usage.inputTokens,
+        usage.cacheReadTokens,
+        usage.outputTokens,
+        usage.cacheWriteTokens,
+      ) ?? 0;
+    totalsByDate.set(usage.date, (totalsByDate.get(usage.date) ?? 0) + cost);
+  }
+
+  return Array.from(totalsByDate, ([date, cost]) => ({ date, cost })).sort((a, b) =>
+    a.date.localeCompare(b.date),
+  );
+}

--- a/apps/desktop/src/views/AnalyticsDashboardView.vue
+++ b/apps/desktop/src/views/AnalyticsDashboardView.vue
@@ -48,7 +48,13 @@ const totalWholesaleCost = computed(() => {
   return data.value.modelDistribution.reduce(
     (sum, m) =>
       sum +
-      (prefs.computeWholesaleCost(m.model, m.inputTokens, m.cacheReadTokens, m.outputTokens) ?? 0),
+      (prefs.computeWholesaleCost(
+        m.model,
+        m.inputTokens,
+        m.cacheReadTokens,
+        m.outputTokens,
+        m.cacheWriteTokens,
+      ) ?? 0),
     0,
   );
 });

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -532,9 +532,9 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
   position: sticky;
   bottom: 0;
   z-index: 8;
-  width: min(720px, 100%);
-  margin: 16px auto 0;
-  box-shadow: 0 8px 24px var(--shadow-color, rgba(0, 0, 0, 0.22));
+  width: 100%;
+  margin: 8px 0 0;
+  background: var(--canvas-default, #0d1117);
 }
 
 /* Highlight animation for scroll-to-turn from search deep-links */

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -12,7 +12,9 @@ import {
   formatNumber,
   formatTime,
   getAgentColor,
+  getMainAgentObjective,
   MarkdownContent,
+  ObjectiveBanner,
   ReasoningBlock,
   StatCard,
   ToolCallDetail,
@@ -24,7 +26,7 @@ import {
   useSessionTabLoader,
   useToggleSet,
 } from "@tracepilot/ui";
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { type RouteLocationNormalizedLoaded, useRoute } from "vue-router";
 import ChatViewMode from "@/components/conversation/ChatViewMode.vue";
 import { useAutoScroll } from "@/composables/useAutoScroll";
@@ -243,6 +245,36 @@ function retryLoadTurns() {
   store.loaded.delete("turns");
   store.loadTurns();
 }
+
+// ── Persistent objective banner ─────────────────────────────────────────
+// Latest report_intent across the main agent's tool calls, regardless of
+// turn — gives the user a stable "what is the agent currently aiming at?"
+// indicator that complements the inline pill rendering inside the chat.
+
+const sessionObjective = computed(() => getMainAgentObjective(store.turns));
+
+const sessionObjectiveStatus = computed<"running" | "completed" | "idle">(() => {
+  if (store.detail?.shutdownMetrics) return "completed";
+  if (store.turns.length === 0) return "idle";
+  return "running";
+});
+
+function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
+  // Find the owning turn and reveal via the active view.
+  const turn = store.turns.find((t) =>
+    t.toolCalls.some(
+      (tc) =>
+        (info.eventIndex != null && tc.eventIndex === info.eventIndex) ||
+        (info.toolCallId != null && tc.toolCallId === info.toolCallId),
+    ),
+  );
+  if (!turn) return;
+  if (activeView.value === "chat" && chatViewRef.value) {
+    chatViewRef.value.revealEvent(turn.turnIndex, info.eventIndex);
+    return;
+  }
+  scrollToTarget(turn.turnIndex, info.eventIndex ?? null);
+}
 </script>
 
 <template>
@@ -255,6 +287,16 @@ function retryLoadTurns() {
       :retryable="true"
       class="mb-4"
       @retry="retryLoadTurns"
+    />
+
+    <!-- Persistent current-objective banner (sticks below page header on scroll) -->
+    <ObjectiveBanner
+      class="conv-objective-banner"
+      scope="session"
+      label="Current objective"
+      :objective="sessionObjective"
+      :status="sessionObjectiveStatus"
+      @reveal="revealObjective"
     />
 
     <!-- Mini stat row -->
@@ -457,6 +499,16 @@ function retryLoadTurns() {
       </div>
     </div>
 
+    <ObjectiveBanner
+      v-if="sessionObjective"
+      class="conv-objective-dock"
+      scope="session"
+      label="Current objective"
+      :objective="sessionObjective"
+      :status="sessionObjectiveStatus"
+      @reveal="revealObjective"
+    />
+
     <!-- Floating scroll buttons -->
     <Transition name="fab">
       <div v-if="hasOverflow && (!isLockedToBottom || showScrollToTop)" class="scroll-fab-group">
@@ -484,6 +536,41 @@ function retryLoadTurns() {
 </template>
 
 <style scoped>
+/* Persistent objective banner sits above the stat row and sticks to the
+ * top of the page-content scroll container so it stays visible while
+ * users scroll long conversations. */
+.conv-objective-banner {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  margin-bottom: 12px;
+  background: var(--canvas-default);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 6px 14px var(--shadow-color, rgba(0, 0, 0, 0.18));
+}
+
+.conv-objective-dock {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  z-index: calc(var(--z-fab, 55) - 1);
+  width: min(720px, calc(100vw - var(--sidebar-width) - 160px));
+  background: var(--canvas-overlay, var(--canvas-default));
+  box-shadow: 0 12px 30px var(--shadow-color, rgba(0, 0, 0, 0.28));
+  backdrop-filter: blur(10px);
+}
+
+@media (max-width: 900px) {
+  .conv-objective-dock {
+    left: 16px;
+    right: 16px;
+    bottom: 88px;
+    width: auto;
+    transform: none;
+  }
+}
+
 /* Highlight animation for scroll-to-turn from search deep-links */
 .turn-highlight {
   animation: turn-flash 4s ease-out;

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -289,16 +289,6 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
       @retry="retryLoadTurns"
     />
 
-    <!-- Persistent current-objective banner (sticks below page header on scroll) -->
-    <ObjectiveBanner
-      class="conv-objective-banner"
-      scope="session"
-      label="Current objective"
-      :objective="sessionObjective"
-      :status="sessionObjectiveStatus"
-      @reveal="revealObjective"
-    />
-
     <!-- Mini stat row -->
     <div class="grid-3 mb-4">
       <StatCard :value="store.turns.length" label="Turns" color="accent" mini />
@@ -317,7 +307,10 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
     <ChatViewMode
       v-else-if="activeView === 'chat'"
       ref="chatViewRef"
+      :objective="sessionObjective"
+      :objective-status="sessionObjectiveStatus"
       @message-sent="handleChatSteeringMessage"
+      @reveal-objective="revealObjective"
     />
 
     <!-- ═══════════════ COMPACT VIEW ═══════════════ -->
@@ -500,10 +493,9 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
     </div>
 
     <ObjectiveBanner
-      v-if="sessionObjective"
-      class="conv-objective-dock"
+      v-if="activeView !== 'chat' && sessionObjective"
+      class="conv-objective-strip"
       scope="session"
-      label="Current objective"
       :objective="sessionObjective"
       :status="sessionObjectiveStatus"
       @reveal="revealObjective"
@@ -536,39 +528,13 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
 </template>
 
 <style scoped>
-/* Persistent objective banner sits above the stat row and sticks to the
- * top of the page-content scroll container so it stays visible while
- * users scroll long conversations. */
-.conv-objective-banner {
+.conv-objective-strip {
   position: sticky;
-  top: 0;
-  z-index: 5;
-  margin-bottom: 12px;
-  background: var(--canvas-default);
-  backdrop-filter: blur(6px);
-  box-shadow: 0 6px 14px var(--shadow-color, rgba(0, 0, 0, 0.18));
-}
-
-.conv-objective-dock {
-  position: fixed;
-  left: 50%;
-  bottom: 28px;
-  transform: translateX(-50%);
-  z-index: calc(var(--z-fab, 55) - 1);
-  width: min(720px, calc(100vw - var(--sidebar-width) - 160px));
-  background: var(--canvas-overlay, var(--canvas-default));
-  box-shadow: 0 12px 30px var(--shadow-color, rgba(0, 0, 0, 0.28));
-  backdrop-filter: blur(10px);
-}
-
-@media (max-width: 900px) {
-  .conv-objective-dock {
-    left: 16px;
-    right: 16px;
-    bottom: 88px;
-    width: auto;
-    transform: none;
-  }
+  bottom: 0;
+  z-index: 8;
+  width: min(720px, 100%);
+  margin: 16px auto 0;
+  box-shadow: 0 8px 24px var(--shadow-color, rgba(0, 0, 0, 0.22));
 }
 
 /* Highlight animation for scroll-to-turn from search deep-links */

--- a/apps/desktop/src/views/tabs/ConversationTab.vue
+++ b/apps/desktop/src/views/tabs/ConversationTab.vue
@@ -530,11 +530,9 @@ function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
 <style scoped>
 .conv-objective-strip {
   position: sticky;
-  bottom: 0;
+  bottom: 12px;
   z-index: 8;
-  width: 100%;
-  margin: 8px 0 0;
-  background: var(--canvas-default, #0d1117);
+  margin: 12px auto 0;
 }
 
 /* Highlight animation for scroll-to-turn from search deep-links */

--- a/crates/tracepilot-core/src/analytics/dashboard/accumulator.rs
+++ b/crates/tracepilot-core/src/analytics/dashboard/accumulator.rs
@@ -103,6 +103,7 @@ impl AnalyticsAccumulator {
             activity_per_day: daily.activity_per_day,
             model_distribution,
             cost_by_day: daily.cost_by_day,
+            model_usage_by_day: daily.model_usage_by_day,
             api_duration_stats,
             productivity_metrics,
             cache_stats,

--- a/crates/tracepilot-core/src/analytics/dashboard/daily.rs
+++ b/crates/tracepilot-core/src/analytics/dashboard/daily.rs
@@ -2,19 +2,21 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::models::event_types::{ModelMetricDetail, SessionSegment};
 
-use super::super::types::{DayActivity, DayCost, DayTokens};
+use super::super::types::{DayActivity, DayCost, DayModelUsage, DayTokens};
 
 #[derive(Default)]
 pub(super) struct DailySeriesAccumulator {
     tokens_by_day: BTreeMap<String, u64>,
     activity_by_day: BTreeMap<String, u32>,
     cost_by_day: BTreeMap<String, f64>,
+    model_usage_by_day: BTreeMap<(String, String), DayModelUsageTotals>,
 }
 
 pub(super) struct DailySeries {
     pub token_usage_by_day: Vec<DayTokens>,
     pub activity_per_day: Vec<DayActivity>,
     pub cost_by_day: Vec<DayCost>,
+    pub model_usage_by_day: Vec<DayModelUsage>,
 }
 
 impl DailySeriesAccumulator {
@@ -25,10 +27,11 @@ impl DailySeriesAccumulator {
             let mut seg_tokens: u64 = 0;
             let mut seg_cost: f64 = 0.0;
             if let Some(ref mm) = seg.model_metrics {
-                for detail in mm.values() {
+                for (model, detail) in mm {
                     let totals = tokens_and_cost(detail);
                     seg_tokens += totals.tokens;
                     seg_cost += totals.cost;
+                    self.record_model_usage(&end_date, model, detail);
                 }
             }
             *self.tokens_by_day.entry(end_date.clone()).or_insert(0) += seg_tokens;
@@ -45,10 +48,11 @@ impl DailySeriesAccumulator {
         *self.activity_by_day.entry(date.to_string()).or_insert(0) += 1;
         let mut fallback_tokens = 0;
         let mut fallback_cost = 0.0;
-        for detail in model_metrics.values() {
+        for (model, detail) in model_metrics {
             let totals = tokens_and_cost(detail);
             fallback_tokens += totals.tokens;
             fallback_cost += totals.cost;
+            self.record_model_usage(date, model, detail);
         }
         if fallback_tokens > 0 {
             *self.tokens_by_day.entry(date.to_string()).or_insert(0) += fallback_tokens;
@@ -75,6 +79,70 @@ impl DailySeriesAccumulator {
                 .into_iter()
                 .map(|(date, cost)| DayCost { date, cost })
                 .collect(),
+            model_usage_by_day: self
+                .model_usage_by_day
+                .into_values()
+                .map(Into::into)
+                .collect(),
+        }
+    }
+
+    fn record_model_usage(&mut self, date: &str, model: &str, detail: &ModelMetricDetail) {
+        let Some(usage) = detail.usage.as_ref() else {
+            return;
+        };
+        let key = (date.to_string(), model.to_string());
+        let entry = self
+            .model_usage_by_day
+            .entry(key)
+            .or_insert_with(|| DayModelUsageTotals::new(date.to_string(), model.to_string()));
+        entry.input_tokens += usage.input_tokens.unwrap_or(0);
+        entry.output_tokens += usage.output_tokens.unwrap_or(0);
+        entry.cache_read_tokens += usage.cache_read_tokens.unwrap_or(0);
+        entry.cache_write_tokens += usage.cache_write_tokens.unwrap_or(0);
+        if let Some(reasoning_tokens) = usage.reasoning_tokens {
+            entry.reasoning_tokens_sum += reasoning_tokens;
+            entry.has_reasoning_tokens = true;
+        }
+    }
+}
+
+#[derive(Default)]
+struct DayModelUsageTotals {
+    date: String,
+    model: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+    reasoning_tokens_sum: u64,
+    has_reasoning_tokens: bool,
+}
+
+impl DayModelUsageTotals {
+    fn new(date: String, model: String) -> Self {
+        Self {
+            date,
+            model,
+            ..Self::default()
+        }
+    }
+}
+
+impl From<DayModelUsageTotals> for DayModelUsage {
+    fn from(value: DayModelUsageTotals) -> Self {
+        Self {
+            date: value.date,
+            model: value.model,
+            input_tokens: value.input_tokens,
+            output_tokens: value.output_tokens,
+            cache_read_tokens: value.cache_read_tokens,
+            cache_write_tokens: value.cache_write_tokens,
+            reasoning_tokens: if value.has_reasoning_tokens {
+                Some(value.reasoning_tokens_sum)
+            } else {
+                None
+            },
         }
     }
 }

--- a/crates/tracepilot-core/src/analytics/dashboard/models.rs
+++ b/crates/tracepilot-core/src/analytics/dashboard/models.rs
@@ -96,6 +96,7 @@ impl ModelDistributionAccumulator {
                     input_tokens: totals.input_tokens,
                     output_tokens: totals.output_tokens,
                     cache_read_tokens: totals.cache_read_tokens,
+                    cache_write_tokens: totals.cache_write_tokens,
                     premium_requests: totals.premium_cost,
                     request_count: totals.request_count,
                     reasoning_tokens: if totals.has_reasoning_data {

--- a/crates/tracepilot-core/src/analytics/dashboard/tests.rs
+++ b/crates/tracepilot-core/src/analytics/dashboard/tests.rs
@@ -32,6 +32,11 @@ fn test_analytics_single_session() {
     assert!((result.total_cost - 1.50).abs() < f64::EPSILON);
     assert_eq!(result.activity_per_day.len(), 1);
     assert_eq!(result.activity_per_day[0].date, "2026-01-15");
+    assert_eq!(result.model_usage_by_day.len(), 1);
+    assert_eq!(result.model_usage_by_day[0].date, "2026-01-15");
+    assert_eq!(result.model_usage_by_day[0].model, "claude-opus-4.6");
+    assert_eq!(result.model_usage_by_day[0].input_tokens, 5000);
+    assert_eq!(result.model_usage_by_day[0].output_tokens, 5000);
     assert_eq!(result.model_distribution.len(), 1);
     assert_eq!(result.model_distribution[0].model, "claude-opus-4.6");
     assert!((result.model_distribution[0].percentage - 100.0).abs() < f64::EPSILON);

--- a/crates/tracepilot-core/src/analytics/types.rs
+++ b/crates/tracepilot-core/src/analytics/types.rs
@@ -37,6 +37,7 @@ pub struct AnalyticsData {
     pub activity_per_day: Vec<DayActivity>,
     pub model_distribution: Vec<ModelDistEntry>,
     pub cost_by_day: Vec<DayCost>,
+    pub model_usage_by_day: Vec<DayModelUsage>,
     pub api_duration_stats: ApiDurationStats,
     pub productivity_metrics: ProductivityMetrics,
     pub cache_stats: CacheStats,
@@ -73,6 +74,9 @@ pub struct ModelDistEntry {
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
+    /// Cache-write (a.k.a. cache-creation) tokens, billed separately from
+    /// `input_tokens` on Anthropic-style models.
+    pub cache_write_tokens: u64,
     pub premium_requests: f64,
     /// Number of API requests made to this model.
     pub request_count: u64,
@@ -86,6 +90,19 @@ pub struct ModelDistEntry {
 pub struct DayCost {
     pub date: String,
     pub cost: f64,
+}
+
+/// Per-day model token usage for exact local/direct API cost trends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DayModelUsage {
+    pub date: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub reasoning_tokens: Option<u64>,
 }
 
 /// Incident counts for a single day.

--- a/crates/tracepilot-indexer/src/error.rs
+++ b/crates/tracepilot-indexer/src/error.rs
@@ -36,6 +36,10 @@ pub enum IndexerError {
     /// Session parsing error (from tracepilot-core).
     #[error(transparent)]
     SessionParse(#[from] tracepilot_core::TracePilotError),
+
+    /// JSON parsing failed for structured analytics payloads stored in the index.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 }
 
 pub type Result<T> = std::result::Result<T, IndexerError>;

--- a/crates/tracepilot-indexer/src/index_db/analytics_queries/dashboard.rs
+++ b/crates/tracepilot-indexer/src/index_db/analytics_queries/dashboard.rs
@@ -1,7 +1,10 @@
+use std::collections::BTreeMap;
+
 use crate::Result;
 use rusqlite::{Connection, params_from_iter};
 
 use tracepilot_core::analytics::types::*;
+use tracepilot_core::models::event_types::ModelMetricDetail;
 
 use super::super::helpers::*;
 
@@ -142,6 +145,8 @@ pub(super) fn query_analytics(
     );
     let refs = to_refs(&cbd_values);
     let cost_by_day = query_day_cost(conn, &cbd_sql, &refs)?;
+    let model_usage_by_day =
+        query_model_usage_by_day(conn, &where_clause, &bind_values, from_date, to_date)?;
 
     // Model distribution from session_model_metrics
     let mdist_sql = format!(
@@ -150,6 +155,7 @@ pub(super) fn query_analytics(
                     SUM(m.input_tokens),
                     SUM(m.output_tokens),
                     SUM(m.cache_read_tokens),
+                    SUM(m.cache_write_tokens),
                     SUM(m.cost),
                     SUM(m.request_count),
                     SUM(COALESCE(m.reasoning_tokens, 0)),
@@ -260,6 +266,7 @@ pub(super) fn query_analytics(
         activity_per_day,
         model_distribution,
         cost_by_day,
+        model_usage_by_day,
         api_duration_stats,
         productivity_metrics: ProductivityMetrics {
             avg_turns_per_session,
@@ -274,4 +281,138 @@ pub(super) fn query_analytics(
         total_truncations: total_truncations.max(0) as u64,
         incidents_by_day,
     })
+}
+
+#[derive(Default)]
+struct DayModelUsageTotals {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+    reasoning_tokens_sum: u64,
+    has_reasoning_tokens: bool,
+}
+
+fn query_model_usage_by_day(
+    conn: &Connection,
+    where_clause: &str,
+    bind_values: &[String],
+    from_date: Option<&str>,
+    to_date: Option<&str>,
+) -> Result<Vec<DayModelUsage>> {
+    let mut totals: BTreeMap<(String, String), DayModelUsageTotals> = BTreeMap::new();
+
+    let (segment_where, segment_values) = append_segment_date_filter(
+        where_clause,
+        bind_values,
+        from_date,
+        to_date,
+        "m.end_timestamp",
+    );
+    let segment_sql = format!(
+        "SELECT date(m.end_timestamp) as d, m.model_metrics_json
+             FROM session_segments m
+             JOIN sessions s ON s.id = m.session_id
+             {} AND d IS NOT NULL AND m.model_metrics_json IS NOT NULL
+             ORDER BY d",
+        segment_where
+    );
+    let refs = to_refs(&segment_values);
+    let mut stmt = conn.prepare(&segment_sql)?;
+    let rows = stmt.query_map(params_from_iter(refs.iter().copied()), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (date, json) = row?;
+        let model_metrics: std::collections::HashMap<String, ModelMetricDetail> =
+            serde_json::from_str(&json)?;
+        for (model, detail) in model_metrics {
+            add_model_usage(&mut totals, &date, &model, &detail);
+        }
+    }
+
+    let fallback_sql = format!(
+        "SELECT date(COALESCE(s.updated_at, s.created_at)) as d,
+                    m.model_name,
+                    COALESCE(SUM(m.input_tokens), 0),
+                    COALESCE(SUM(m.output_tokens), 0),
+                    COALESCE(SUM(m.cache_read_tokens), 0),
+                    COALESCE(SUM(m.cache_write_tokens), 0),
+                    COALESCE(SUM(COALESCE(m.reasoning_tokens, 0)), 0),
+                    MAX(CASE WHEN m.reasoning_tokens IS NOT NULL THEN 1 ELSE 0 END)
+             FROM session_model_metrics m
+             JOIN sessions s ON s.id = m.session_id{}
+             AND d IS NOT NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM session_segments seg WHERE seg.session_id = s.id
+             )
+             GROUP BY d, m.model_name
+             ORDER BY d, m.model_name",
+        where_clause
+    );
+    let refs = to_refs(bind_values);
+    let mut stmt = conn.prepare(&fallback_sql)?;
+    let fallback_rows = stmt.query_map(params_from_iter(refs.iter().copied()), |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, i64>(6)?,
+            row.get::<_, i64>(7)?,
+        ))
+    })?;
+    for row in fallback_rows {
+        let (date, model, input, output, cache_read, cache_write, reasoning, has_reasoning) = row?;
+        let entry = totals.entry((date.clone(), model.clone())).or_default();
+        entry.input_tokens += input.max(0) as u64;
+        entry.output_tokens += output.max(0) as u64;
+        entry.cache_read_tokens += cache_read.max(0) as u64;
+        entry.cache_write_tokens += cache_write.max(0) as u64;
+        if has_reasoning != 0 {
+            entry.reasoning_tokens_sum += reasoning.max(0) as u64;
+            entry.has_reasoning_tokens = true;
+        }
+    }
+
+    Ok(totals
+        .into_iter()
+        .map(|((date, model), totals)| DayModelUsage {
+            date,
+            model,
+            input_tokens: totals.input_tokens,
+            output_tokens: totals.output_tokens,
+            cache_read_tokens: totals.cache_read_tokens,
+            cache_write_tokens: totals.cache_write_tokens,
+            reasoning_tokens: if totals.has_reasoning_tokens {
+                Some(totals.reasoning_tokens_sum)
+            } else {
+                None
+            },
+        })
+        .collect())
+}
+
+fn add_model_usage(
+    totals: &mut BTreeMap<(String, String), DayModelUsageTotals>,
+    date: &str,
+    model: &str,
+    detail: &ModelMetricDetail,
+) {
+    let Some(usage) = detail.usage.as_ref() else {
+        return;
+    };
+    let entry = totals
+        .entry((date.to_string(), model.to_string()))
+        .or_default();
+    entry.input_tokens += usage.input_tokens.unwrap_or(0);
+    entry.output_tokens += usage.output_tokens.unwrap_or(0);
+    entry.cache_read_tokens += usage.cache_read_tokens.unwrap_or(0);
+    entry.cache_write_tokens += usage.cache_write_tokens.unwrap_or(0);
+    if let Some(reasoning_tokens) = usage.reasoning_tokens {
+        entry.reasoning_tokens_sum += reasoning_tokens;
+        entry.has_reasoning_tokens = true;
+    }
 }

--- a/crates/tracepilot-indexer/src/index_db/helpers/model_distribution.rs
+++ b/crates/tracepilot-indexer/src/index_db/helpers/model_distribution.rs
@@ -4,7 +4,7 @@ use tracepilot_core::analytics::types::ModelDistEntry;
 
 /// Raw row type returned by model-distribution queries before the `i64` sentinel
 /// for `has_reasoning` is converted to `bool`.
-type ModelDistRawRow = (String, i64, i64, i64, i64, f64, i64, i64, bool);
+type ModelDistRawRow = (String, i64, i64, i64, i64, i64, f64, i64, i64, bool);
 
 pub(in crate::index_db) fn query_model_distribution(
     conn: &Connection,
@@ -19,10 +19,11 @@ pub(in crate::index_db) fn query_model_distribution(
             row.get::<_, i64>(2)?,
             row.get::<_, i64>(3)?,
             row.get::<_, i64>(4)?,
-            row.get::<_, f64>(5)?,
-            row.get::<_, i64>(6)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, f64>(6)?,
             row.get::<_, i64>(7)?,
             row.get::<_, i64>(8)?,
+            row.get::<_, i64>(9)?,
         ))
     })?;
     let mut entries: Vec<ModelDistRawRow> = Vec::new();
@@ -34,6 +35,7 @@ pub(in crate::index_db) fn query_model_distribution(
             input_t,
             output_t,
             cache_read,
+            cache_write,
             cost,
             request_count,
             reasoning_sum,
@@ -46,6 +48,7 @@ pub(in crate::index_db) fn query_model_distribution(
             input_t,
             output_t,
             cache_read,
+            cache_write,
             cost,
             request_count,
             reasoning_sum,
@@ -61,6 +64,7 @@ pub(in crate::index_db) fn query_model_distribution(
                 input_t,
                 output_t,
                 cache_read,
+                cache_write,
                 cost,
                 request_count,
                 reasoning_sum,
@@ -78,6 +82,7 @@ pub(in crate::index_db) fn query_model_distribution(
                     input_tokens: input_t as u64,
                     output_tokens: output_t as u64,
                     cache_read_tokens: cache_read as u64,
+                    cache_write_tokens: cache_write as u64,
                     premium_requests: cost,
                     request_count: request_count as u64,
                     reasoning_tokens: if has_reasoning {

--- a/crates/tracepilot-indexer/src/index_db/tests/analytics.rs
+++ b/crates/tracepilot-indexer/src/index_db/tests/analytics.rs
@@ -31,6 +31,57 @@ fn test_query_analytics_basic() {
 }
 
 #[test]
+fn test_query_analytics_model_usage_by_day_from_segments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = IndexDb::open_or_create(&tmp.path().join("index.db")).unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO sessions (id, path, repository, created_at, updated_at, indexed_at)
+             VALUES ('segmented-session', 'C:\\test\\segmented-session', 'org/repo',
+                     '2026-03-10T07:14:50Z', '2026-03-12T09:00:00Z', datetime('now'))",
+            [],
+        )
+        .unwrap();
+    db.conn
+        .execute(
+            "INSERT INTO session_segments
+             (session_id, start_timestamp, end_timestamp, total_tokens, total_requests,
+              total_premium_requests, total_api_duration_ms, current_model, model_metrics_json)
+             VALUES
+             ('segmented-session', '2026-03-10T07:00:00Z', '2026-03-10T07:15:00Z',
+              150, 1, 1.0, 1000, 'claude-opus-4.6',
+              '{\"claude-opus-4.6\":{\"usage\":{\"inputTokens\":100,\"outputTokens\":50,\"cacheReadTokens\":20,\"cacheWriteTokens\":10}}}'),
+             ('segmented-session', '2026-03-11T08:00:00Z', '2026-03-11T08:15:00Z',
+              300, 2, 2.0, 2000, 'gpt-5.4',
+              '{\"gpt-5.4\":{\"usage\":{\"inputTokens\":200,\"outputTokens\":100,\"cacheReadTokens\":40,\"cacheWriteTokens\":0,\"reasoningTokens\":25}}}')",
+            [],
+        )
+        .unwrap();
+
+    let result = db.query_analytics(None, None, None, false).unwrap();
+
+    assert_eq!(result.model_usage_by_day.len(), 2);
+    let day_one = result
+        .model_usage_by_day
+        .iter()
+        .find(|entry| entry.date == "2026-03-10")
+        .unwrap();
+    assert_eq!(day_one.model, "claude-opus-4.6");
+    assert_eq!(day_one.input_tokens, 100);
+    assert_eq!(day_one.output_tokens, 50);
+    assert_eq!(day_one.cache_read_tokens, 20);
+    assert_eq!(day_one.cache_write_tokens, 10);
+
+    let day_two = result
+        .model_usage_by_day
+        .iter()
+        .find(|entry| entry.date == "2026-03-11")
+        .unwrap();
+    assert_eq!(day_two.model, "gpt-5.4");
+    assert_eq!(day_two.reasoning_tokens, Some(25));
+}
+
+#[test]
 fn test_query_analytics_repo_filter() {
     let tmp = tempfile::tempdir().unwrap();
     let db = IndexDb::open_or_create(&tmp.path().join("index.db")).unwrap();

--- a/packages/client/src/mock/analytics.ts
+++ b/packages/client/src/mock/analytics.ts
@@ -23,6 +23,7 @@ export const MOCK_ANALYTICS: AnalyticsData = {
       inputTokens: 82_000,
       outputTokens: 38_000,
       cacheReadTokens: 4_200,
+      cacheWriteTokens: 0,
       premiumRequests: 24,
       requestCount: 46,
     },
@@ -33,6 +34,7 @@ export const MOCK_ANALYTICS: AnalyticsData = {
       inputTokens: 70_000,
       outputTokens: 33_500,
       cacheReadTokens: 3_100,
+      cacheWriteTokens: 1_200,
       premiumRequests: 18,
       requestCount: 39,
     },
@@ -41,6 +43,29 @@ export const MOCK_ANALYTICS: AnalyticsData = {
     date: new Date(new Date(NOW).getTime() - (6 - i) * 86_400_000).toISOString().split("T")[0],
     cost: 12 + i * 1.5,
   })),
+  modelUsageByDay: Array.from({ length: 7 }, (_, i) => {
+    const date = new Date(new Date(NOW).getTime() - (6 - i) * 86_400_000)
+      .toISOString()
+      .split("T")[0];
+    return [
+      {
+        date,
+        model: "gpt-5.4",
+        inputTokens: 10_000 + i * 900,
+        outputTokens: 4_800 + i * 450,
+        cacheReadTokens: 600 + i * 40,
+        cacheWriteTokens: 0,
+      },
+      {
+        date,
+        model: "claude-opus-4.6",
+        inputTokens: 8_500 + i * 650,
+        outputTokens: 4_100 + i * 350,
+        cacheReadTokens: 450 + i * 35,
+        cacheWriteTokens: 120 + i * 20,
+      },
+    ];
+  }).flat(),
   apiDurationStats: {
     avgMs: 480,
     medianMs: 410,

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -23,12 +23,28 @@ export interface AnalyticsData {
     inputTokens: number;
     outputTokens: number;
     cacheReadTokens: number;
+    /**
+     * Cache-write (a.k.a. cache-creation) tokens. Billed separately from
+     * `inputTokens` on Anthropic-style models. Older indexer rows that
+     * predate cache-write aggregation default to 0.
+     */
+    cacheWriteTokens: number;
     premiumRequests: number;
     requestCount: number;
     reasoningTokens?: number | null;
   }>;
   /** Cost per day for trend charts */
   costByDay: Array<{ date: string; cost: number }>;
+  /** Per-day model token usage for exact local/direct API cost trends */
+  modelUsageByDay: Array<{
+    date: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    reasoningTokens?: number | null;
+  }>;
   /** API duration statistics (avg, median, p95 of total_api_duration_ms per session) */
   apiDurationStats: ApiDurationStats;
   /** Productivity heuristics */

--- a/packages/types/src/pricing.ts
+++ b/packages/types/src/pricing.ts
@@ -238,6 +238,16 @@ export function calculateTokenCost(
   const cacheReadTokens = usage.cacheReadTokens ?? 0;
   const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
   const reasoningTokens = usage.reasoningTokens ?? 0;
+  // Token-counting convention (must match the rest of the system, including
+  // the Rust accumulators in tracepilot-core/analytics):
+  //   - `inputTokens` is the TOTAL prompt token count and INCLUDES
+  //     `cacheReadTokens`. Non-cached input is therefore
+  //     `inputTokens - cacheReadTokens`.
+  //   - `cacheWriteTokens` (a.k.a. cache-creation) is DISJOINT from
+  //     `inputTokens` and is billed separately at `cacheWritePerM`. It is
+  //     significant for Anthropic models (~1.25× input rate).
+  //   - `reasoningTokens` is DISJOINT from `outputTokens` and only billed
+  //     when a model defines `reasoningPerM`.
   const nonCachedInputTokens = Math.max(inputTokens - cacheReadTokens, 0);
   const inputCost = (nonCachedInputTokens / 1_000_000) * entry.rates.inputPerM;
   const cachedInputCost = (cacheReadTokens / 1_000_000) * entry.rates.cachedInputPerM;

--- a/packages/ui/src/__tests__/ObjectiveBanner.test.ts
+++ b/packages/ui/src/__tests__/ObjectiveBanner.test.ts
@@ -25,15 +25,10 @@ describe("ObjectiveBanner", () => {
     expect(w.find(".ob-status").text()).toBe("Awaiting");
   });
 
-  it("shows a compact updates badge when the objective changed multiple times", () => {
+  it("does not render update counts for repeated objective changes", () => {
     const w = mount(ObjectiveBanner, {
       props: { objective: { ...sample, updateCount: 4 } },
     });
-    expect(w.find(".ob-updates").text()).toBe("+3");
-  });
-
-  it("does not show updates badge for a single-update objective", () => {
-    const w = mount(ObjectiveBanner, { props: { objective: sample } });
     expect(w.find(".ob-updates").exists()).toBe(false);
   });
 
@@ -76,6 +71,7 @@ describe("ObjectiveBanner", () => {
     expect(w.find(".ob-status").classes()).toContain("ob-status-running");
     expect(w.classes()).toContain("status-running");
     expect(w.find(".ob-dot").exists()).toBe(true);
+    expect(w.find(".ob-status-dots").exists()).toBe(true);
   });
 
   it("exposes accessible status semantics", () => {

--- a/packages/ui/src/__tests__/ObjectiveBanner.test.ts
+++ b/packages/ui/src/__tests__/ObjectiveBanner.test.ts
@@ -15,21 +15,21 @@ describe("ObjectiveBanner", () => {
   it("renders the objective text and accent label", () => {
     const w = mount(ObjectiveBanner, { props: { objective: sample } });
     expect(w.find(".ob-text").text()).toBe(sample.text);
-    expect(w.find(".ob-label").text()).toBe("Current objective");
+    expect(w.find(".ob-label").text()).toBe("Objective");
   });
 
   it("falls back to a muted empty state when objective is null", () => {
     const w = mount(ObjectiveBanner, { props: { objective: null } });
     expect(w.classes()).toContain("empty");
-    expect(w.find(".empty-text").text()).toBe("No objective reported yet");
-    expect(w.find(".ob-status").text()).toBe("Awaiting objective");
+    expect(w.find(".empty-text").text()).toBe("No objective yet");
+    expect(w.find(".ob-status").text()).toBe("Awaiting");
   });
 
-  it("shows an updates badge when the objective changed multiple times", () => {
+  it("shows a compact updates badge when the objective changed multiple times", () => {
     const w = mount(ObjectiveBanner, {
       props: { objective: { ...sample, updateCount: 4 } },
     });
-    expect(w.find(".ob-updates").text()).toBe("Updated 4×");
+    expect(w.find(".ob-updates").text()).toBe("+3");
   });
 
   it("does not show updates badge for a single-update objective", () => {
@@ -42,7 +42,7 @@ describe("ObjectiveBanner", () => {
       props: { objective: sample, status: "completed" },
     });
     const pill = w.find(".ob-status");
-    expect(pill.text()).toBe("Completed");
+    expect(pill.text()).toBe("Done");
     expect(pill.classes()).toContain("ob-status-completed");
   });
 
@@ -71,10 +71,11 @@ describe("ObjectiveBanner", () => {
     expect(w.emitted("reveal")).toBeUndefined();
   });
 
-  it("shows running progress treatment for active objectives", () => {
+  it("shows a running treatment for active objectives", () => {
     const w = mount(ObjectiveBanner, { props: { objective: sample, status: "running" } });
     expect(w.find(".ob-status").classes()).toContain("ob-status-running");
-    expect(w.find(".ob-progress").exists()).toBe(true);
+    expect(w.classes()).toContain("status-running");
+    expect(w.find(".ob-dot").exists()).toBe(true);
   });
 
   it("exposes accessible status semantics", () => {

--- a/packages/ui/src/__tests__/ObjectiveBanner.test.ts
+++ b/packages/ui/src/__tests__/ObjectiveBanner.test.ts
@@ -1,0 +1,95 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import ObjectiveBanner from "../components/ObjectiveBanner.vue";
+import type { CurrentObjective } from "../utils/objective";
+
+const sample: CurrentObjective = {
+  text: "Implementing objective banner",
+  toolCallId: "tc-1",
+  eventIndex: 12,
+  timestamp: "2024-01-01T00:00:00Z",
+  updateCount: 1,
+};
+
+describe("ObjectiveBanner", () => {
+  it("renders the objective text and accent label", () => {
+    const w = mount(ObjectiveBanner, { props: { objective: sample } });
+    expect(w.find(".ob-text").text()).toBe(sample.text);
+    expect(w.find(".ob-label").text()).toBe("Current objective");
+  });
+
+  it("falls back to a muted empty state when objective is null", () => {
+    const w = mount(ObjectiveBanner, { props: { objective: null } });
+    expect(w.classes()).toContain("empty");
+    expect(w.find(".empty-text").text()).toBe("No objective reported yet");
+    expect(w.find(".ob-status").text()).toBe("Awaiting objective");
+  });
+
+  it("shows an updates badge when the objective changed multiple times", () => {
+    const w = mount(ObjectiveBanner, {
+      props: { objective: { ...sample, updateCount: 4 } },
+    });
+    expect(w.find(".ob-updates").text()).toBe("Updated 4×");
+  });
+
+  it("does not show updates badge for a single-update objective", () => {
+    const w = mount(ObjectiveBanner, { props: { objective: sample } });
+    expect(w.find(".ob-updates").exists()).toBe(false);
+  });
+
+  it("renders the completed status pill with success styling", () => {
+    const w = mount(ObjectiveBanner, {
+      props: { objective: sample, status: "completed" },
+    });
+    const pill = w.find(".ob-status");
+    expect(pill.text()).toBe("Completed");
+    expect(pill.classes()).toContain("ob-status-completed");
+  });
+
+  it("emits reveal with deep-link metadata when objective is clicked", async () => {
+    const w = mount(ObjectiveBanner, { props: { objective: sample } });
+    await w.find(".ob-text").trigger("click");
+    const events = w.emitted("reveal");
+    expect(events).toBeTruthy();
+    expect(events![0][0]).toEqual({ eventIndex: 12, toolCallId: "tc-1" });
+  });
+
+  it("does not emit reveal when there is no objective", async () => {
+    const w = mount(ObjectiveBanner, { props: { objective: null } });
+    // The empty state renders a span, not a button — clicking should be a no-op.
+    await w.find(".empty-text").trigger("click");
+    expect(w.emitted("reveal")).toBeUndefined();
+  });
+
+  it("renders static objective text when no deep-link metadata is available", async () => {
+    const w = mount(ObjectiveBanner, {
+      props: { objective: { text: "Legacy objective", updateCount: 1 } },
+    });
+    expect(w.find("button.ob-text").exists()).toBe(false);
+    expect(w.find(".ob-text-static").text()).toBe("Legacy objective");
+    await w.find(".ob-text-static").trigger("click");
+    expect(w.emitted("reveal")).toBeUndefined();
+  });
+
+  it("shows running progress treatment for active objectives", () => {
+    const w = mount(ObjectiveBanner, { props: { objective: sample, status: "running" } });
+    expect(w.find(".ob-status").classes()).toContain("ob-status-running");
+    expect(w.find(".ob-progress").exists()).toBe(true);
+  });
+
+  it("exposes accessible status semantics", () => {
+    const w = mount(ObjectiveBanner, { props: { objective: sample } });
+    expect(w.attributes("role")).toBe("status");
+    expect(w.attributes("aria-live")).toBe("polite");
+    expect(w.attributes("aria-label")).toContain(sample.text);
+  });
+
+  it("applies the subagent accent color via CSS custom property", () => {
+    const w = mount(ObjectiveBanner, {
+      props: { objective: sample, scope: "subagent", accentColor: "#ff00aa" },
+    });
+    const style = w.attributes("style") ?? "";
+    expect(style).toContain("--ob-accent: #ff00aa");
+    expect(w.classes()).toContain("scope-subagent");
+  });
+});

--- a/packages/ui/src/__tests__/SubagentPanelSlots.test.ts
+++ b/packages/ui/src/__tests__/SubagentPanelSlots.test.ts
@@ -1,6 +1,6 @@
 import type { TurnToolCall } from "@tracepilot/types";
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import SubagentPanel from "../components/SubagentPanel/SubagentPanel.vue";
 import type { SubagentView } from "../components/SubagentPanel/types";
 
@@ -61,5 +61,52 @@ describe("SubagentPanel slots", () => {
 
     expect(wrapper.find(".tool-call-item").exists()).toBe(true);
     expect(wrapper.text()).toContain("view");
+  });
+
+  it("reveals the originating intent row when the objective is clicked", async () => {
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    try {
+      const wrapper = mount(SubagentPanel, {
+        props: {
+          view: {
+            ...makeView(makeToolCall()),
+            status: "in-progress",
+            activities: [
+              {
+                kind: "pill",
+                key: "intent-1",
+                sortKey: 1,
+                type: "intent",
+                label: "Reviewing branch",
+                toolCall: makeToolCall({
+                  toolName: "report_intent",
+                  toolCallId: "intent-call",
+                  eventIndex: 42,
+                  arguments: { intent: "Reviewing branch" },
+                }),
+              },
+            ],
+          },
+          renderMarkdown: false,
+          fullResults: new Map(),
+          loadingResults: emptyResultSet(),
+          failedResults: emptyResultSet(),
+        },
+      });
+
+      await wrapper.find("button.ob-text").trigger("click");
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+      expect(wrapper.find('[data-sap-event-idx="42"]').classes()).toContain("sap-reveal-highlight");
+    } finally {
+      Object.defineProperty(Element.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      });
+    }
   });
 });

--- a/packages/ui/src/__tests__/objective.test.ts
+++ b/packages/ui/src/__tests__/objective.test.ts
@@ -1,0 +1,200 @@
+import type { TurnToolCall } from "@tracepilot/types";
+import { describe, expect, it } from "vitest";
+import type { SubagentActivityItem } from "../components/SubagentPanel/types";
+import {
+  getCurrentObjective,
+  getMainAgentObjective,
+  getSubagentObjective,
+} from "../utils/objective";
+
+function intentCall(intent: string, partial: Partial<TurnToolCall> = {}): TurnToolCall {
+  return {
+    toolName: "report_intent",
+    isComplete: true,
+    arguments: { intent },
+    ...partial,
+  };
+}
+
+describe("getCurrentObjective", () => {
+  it("returns null when there are no tool calls", () => {
+    expect(getCurrentObjective([])).toBeNull();
+  });
+
+  it("returns null when there are no report_intent calls", () => {
+    const calls: TurnToolCall[] = [
+      { toolName: "view", isComplete: true, arguments: { path: "/x" } },
+      { toolName: "grep", isComplete: true, arguments: {} },
+    ];
+    expect(getCurrentObjective(calls)).toBeNull();
+  });
+
+  it("ignores empty / whitespace intents", () => {
+    const calls = [intentCall("   "), intentCall("")];
+    expect(getCurrentObjective(calls)).toBeNull();
+  });
+
+  it("returns the latest intent ordered by eventIndex", () => {
+    const calls = [
+      intentCall("first", { eventIndex: 1, toolCallId: "a" }),
+      intentCall("middle", { eventIndex: 5, toolCallId: "b" }),
+      intentCall("latest", { eventIndex: 9, toolCallId: "c" }),
+      intentCall("older", { eventIndex: 4, toolCallId: "d" }),
+    ];
+    const obj = getCurrentObjective(calls);
+    expect(obj).not.toBeNull();
+    expect(obj!.text).toBe("latest");
+    expect(obj!.toolCallId).toBe("c");
+    expect(obj!.eventIndex).toBe(9);
+    expect(obj!.updateCount).toBe(4);
+  });
+
+  it("falls back to timestamp when eventIndex is missing", () => {
+    const calls = [
+      intentCall("a", { startedAt: "2024-01-01T10:00:00Z" }),
+      intentCall("b", { startedAt: "2024-01-01T11:00:00Z" }),
+      intentCall("c", { startedAt: "2024-01-01T09:00:00Z" }),
+    ];
+    expect(getCurrentObjective(calls)!.text).toBe("b");
+  });
+
+  it("falls back to input order when neither eventIndex nor timestamp is set", () => {
+    const calls = [intentCall("first"), intentCall("second"), intentCall("third")];
+    expect(getCurrentObjective(calls)!.text).toBe("third");
+  });
+
+  it("trims surrounding whitespace from the intent text", () => {
+    const calls = [intentCall("  Building things  ", { eventIndex: 1 })];
+    expect(getCurrentObjective(calls)!.text).toBe("Building things");
+  });
+
+  it("does not count consecutive duplicate intent text as a new update", () => {
+    const calls = [
+      intentCall("building", { eventIndex: 1 }),
+      intentCall("building", { eventIndex: 2 }),
+      intentCall("testing", { eventIndex: 3 }),
+    ];
+    expect(getCurrentObjective(calls)!.updateCount).toBe(2);
+  });
+});
+
+describe("getMainAgentObjective", () => {
+  it("scopes to tool calls without a parentToolCallId", () => {
+    const turns = [
+      {
+        toolCalls: [
+          intentCall("subagent intent", { eventIndex: 5, parentToolCallId: "p1" }),
+          intentCall("main intent", { eventIndex: 6 }),
+        ],
+      },
+      {
+        toolCalls: [intentCall("nested", { eventIndex: 12, parentToolCallId: "p2" })],
+      },
+    ];
+    expect(getMainAgentObjective(turns)!.text).toBe("main intent");
+  });
+
+  it("returns null when only sub-agents have intents", () => {
+    const turns = [
+      {
+        toolCalls: [intentCall("child only", { eventIndex: 1, parentToolCallId: "p" })],
+      },
+    ];
+    expect(getMainAgentObjective(turns)).toBeNull();
+  });
+
+  it("prefers eventIndex chronology over timestamp fallback when records are mixed", () => {
+    const turns = [
+      {
+        toolCalls: [
+          intentCall("timestamp-only", { startedAt: "2099-01-01T00:00:00Z" }),
+          intentCall("event-indexed", { eventIndex: 1, startedAt: "2024-01-01T00:00:00Z" }),
+        ],
+      },
+    ];
+    expect(getMainAgentObjective(turns)!.text).toBe("event-indexed");
+  });
+
+  it("counts every main-agent intent update", () => {
+    const turns = [
+      {
+        toolCalls: [intentCall("a", { eventIndex: 1 }), intentCall("b", { eventIndex: 4 })],
+      },
+      { toolCalls: [intentCall("c", { eventIndex: 9 })] },
+    ];
+    const obj = getMainAgentObjective(turns)!;
+    expect(obj.text).toBe("c");
+    expect(obj.updateCount).toBe(3);
+  });
+});
+
+describe("getSubagentObjective", () => {
+  function pill(intent: string, eventIndex?: number): SubagentActivityItem {
+    return {
+      kind: "pill",
+      key: `pill-${intent}`,
+      sortKey: eventIndex ?? 0,
+      type: "intent",
+      label: intent,
+      toolCall: {
+        toolName: "report_intent",
+        isComplete: true,
+        arguments: { intent },
+        eventIndex,
+      },
+    };
+  }
+
+  it("returns null when there are no intent pills", () => {
+    const activities: SubagentActivityItem[] = [
+      { kind: "reasoning", key: "r", sortKey: 0, content: "thinking" },
+    ];
+    expect(getSubagentObjective(activities)).toBeNull();
+  });
+
+  it("returns latest intent pill", () => {
+    const activities: SubagentActivityItem[] = [
+      pill("first", 2),
+      { kind: "reasoning", key: "r", sortKey: 3, content: "..." },
+      pill("second", 10),
+      pill("third", 7),
+    ];
+    const obj = getSubagentObjective(activities)!;
+    expect(obj.text).toBe("second");
+    expect(obj.updateCount).toBe(3);
+  });
+
+  it("ignores non-intent pills", () => {
+    const activities: SubagentActivityItem[] = [
+      pill("real", 1),
+      {
+        kind: "pill",
+        key: "mem",
+        sortKey: 5,
+        type: "memory",
+        label: "saved fact",
+        toolCall: {
+          toolName: "store_memory",
+          isComplete: true,
+          arguments: { fact: "x" },
+          eventIndex: 5,
+        },
+      },
+    ];
+    expect(getSubagentObjective(activities)!.text).toBe("real");
+  });
+
+  it("falls back to the pill label when the args lack an intent string", () => {
+    const activities: SubagentActivityItem[] = [
+      {
+        kind: "pill",
+        key: "p",
+        sortKey: 1,
+        type: "intent",
+        label: "Label fallback",
+        toolCall: { toolName: "report_intent", isComplete: true, arguments: {}, eventIndex: 1 },
+      },
+    ];
+    expect(getSubagentObjective(activities)!.text).toBe("Label fallback");
+  });
+});

--- a/packages/ui/src/components/ObjectiveBanner.vue
+++ b/packages/ui/src/components/ObjectiveBanner.vue
@@ -43,11 +43,6 @@ const statusLabel = computed(() => {
   }
 });
 
-const updateBadge = computed(() => {
-  const n = props.objective?.updateCount ?? 0;
-  return n > 1 ? `+${n - 1}` : null;
-});
-
 const ariaText = computed(() => {
   if (!props.objective) return `${props.label}: none reported yet.`;
   return `${props.label}: ${props.objective.text}.`;
@@ -91,14 +86,12 @@ function handleClick() {
       {{ objective!.text }}
     </span>
     <span v-else class="ob-text empty-text">No objective yet</span>
-    <span
-      v-if="updateBadge"
-      class="ob-updates"
-      :title="`Objective changed ${objective?.updateCount} times`"
-    >
-      {{ updateBadge }}
+    <span :class="['ob-status', `ob-status-${status}`]">
+      {{ statusLabel }}
+      <span v-if="status === 'running' && hasObjective" class="ob-status-dots" aria-hidden="true">
+        <span>.</span><span>.</span><span>.</span>
+      </span>
     </span>
-    <span :class="['ob-status', `ob-status-${status}`]">{{ statusLabel }}</span>
   </section>
 </template>
 
@@ -184,7 +177,6 @@ button.ob-text:focus-visible {
   font-weight: 400;
 }
 
-.ob-updates,
 .ob-status {
   font-size: 0.6875rem;
   font-weight: 500;
@@ -193,13 +185,29 @@ button.ob-text:focus-visible {
   color: var(--text-tertiary, #8b949e);
 }
 
-.ob-updates {
-  color: color-mix(in srgb, var(--ob-accent) 70%, var(--text-tertiary, #8b949e));
-  font-variant-numeric: tabular-nums;
+.ob-status-running {
+  display: inline-flex;
+  align-items: baseline;
+  color: color-mix(in srgb, var(--ob-accent) 80%, var(--text-secondary, #b1bac4));
 }
 
-.ob-status-running {
-  color: color-mix(in srgb, var(--ob-accent) 80%, var(--text-secondary, #b1bac4));
+.ob-status-dots {
+  display: inline-flex;
+  width: 1em;
+  margin-left: 1px;
+}
+
+.ob-status-dots span {
+  opacity: 0;
+  animation: objectiveDotFade 1.2s ease-in-out infinite;
+}
+
+.ob-status-dots span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.ob-status-dots span:nth-child(3) {
+  animation-delay: 0.32s;
 }
 
 .ob-status-completed {
@@ -225,9 +233,25 @@ button.ob-text:focus-visible {
   }
 }
 
+@keyframes objectiveDotFade {
+  0%,
+  35% {
+    opacity: 0;
+  }
+  55%,
+  100% {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .status-running .ob-dot {
+  .status-running .ob-dot,
+  .ob-status-dots span {
     animation: none;
+  }
+
+  .ob-status-dots span {
+    opacity: 1;
   }
 }
 </style>

--- a/packages/ui/src/components/ObjectiveBanner.vue
+++ b/packages/ui/src/components/ObjectiveBanner.vue
@@ -105,23 +105,25 @@ function handleClick() {
 <style scoped>
 .objective-banner {
   --ob-accent: var(--accent-fg, #58a6ff);
-  display: grid;
-  grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
-  padding: 4px 10px;
-  border: 0;
-  border-top: 1px solid color-mix(in srgb, var(--ob-accent) 18%, var(--border-muted, transparent));
-  background: transparent;
+  padding: 5px 9px;
+  border: 1px solid color-mix(in srgb, var(--ob-accent) 14%, var(--border-muted, transparent));
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, var(--canvas-overlay, var(--canvas-default, #0d1117)) 82%, transparent);
   color: var(--text-secondary, #b1bac4);
   font-size: 0.75rem;
   line-height: 1.3;
+  box-shadow: 0 8px 24px color-mix(in srgb, #000 16%, transparent);
 }
 
 .objective-banner.empty {
   --ob-accent: var(--text-tertiary, #8b949e);
-  border-top-color: var(--border-muted, transparent);
+  border-color: var(--border-muted, transparent);
 }
 
 .ob-dot {
@@ -144,7 +146,7 @@ function handleClick() {
   color: var(--text-tertiary, #8b949e);
   font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
 }
 
 .ob-text {
@@ -184,7 +186,6 @@ button.ob-text:focus-visible {
 
 .ob-updates,
 .ob-status {
-  justify-self: end;
   font-size: 0.6875rem;
   font-weight: 500;
   line-height: 1;
@@ -215,7 +216,7 @@ button.ob-text:focus-visible {
 
 .objective-banner.scope-subagent {
   padding-left: 8px;
-  border-left: 2px solid var(--ob-accent);
+  border-left-color: var(--ob-accent);
 }
 
 @keyframes objectiveDot {

--- a/packages/ui/src/components/ObjectiveBanner.vue
+++ b/packages/ui/src/components/ObjectiveBanner.vue
@@ -1,13 +1,4 @@
 <script setup lang="ts">
-/**
- * ObjectiveBanner — persistent display of the *current* session or subagent
- * objective (latest `report_intent`). Mirrors what the CLI surfaces as a
- * progress bar so users can always see what the agent is currently aiming
- * at, without scanning inline events.
- *
- * The banner intentionally adopts the existing accent‑subtle pill idiom
- * used by the chat view's intent pill so it feels native, not generic.
- */
 import { computed } from "vue";
 import type { CurrentObjective } from "../utils/objective";
 
@@ -17,30 +8,19 @@ type ObjectiveStatus = "running" | "completed" | "failed" | "idle";
 const props = withDefaults(
   defineProps<{
     objective: CurrentObjective | null;
-    /** "session" gets a generic accent; "subagent" inherits the agent color. */
     scope?: ObjectiveScope;
-    /** Optional override label (defaults to "Current objective"). */
     label?: string;
-    /** Drives the right‑hand status pill. */
     status?: ObjectiveStatus;
-    /** Custom accent color (used by the subagent variant). */
     accentColor?: string;
-    /** Hide the leading 🎯 icon (for embeds that already show one). */
-    hideIcon?: boolean;
   }>(),
   {
     scope: "session",
-    label: "Current objective",
+    label: "Objective",
     status: "running",
-    hideIcon: false,
   },
 );
 
 const emit = defineEmits<{
-  /**
-   * Emitted when the user clicks the objective text. Hosts can use this to
-   * scroll to / reveal the originating `report_intent` event.
-   */
   reveal: [info: { eventIndex?: number; toolCallId?: string }];
 }>();
 
@@ -50,21 +30,22 @@ const canReveal = computed(
 );
 
 const statusLabel = computed(() => {
+  if (!hasObjective.value) return "Awaiting";
   switch (props.status) {
     case "completed":
-      return "Completed";
+      return "Done";
     case "failed":
       return "Failed";
     case "idle":
-      return hasObjective.value ? "Idle" : "Awaiting objective";
+      return "Idle";
     default:
-      return hasObjective.value ? "In progress" : "Awaiting objective";
+      return "Running";
   }
 });
 
 const updateBadge = computed(() => {
   const n = props.objective?.updateCount ?? 0;
-  return n > 1 ? `Updated ${n}×` : null;
+  return n > 1 ? `+${n - 1}` : null;
 });
 
 const ariaText = computed(() => {
@@ -83,13 +64,6 @@ function handleClick() {
     toolCallId: props.objective.toolCallId,
   });
 }
-
-function handleKey(ev: KeyboardEvent) {
-  if (ev.key === "Enter" || ev.key === " ") {
-    ev.preventDefault();
-    handleClick();
-  }
-}
 </script>
 
 <template>
@@ -102,208 +76,160 @@ function handleKey(ev: KeyboardEvent) {
     :aria-label="ariaText"
     :data-objective-event-idx="objective?.eventIndex ?? undefined"
   >
-    <span v-if="!hideIcon" class="ob-icon" aria-hidden="true">🎯</span>
-    <div class="ob-body">
-      <span class="ob-label">{{ label }}</span>
-      <button
-        v-if="hasObjective && canReveal"
-        type="button"
-        class="ob-text"
-        :title="objective!.text"
-        @click="handleClick"
-        @keydown="handleKey"
-      >
-        {{ objective!.text }}
-      </button>
-      <span v-else-if="hasObjective" class="ob-text ob-text-static" :title="objective!.text">
-        {{ objective!.text }}
-      </span>
-      <span v-else class="ob-text empty-text">No objective reported yet</span>
-    </div>
-    <span v-if="updateBadge" class="ob-updates" :title="`Objective changed ${objective?.updateCount} times`">{{ updateBadge }}</span>
+    <span class="ob-dot" aria-hidden="true" />
+    <span class="ob-label">{{ label }}</span>
+    <button
+      v-if="hasObjective && canReveal"
+      type="button"
+      class="ob-text"
+      :title="objective!.text"
+      @click="handleClick"
+    >
+      {{ objective!.text }}
+    </button>
+    <span v-else-if="hasObjective" class="ob-text ob-text-static" :title="objective!.text">
+      {{ objective!.text }}
+    </span>
+    <span v-else class="ob-text empty-text">No objective yet</span>
+    <span
+      v-if="updateBadge"
+      class="ob-updates"
+      :title="`Objective changed ${objective?.updateCount} times`"
+    >
+      {{ updateBadge }}
+    </span>
     <span :class="['ob-status', `ob-status-${status}`]">{{ statusLabel }}</span>
-    <span v-if="status === 'running' && hasObjective" class="ob-progress" aria-hidden="true" />
   </section>
 </template>
 
 <style scoped>
 .objective-banner {
   --ob-accent: var(--accent-fg, #58a6ff);
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto auto;
   align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: var(--radius-md, 6px);
-  background: color-mix(in srgb, var(--ob-accent) 8%, var(--canvas-inset, var(--canvas-default, #0d1117)));
-  border: 1px solid color-mix(in srgb, var(--ob-accent) 25%, transparent);
-  font-size: 0.8125rem;
-  line-height: 1.35;
+  gap: 8px;
   min-width: 0;
-  position: relative;
-  overflow: hidden;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--ob-accent) 20%, var(--border-default, transparent));
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, var(--ob-accent) 6%, var(--canvas-overlay, var(--canvas-default, #0d1117)));
+  color: var(--text-secondary, #b1bac4);
+  font-size: 0.75rem;
+  line-height: 1.3;
 }
 
 .objective-banner.empty {
-  --ob-accent: var(--text-tertiary, #6e7681);
-  background: var(--canvas-inset, var(--canvas-default, #0d1117));
+  --ob-accent: var(--text-tertiary, #8b949e);
+  background: var(--canvas-subtle, var(--canvas-default, #0d1117));
 }
 
-.ob-icon {
-  flex-shrink: 0;
-  font-size: 14px;
-  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--ob-accent) 35%, transparent));
+.ob-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ob-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ob-accent) 12%, transparent);
 }
 
-.objective-banner.empty .ob-icon {
-  filter: none;
-  opacity: 0.55;
+.status-running .ob-dot {
+  animation: objectiveDot 1.5s ease-in-out infinite;
 }
 
-.ob-body {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  flex: 1;
-  min-width: 0;
+.objective-banner.empty .ob-dot {
+  opacity: 0.45;
+  box-shadow: none;
 }
 
 .ob-label {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
   color: var(--text-tertiary, #8b949e);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .ob-text {
+  min-width: 0;
   appearance: none;
-  background: transparent;
   border: 0;
-  padding: 0;
-  margin: 0;
-  text-align: left;
+  background: transparent;
+  color: var(--text-primary, #f0f6fc);
   font: inherit;
-  color: var(--ob-accent);
   font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
+  text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 100%;
+  white-space: nowrap;
 }
 
-.ob-text:hover,
-.ob-text:focus-visible {
-  text-decoration: underline;
+button.ob-text {
+  cursor: pointer;
+}
+
+button.ob-text:hover,
+button.ob-text:focus-visible {
+  color: var(--ob-accent);
   outline: none;
 }
 
-.ob-text.empty-text {
+.ob-text-static,
+.empty-text {
   cursor: default;
+}
+
+.empty-text {
   color: var(--text-tertiary, #8b949e);
   font-weight: 400;
-  font-style: italic;
 }
 
-.ob-text-static {
-  cursor: default;
-}
-
-.ob-updates {
-  flex-shrink: 0;
-  font-size: 0.6875rem;
-  color: var(--text-secondary, #b1bac4);
-  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
-  padding: 1px 7px;
-  border-radius: var(--radius-full, 100px);
-}
-
+.ob-updates,
 .ob-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  flex-shrink: 0;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: var(--radius-full, 100px);
-  background: color-mix(in srgb, var(--ob-accent) 18%, transparent);
-  color: var(--ob-accent);
+  justify-self: end;
+  border-radius: var(--radius-full, 999px);
+  background: color-mix(in srgb, var(--ob-accent) 12%, transparent);
+  color: color-mix(in srgb, var(--ob-accent) 82%, var(--text-primary, #f0f6fc));
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1;
   white-space: nowrap;
 }
 
-.ob-status-running::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 38%, transparent);
-  animation: objectivePulse 1.4s ease-out infinite;
+.ob-updates {
+  padding: 3px 5px;
+}
+
+.ob-status {
+  padding: 4px 7px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .ob-status-completed {
-  background: var(--success-subtle, rgba(46, 160, 67, 0.15));
   color: var(--success-fg, #3fb950);
 }
 
 .ob-status-failed {
-  background: var(--danger-subtle, rgba(248, 81, 73, 0.15));
   color: var(--danger-fg, #f85149);
 }
 
 .ob-status-idle {
-  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
   color: var(--text-tertiary, #8b949e);
 }
 
-.ob-progress {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 2px;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    color-mix(in srgb, var(--ob-accent) 20%, transparent) 20%,
-    var(--ob-accent) 48%,
-    color-mix(in srgb, var(--ob-accent) 20%, transparent) 76%,
-    transparent 100%
-  );
-  transform: translateX(-100%);
-  animation: objectiveProgressSweep 1.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
-  opacity: 0.75;
+.objective-banner.scope-subagent {
+  border-left-width: 3px;
 }
 
-@keyframes objectivePulse {
-  70% {
-    box-shadow: 0 0 0 6px color-mix(in srgb, currentColor 0%, transparent);
-  }
-  100% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 0%, transparent);
-  }
-}
-
-@keyframes objectiveProgressSweep {
-  to {
-    transform: translateX(100%);
+@keyframes objectiveDot {
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--ob-accent) 0%, transparent);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ob-status-running::before,
-  .ob-progress {
+  .status-running .ob-dot {
     animation: none;
   }
-
-  .ob-progress {
-    transform: none;
-  }
-}
-
-/* Subagent variant sits flush inside the panel and is slightly more compact. */
-.objective-banner.scope-subagent {
-  padding: 6px 10px;
 }
 </style>

--- a/packages/ui/src/components/ObjectiveBanner.vue
+++ b/packages/ui/src/components/ObjectiveBanner.vue
@@ -1,0 +1,309 @@
+<script setup lang="ts">
+/**
+ * ObjectiveBanner — persistent display of the *current* session or subagent
+ * objective (latest `report_intent`). Mirrors what the CLI surfaces as a
+ * progress bar so users can always see what the agent is currently aiming
+ * at, without scanning inline events.
+ *
+ * The banner intentionally adopts the existing accent‑subtle pill idiom
+ * used by the chat view's intent pill so it feels native, not generic.
+ */
+import { computed } from "vue";
+import type { CurrentObjective } from "../utils/objective";
+
+type ObjectiveScope = "session" | "subagent";
+type ObjectiveStatus = "running" | "completed" | "failed" | "idle";
+
+const props = withDefaults(
+  defineProps<{
+    objective: CurrentObjective | null;
+    /** "session" gets a generic accent; "subagent" inherits the agent color. */
+    scope?: ObjectiveScope;
+    /** Optional override label (defaults to "Current objective"). */
+    label?: string;
+    /** Drives the right‑hand status pill. */
+    status?: ObjectiveStatus;
+    /** Custom accent color (used by the subagent variant). */
+    accentColor?: string;
+    /** Hide the leading 🎯 icon (for embeds that already show one). */
+    hideIcon?: boolean;
+  }>(),
+  {
+    scope: "session",
+    label: "Current objective",
+    status: "running",
+    hideIcon: false,
+  },
+);
+
+const emit = defineEmits<{
+  /**
+   * Emitted when the user clicks the objective text. Hosts can use this to
+   * scroll to / reveal the originating `report_intent` event.
+   */
+  reveal: [info: { eventIndex?: number; toolCallId?: string }];
+}>();
+
+const hasObjective = computed(() => !!props.objective);
+const canReveal = computed(
+  () => props.objective?.eventIndex != null || !!props.objective?.toolCallId,
+);
+
+const statusLabel = computed(() => {
+  switch (props.status) {
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "idle":
+      return hasObjective.value ? "Idle" : "Awaiting objective";
+    default:
+      return hasObjective.value ? "In progress" : "Awaiting objective";
+  }
+});
+
+const updateBadge = computed(() => {
+  const n = props.objective?.updateCount ?? 0;
+  return n > 1 ? `Updated ${n}×` : null;
+});
+
+const ariaText = computed(() => {
+  if (!props.objective) return `${props.label}: none reported yet.`;
+  return `${props.label}: ${props.objective.text}.`;
+});
+
+const accentStyle = computed(() =>
+  props.accentColor && props.scope === "subagent" ? { "--ob-accent": props.accentColor } : {},
+);
+
+function handleClick() {
+  if (!props.objective || !canReveal.value) return;
+  emit("reveal", {
+    eventIndex: props.objective.eventIndex,
+    toolCallId: props.objective.toolCallId,
+  });
+}
+
+function handleKey(ev: KeyboardEvent) {
+  if (ev.key === "Enter" || ev.key === " ") {
+    ev.preventDefault();
+    handleClick();
+  }
+}
+</script>
+
+<template>
+  <section
+    class="objective-banner"
+    :class="[`scope-${scope}`, `status-${status}`, { empty: !hasObjective }]"
+    :style="accentStyle"
+    role="status"
+    aria-live="polite"
+    :aria-label="ariaText"
+    :data-objective-event-idx="objective?.eventIndex ?? undefined"
+  >
+    <span v-if="!hideIcon" class="ob-icon" aria-hidden="true">🎯</span>
+    <div class="ob-body">
+      <span class="ob-label">{{ label }}</span>
+      <button
+        v-if="hasObjective && canReveal"
+        type="button"
+        class="ob-text"
+        :title="objective!.text"
+        @click="handleClick"
+        @keydown="handleKey"
+      >
+        {{ objective!.text }}
+      </button>
+      <span v-else-if="hasObjective" class="ob-text ob-text-static" :title="objective!.text">
+        {{ objective!.text }}
+      </span>
+      <span v-else class="ob-text empty-text">No objective reported yet</span>
+    </div>
+    <span v-if="updateBadge" class="ob-updates" :title="`Objective changed ${objective?.updateCount} times`">{{ updateBadge }}</span>
+    <span :class="['ob-status', `ob-status-${status}`]">{{ statusLabel }}</span>
+    <span v-if="status === 'running' && hasObjective" class="ob-progress" aria-hidden="true" />
+  </section>
+</template>
+
+<style scoped>
+.objective-banner {
+  --ob-accent: var(--accent-fg, #58a6ff);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md, 6px);
+  background: color-mix(in srgb, var(--ob-accent) 8%, var(--canvas-inset, var(--canvas-default, #0d1117)));
+  border: 1px solid color-mix(in srgb, var(--ob-accent) 25%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  min-width: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.objective-banner.empty {
+  --ob-accent: var(--text-tertiary, #6e7681);
+  background: var(--canvas-inset, var(--canvas-default, #0d1117));
+}
+
+.ob-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--ob-accent) 35%, transparent));
+}
+
+.objective-banner.empty .ob-icon {
+  filter: none;
+  opacity: 0.55;
+}
+
+.ob-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ob-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, #8b949e);
+}
+
+.ob-text {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  font: inherit;
+  color: var(--ob-accent);
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.ob-text:hover,
+.ob-text:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.ob-text.empty-text {
+  cursor: default;
+  color: var(--text-tertiary, #8b949e);
+  font-weight: 400;
+  font-style: italic;
+}
+
+.ob-text-static {
+  cursor: default;
+}
+
+.ob-updates {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  color: var(--text-secondary, #b1bac4);
+  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
+  padding: 1px 7px;
+  border-radius: var(--radius-full, 100px);
+}
+
+.ob-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-full, 100px);
+  background: color-mix(in srgb, var(--ob-accent) 18%, transparent);
+  color: var(--ob-accent);
+  white-space: nowrap;
+}
+
+.ob-status-running::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 38%, transparent);
+  animation: objectivePulse 1.4s ease-out infinite;
+}
+
+.ob-status-completed {
+  background: var(--success-subtle, rgba(46, 160, 67, 0.15));
+  color: var(--success-fg, #3fb950);
+}
+
+.ob-status-failed {
+  background: var(--danger-subtle, rgba(248, 81, 73, 0.15));
+  color: var(--danger-fg, #f85149);
+}
+
+.ob-status-idle {
+  background: var(--neutral-subtle, rgba(110, 118, 129, 0.1));
+  color: var(--text-tertiary, #8b949e);
+}
+
+.ob-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--ob-accent) 20%, transparent) 20%,
+    var(--ob-accent) 48%,
+    color-mix(in srgb, var(--ob-accent) 20%, transparent) 76%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: objectiveProgressSweep 1.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  opacity: 0.75;
+}
+
+@keyframes objectivePulse {
+  70% {
+    box-shadow: 0 0 0 6px color-mix(in srgb, currentColor 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 0%, transparent);
+  }
+}
+
+@keyframes objectiveProgressSweep {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ob-status-running::before,
+  .ob-progress {
+    animation: none;
+  }
+
+  .ob-progress {
+    transform: none;
+  }
+}
+
+/* Subagent variant sits flush inside the panel and is slightly more compact. */
+.objective-banner.scope-subagent {
+  padding: 6px 10px;
+}
+</style>

--- a/packages/ui/src/components/ObjectiveBanner.vue
+++ b/packages/ui/src/components/ObjectiveBanner.vue
@@ -110,10 +110,10 @@ function handleClick() {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  padding: 7px 10px;
-  border: 1px solid color-mix(in srgb, var(--ob-accent) 20%, var(--border-default, transparent));
-  border-radius: var(--radius-md, 8px);
-  background: color-mix(in srgb, var(--ob-accent) 6%, var(--canvas-overlay, var(--canvas-default, #0d1117)));
+  padding: 4px 10px;
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--ob-accent) 18%, var(--border-muted, transparent));
+  background: transparent;
   color: var(--text-secondary, #b1bac4);
   font-size: 0.75rem;
   line-height: 1.3;
@@ -121,32 +121,30 @@ function handleClick() {
 
 .objective-banner.empty {
   --ob-accent: var(--text-tertiary, #8b949e);
-  background: var(--canvas-subtle, var(--canvas-default, #0d1117));
+  border-top-color: var(--border-muted, transparent);
 }
 
 .ob-dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--ob-accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ob-accent) 12%, transparent);
 }
 
 .status-running .ob-dot {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ob-accent) 14%, transparent);
   animation: objectiveDot 1.5s ease-in-out infinite;
 }
 
 .objective-banner.empty .ob-dot {
   opacity: 0.45;
-  box-shadow: none;
 }
 
 .ob-label {
   color: var(--text-tertiary, #8b949e);
   font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .ob-text {
@@ -161,6 +159,7 @@ function handleClick() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 0;
 }
 
 button.ob-text {
@@ -186,23 +185,20 @@ button.ob-text:focus-visible {
 .ob-updates,
 .ob-status {
   justify-self: end;
-  border-radius: var(--radius-full, 999px);
-  background: color-mix(in srgb, var(--ob-accent) 12%, transparent);
-  color: color-mix(in srgb, var(--ob-accent) 82%, var(--text-primary, #f0f6fc));
-  font-size: 0.625rem;
-  font-weight: 700;
+  font-size: 0.6875rem;
+  font-weight: 500;
   line-height: 1;
   white-space: nowrap;
+  color: var(--text-tertiary, #8b949e);
 }
 
 .ob-updates {
-  padding: 3px 5px;
+  color: color-mix(in srgb, var(--ob-accent) 70%, var(--text-tertiary, #8b949e));
+  font-variant-numeric: tabular-nums;
 }
 
-.ob-status {
-  padding: 4px 7px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.ob-status-running {
+  color: color-mix(in srgb, var(--ob-accent) 80%, var(--text-secondary, #b1bac4));
 }
 
 .ob-status-completed {
@@ -218,7 +214,8 @@ button.ob-text:focus-visible {
 }
 
 .objective-banner.scope-subagent {
-  border-left-width: 3px;
+  padding-left: 8px;
+  border-left: 2px solid var(--ob-accent);
 }
 
 @keyframes objectiveDot {

--- a/packages/ui/src/components/SubagentPanel/SubagentActivityStream.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentActivityStream.vue
@@ -128,6 +128,8 @@ function richEnabled(toolName: string): boolean {
         <div
           v-else-if="item.kind === 'pill'"
           :class="['sap-pill', `sap-pill--${item.type}`]"
+          :data-sap-event-idx="item.toolCall.eventIndex ?? undefined"
+          :data-sap-tool-call-id="item.toolCall.toolCallId ?? undefined"
         >
           <span class="sap-pill-icon">{{ pillIcon(item.type) }}</span>
           <span class="sap-pill-label">{{ item.label }}</span>

--- a/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
@@ -3,7 +3,7 @@
 // inline transition, scroll container, prev/next nav). Both the conversation
 // slide-out and the agent-tree inline panel render this same body so they
 // cannot drift.
-import { computed, ref, useSlots, watch } from "vue";
+import { computed, nextTick, ref, useSlots, watch } from "vue";
 import { getAgentColor, getAgentIcon } from "../../utils/agentTypes";
 import { formatDuration, formatLiveDuration } from "../../utils/formatters";
 import { getSubagentObjective } from "../../utils/objective";
@@ -58,6 +58,7 @@ const headerDuration = computed(() => {
 
 const promptExpanded = ref(false);
 const outputExpanded = ref(false);
+const bodyEl = ref<HTMLElement | null>(null);
 
 const descriptionText = computed(() => props.view.intentSummary || props.view.description || "");
 
@@ -73,6 +74,28 @@ const objectiveStatus = computed<"running" | "completed" | "failed" | "idle">(()
       return currentObjective.value ? "running" : "idle";
   }
 });
+
+function revealObjective(info: { eventIndex?: number; toolCallId?: string }) {
+  const root = bodyEl.value;
+  if (!root) return;
+
+  const selector =
+    info.eventIndex != null
+      ? `[data-sap-event-idx="${info.eventIndex}"]`
+      : info.toolCallId
+        ? `[data-sap-tool-call-id="${CSS.escape(info.toolCallId)}"]`
+        : null;
+  if (!selector) return;
+
+  const target = root.querySelector<HTMLElement>(selector);
+  if (!target) return;
+
+  nextTick(() => {
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    target.classList.add("sap-reveal-highlight");
+    window.setTimeout(() => target.classList.remove("sap-reveal-highlight"), 1800);
+  });
+}
 
 watch(
   () => props.view.id,
@@ -94,7 +117,7 @@ watch(
     @close="emit('close')"
   />
 
-  <div class="sap-body">
+  <div ref="bodyEl" class="sap-body">
     <SubagentModelWarning
       v-if="view.modelSubstituted && view.requestedModel && view.model"
       :requested-model="view.requestedModel"
@@ -161,18 +184,35 @@ watch(
       :objective="currentObjective"
       :status="objectiveStatus"
       :accent-color="agentColor"
+      @reveal="revealObjective"
     />
   </div>
 </template>
 
 <style scoped>
 .sap-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
-.sap-objective { margin-bottom: 2px; }
+.sap-objective {
+  align-self: center;
+  margin-bottom: 2px;
+}
 .sap-objective-footer {
   position: sticky;
   bottom: 0;
   z-index: 2;
   margin-top: 4px;
+}
+:deep(.sap-reveal-highlight) {
+  animation: sapRevealFlash 1.8s ease-out;
+}
+@keyframes sapRevealFlash {
+  0%,
+  45% {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-emphasis, #58a6ff) 65%, transparent);
+    background: color-mix(in srgb, var(--accent-emphasis, #58a6ff) 14%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
 }
 .sap-section { margin: 0; }
 .sap-section-label { font-size: 0.6875rem; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }

--- a/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
@@ -6,6 +6,8 @@
 import { computed, ref, useSlots, watch } from "vue";
 import { getAgentColor, getAgentIcon } from "../../utils/agentTypes";
 import { formatDuration, formatLiveDuration } from "../../utils/formatters";
+import { getSubagentObjective } from "../../utils/objective";
+import ObjectiveBanner from "../ObjectiveBanner.vue";
 import SubagentActivityStream from "./SubagentActivityStream.vue";
 import SubagentCollapsibleBlock from "./SubagentCollapsibleBlock.vue";
 import SubagentModelWarning from "./SubagentModelWarning.vue";
@@ -59,6 +61,19 @@ const outputExpanded = ref(false);
 
 const descriptionText = computed(() => props.view.intentSummary || props.view.description || "");
 
+const currentObjective = computed(() => getSubagentObjective(props.view.activities));
+
+const objectiveStatus = computed<"running" | "completed" | "failed" | "idle">(() => {
+  switch (status.value) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    default:
+      return currentObjective.value ? "running" : "idle";
+  }
+});
+
 watch(
   () => props.view.id,
   () => {
@@ -80,6 +95,15 @@ watch(
   />
 
   <div class="sap-body">
+    <ObjectiveBanner
+      class="sap-objective"
+      scope="subagent"
+      label="Current objective"
+      :objective="currentObjective"
+      :status="objectiveStatus"
+      :accent-color="agentColor"
+    />
+
     <SubagentModelWarning
       v-if="view.modelSubstituted && view.requestedModel && view.model"
       :requested-model="view.requestedModel"
@@ -138,11 +162,29 @@ watch(
         <slot name="tool" v-bind="slotProps" />
       </template>
     </SubagentActivityStream>
+
+    <ObjectiveBanner
+      v-if="currentObjective"
+      class="sap-objective sap-objective-footer"
+      scope="subagent"
+      label="Current objective"
+      :objective="currentObjective"
+      :status="objectiveStatus"
+      :accent-color="agentColor"
+    />
   </div>
 </template>
 
 <style scoped>
 .sap-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+.sap-objective { margin-bottom: 2px; }
+.sap-objective-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  margin-top: 4px;
+  box-shadow: 0 -8px 18px var(--shadow-color, rgba(0, 0, 0, 0.18));
+}
 .sap-section { margin: 0; }
 .sap-section-label { font-size: 0.6875rem; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }
 .sap-description { font-size: 0.8125rem; color: var(--text-secondary); line-height: 1.5; margin: 0; }

--- a/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
@@ -172,8 +172,7 @@ watch(
   position: sticky;
   bottom: 0;
   z-index: 2;
-  margin-top: 6px;
-  box-shadow: 0 -8px 18px var(--shadow-color, rgba(0, 0, 0, 0.16));
+  margin-top: 4px;
 }
 .sap-section { margin: 0; }
 .sap-section-label { font-size: 0.6875rem; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }

--- a/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
+++ b/packages/ui/src/components/SubagentPanel/SubagentPanel.vue
@@ -95,15 +95,6 @@ watch(
   />
 
   <div class="sap-body">
-    <ObjectiveBanner
-      class="sap-objective"
-      scope="subagent"
-      label="Current objective"
-      :objective="currentObjective"
-      :status="objectiveStatus"
-      :accent-color="agentColor"
-    />
-
     <SubagentModelWarning
       v-if="view.modelSubstituted && view.requestedModel && view.model"
       :requested-model="view.requestedModel"
@@ -167,7 +158,6 @@ watch(
       v-if="currentObjective"
       class="sap-objective sap-objective-footer"
       scope="subagent"
-      label="Current objective"
       :objective="currentObjective"
       :status="objectiveStatus"
       :accent-color="agentColor"
@@ -182,8 +172,8 @@ watch(
   position: sticky;
   bottom: 0;
   z-index: 2;
-  margin-top: 4px;
-  box-shadow: 0 -8px 18px var(--shadow-color, rgba(0, 0, 0, 0.18));
+  margin-top: 6px;
+  box-shadow: 0 -8px 18px var(--shadow-color, rgba(0, 0, 0, 0.16));
 }
 .sap-section { margin: 0; }
 .sap-section-label { font-size: 0.6875rem; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -26,6 +26,7 @@ export { default as LoadingSpinner } from "./components/LoadingSpinner.vue";
 export { default as MarkdownContent } from "./components/MarkdownContent.vue";
 export { default as MiniTimeline } from "./components/MiniTimeline.vue";
 export { default as ModalDialog } from "./components/ModalDialog.vue";
+export { default as ObjectiveBanner } from "./components/ObjectiveBanner.vue";
 export { default as PageHeader } from "./components/PageHeader.vue";
 export { default as PageShell } from "./components/PageShell.vue";
 export { default as ProgressBar } from "./components/ProgressBar.vue";
@@ -229,6 +230,12 @@ export {
 } from "./utils/formatters";
 export { detectLanguage, languageDisplayName } from "./utils/languageDetection";
 export { ensureMarkdownReady } from "./utils/markdownLoader";
+export type { CurrentObjective } from "./utils/objective";
+export {
+  getCurrentObjective,
+  getMainAgentObjective,
+  getSubagentObjective,
+} from "./utils/objective";
 export {
   normalizePath,
   pathBasename,

--- a/packages/ui/src/utils/objective.ts
+++ b/packages/ui/src/utils/objective.ts
@@ -1,0 +1,148 @@
+/**
+ * Derive a session's (or subagent's) **current objective** from a list of
+ * tool calls or subagent activity items.
+ *
+ * Source of truth: the latest non-empty `report_intent` tool call. We pick
+ * "latest" by the largest `eventIndex` (when present), falling back to
+ * `completedAt`/`startedAt` timestamps and ultimately to input order so
+ * legacy data without event indices still produces a stable result.
+ *
+ * The CLI surfaces the same value as a progress bar; in the desktop app
+ * we use this helper to drive a persistent objective banner instead of
+ * relying purely on inline pill rendering.
+ */
+import type { TurnToolCall } from "@tracepilot/types";
+import { getToolArgs, toolArgString } from "@tracepilot/types";
+import type { SubagentActivityItem } from "../components/SubagentPanel/types";
+
+export interface CurrentObjective {
+  /** The intent text reported by the agent (already trimmed, never empty). */
+  text: string;
+  /** Tool call id of the originating `report_intent` (for deep-linking). */
+  toolCallId?: string;
+  /** Event index of the originating `report_intent` (for deep-linking). */
+  eventIndex?: number;
+  /** ISO timestamp of the originating event, when available. */
+  timestamp?: string;
+  /** Number of distinct intent updates observed (≥ 1 once we have one). */
+  updateCount: number;
+}
+
+interface IntentRecord {
+  text: string;
+  toolCallId?: string;
+  eventIndex?: number;
+  timestamp?: string;
+  /** Stable input ordinal — used as the final tiebreaker. */
+  ordinal: number;
+}
+
+function recordRank(r: IntentRecord): [number, number, number] {
+  // eventIndex is the canonical chronological key. When missing, fall back
+  // to the parsed timestamp; otherwise rely on the input ordinal. Keep the
+  // domains separate so timestamp-only legacy rows never outrank canonical
+  // event-indexed rows.
+  if (typeof r.eventIndex === "number") return [2, r.eventIndex, r.ordinal];
+  if (r.timestamp) {
+    const t = Date.parse(r.timestamp);
+    if (Number.isFinite(t)) return [1, t, r.ordinal];
+  }
+  return [0, r.ordinal, 0];
+}
+
+function compareRank(a: [number, number, number], b: [number, number, number]): number {
+  return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+}
+
+function pushIfIntent(out: IntentRecord[], tc: TurnToolCall, ordinal: number): void {
+  if (tc.toolName !== "report_intent") return;
+  const text = toolArgString(getToolArgs(tc), "intent").trim();
+  if (!text) return;
+  out.push({
+    text,
+    toolCallId: tc.toolCallId,
+    eventIndex: tc.eventIndex,
+    timestamp: tc.completedAt ?? tc.startedAt,
+    ordinal,
+  });
+}
+
+function finalize(records: IntentRecord[]): CurrentObjective | null {
+  if (records.length === 0) return null;
+  const distinctUpdates = records.reduce<string[]>((acc, record) => {
+    if (acc[acc.length - 1] !== record.text) acc.push(record.text);
+    return acc;
+  }, []);
+  let latest = records[0];
+  let latestRank = recordRank(latest);
+  for (let i = 1; i < records.length; i++) {
+    const rank = recordRank(records[i]);
+    if (compareRank(rank, latestRank) > 0) {
+      latest = records[i];
+      latestRank = rank;
+    }
+  }
+  return {
+    text: latest.text,
+    toolCallId: latest.toolCallId,
+    eventIndex: latest.eventIndex,
+    timestamp: latest.timestamp,
+    updateCount: distinctUpdates.length,
+  };
+}
+
+/**
+ * Returns the latest objective from a flat list of tool calls. The caller
+ * is responsible for pre-filtering scope (e.g. to main agent vs. a single
+ * subagent's children).
+ */
+export function getCurrentObjective(toolCalls: readonly TurnToolCall[]): CurrentObjective | null {
+  const records: IntentRecord[] = [];
+  for (let i = 0; i < toolCalls.length; i++) pushIfIntent(records, toolCalls[i], i);
+  return finalize(records);
+}
+
+/**
+ * Returns the latest objective for the **main agent** of a conversation —
+ * i.e. tool calls without a `parentToolCallId`. Convenience wrapper that
+ * accepts the raw turns array used by the conversation view.
+ */
+export function getMainAgentObjective(
+  turns: readonly { toolCalls: readonly TurnToolCall[] }[],
+): CurrentObjective | null {
+  const records: IntentRecord[] = [];
+  let ordinal = 0;
+  for (const turn of turns) {
+    for (const tc of turn.toolCalls) {
+      if (tc.parentToolCallId) continue;
+      pushIfIntent(records, tc, ordinal++);
+    }
+  }
+  return finalize(records);
+}
+
+/**
+ * Returns the latest objective from a subagent's activity stream. Subagent
+ * panels already build activities (with intent pills); reusing them keeps
+ * the banner perfectly in sync without re-walking child tool calls.
+ */
+export function getSubagentObjective(
+  activities: readonly SubagentActivityItem[],
+): CurrentObjective | null {
+  const records: IntentRecord[] = [];
+  for (let i = 0; i < activities.length; i++) {
+    const a = activities[i];
+    if (a.kind !== "pill" || a.type !== "intent") continue;
+    const tc = a.toolCall;
+    const text = toolArgString(getToolArgs(tc), "intent").trim() || a.label.trim();
+    if (!text) continue;
+    records.push({
+      text,
+      toolCallId: tc.toolCallId,
+      eventIndex: tc.eventIndex,
+      timestamp: tc.completedAt ?? tc.startedAt,
+      ordinal: i,
+    });
+  }
+  return finalize(records);
+}


### PR DESCRIPTION
## Summary
- adds a persisted icon-only desktop sidebar with a cleaner collapsed rail and smoother transition behavior
- fixes analytics/direct API pricing by carrying cache write tokens through model distribution and exact per-day model usage
- adds the analytics cost graph toggle between legacy Copilot and direct API costs
- redesigns current objective chrome for sessions/subagents, with the session strip integrated into the chat/SDK steering bottom stack
- aligns the model performance matrix and prevents API price truncation

## Token pricing bug found
The token math helper was already treating cache reads and cache writes correctly, but aggregate analytics/model comparison omitted `cacheWriteTokens` from model distribution inputs. That understated direct API / wholesale costs for cache-write-heavy usage. This PR threads cache writes through the Rust/TS analytics contracts and cost call sites, plus adds exact per-day direct API model usage for the graph toggle.

## Validation
- `pnpm --filter @tracepilot/desktop test -- src\__tests__\components\layout\AppSidebar.test.ts src\__tests__\views\analytics-views.test.ts src\utils\__tests__\analyticsCostSeries.test.ts src\components\modelComparison\__tests__\ModelComparisonChildren.test.ts`
- `pnpm --filter @tracepilot/ui test -- src\__tests__\objective.test.ts src\__tests__\ObjectiveBanner.test.ts`
- `pnpm --filter @tracepilot/desktop typecheck && pnpm --filter @tracepilot/ui typecheck`
- `cargo test -p tracepilot-core -p tracepilot-indexer`
- `node scripts\check-file-sizes.mjs`
- pre-push hook: repo typecheck, rustfmt-all, file-size guardrail