### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and hide decorative symbol on Search Syntax Guide close button

### DIFF
--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,7 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button class="syntax-help-close" aria-label="Close search syntax guide" @click="$emit('close')"><span aria-hidden="true">✕</span></button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">


### PR DESCRIPTION
**💡 What**: Added an `aria-label` to the close button in the Search Syntax Guide modal and wrapped the raw `✕` unicode character in a `<span aria-hidden="true">`.
**🎯 Why**: The close button was icon-only and relied entirely on a visual `✕` symbol. Screen readers could confusingly read this out as "multiplication sign" or "times". This change provides a clean, descriptive text alternative for assistive technologies.
**📸 Before/After**: N/A - purely structural/accessibility change, no visual differences.
**♿ Accessibility**: Screen readers will now reliably announce "Close search syntax guide" instead of reading a confusing symbol, drastically improving navigation for users dependent on assistive tech.

---
*PR created automatically by Jules for task [11716397680339472388](https://jules.google.com/task/11716397680339472388) started by @MattShelton04*