### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons in search results

### DIFF
--- a/apps/desktop/src/components/search/SearchGroupedResults.vue
+++ b/apps/desktop/src/components/search/SearchGroupedResults.vue
@@ -43,9 +43,10 @@ defineEmits<{
           <button
             class="session-group-filter-btn"
             title="Filter search to this session"
+            aria-label="Filter search to this session"
             @click.stop="$emit('filter-by-session', group.sessionId, group.sessionSummary)"
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
               <path d="M2 4h12M4 8h8M6 12h4" />
             </svg>
           </button>
@@ -53,9 +54,10 @@ defineEmits<{
             :to="`/session/${group.sessionId}/conversation`"
             class="session-group-goto-btn"
             title="Go to session"
+            aria-label="Go to session"
             @click.stop
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
               <path d="M6 3l5 5-5 5" />
             </svg>
           </router-link>

--- a/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
+++ b/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
@@ -37,9 +37,10 @@ const emit = defineEmits<{
       <button
         class="view-mode-btn"
         title="Clear search"
+        aria-label="Clear search"
         @click="emit('clear-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="4" y1="4" x2="12" y2="12" /><line x1="12" y1="4" x2="4" y2="12" />
         </svg>
       </button>
@@ -47,9 +48,10 @@ const emit = defineEmits<{
         v-if="hasResults"
         class="view-mode-btn"
         title="Copy all results"
+        aria-label="Copy all results"
         @click="emit('copy-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="5" y="5" width="9" height="9" rx="1" /><path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
         </svg>
       </button>
@@ -57,9 +59,10 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'flat' }"
         title="Flat list"
+        aria-label="Flat list"
         @click="emit('update:resultViewMode', 'flat')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="2" y1="4" x2="14" y2="4" /><line x1="2" y1="8" x2="14" y2="8" /><line x1="2" y1="12" x2="14" y2="12" />
         </svg>
       </button>
@@ -67,9 +70,10 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'grouped' }"
         title="Grouped by session"
+        aria-label="Grouped by session"
         @click="emit('update:resultViewMode', 'grouped')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="2" y="2" width="12" height="4" rx="1" /><rect x="2" y="10" width="12" height="4" rx="1" />
         </svg>
       </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the "Clear search", "Copy all results", "Flat list", and "Grouped by session" icon-only buttons in the Search Results header, as well as the "Filter search to this session" and "Go to session" icon buttons in grouped search results. Also added `aria-hidden="true"` to their internal `<svg>` icons.

🎯 **Why:** To improve accessibility. Without `aria-label`s, screen readers may read out confusing or useless information for icon-only buttons. Without `aria-hidden` on the inner SVGs, some screen readers will attempt to read the SVG elements themselves instead of just the button label.

📸 **Before/After:** No visual change.

♿ **Accessibility:** This directly fixes a screen reader navigation gap, making the search interface utilities usable and understandable for visually impaired users.

---
*PR created automatically by Jules for task [15941965157850607235](https://jules.google.com/task/15941965157850607235) started by @MattShelton04*