### PR TITLE
🎨 Palette: [accessibility improvement] Hide decorative icons from screen readers

### DIFF
--- a/apps/desktop/src/components/RefreshToolbar.vue
+++ b/apps/desktop/src/components/RefreshToolbar.vue
@@ -69,7 +69,7 @@ onUnmounted(() => {
       aria-label="Refresh data"
       @click="emit('refresh')"
     >
-      <svg class="refresh-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" class="refresh-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 8a6 6 0 1 1-6-6c1.7 0 3.3.7 4.5 1.8L14 5.5" />
         <path d="M14 1.5v4h-4" />
       </svg>

--- a/apps/desktop/src/components/SearchPalette.vue
+++ b/apps/desktop/src/components/SearchPalette.vue
@@ -200,7 +200,7 @@ onUnmounted(() => {
               aria-label="Clear search"
               @click="query = ''"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
             <kbd class="kbd">ESC</kbd>
           </div>

--- a/apps/desktop/src/components/ThemeToggle.vue
+++ b/apps/desktop/src/components/ThemeToggle.vue
@@ -16,11 +16,11 @@ function toggle() {
     @click="toggle"
   >
     <!-- Sun icon (shown in dark mode) -->
-    <svg v-if="prefs.theme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <svg aria-hidden="true" v-if="prefs.theme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
     </svg>
     <!-- Moon icon (shown in light mode) -->
-    <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <svg aria-hidden="true" v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
     </svg>
   </button>

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -49,7 +49,7 @@ function handleOpenRelease() {
       <div class="modal-content" role="dialog" aria-labelledby="update-modal-title">
         <div class="modal-header">
           <h2 id="update-modal-title">Update to v{{ version }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close" @click="emit('close')"><span aria-hidden="true">×</span></button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -45,7 +45,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
       <div class="modal-content" role="dialog" aria-labelledby="whats-new-title">
         <div class="modal-header">
           <h2 id="whats-new-title">🎉 What's New in v{{ currentVersion }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close" @click="emit('close')"><span aria-hidden="true">×</span></button>
         </div>
 
         <div class="modal-body">

--- a/packages/ui/src/components/SearchableSelect.vue
+++ b/packages/ui/src/components/SearchableSelect.vue
@@ -203,11 +203,12 @@ watch(filteredOptions, () => {
           v-if="clearable && searchQuery"
           class="clear-btn"
           title="Clear selection"
+          aria-label="Clear selection"
           @mousedown.prevent="clear"
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
         </button>
-        <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
+        <svg aria-hidden="true" class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
           <path d="M6 9l6 6 6-6" />
         </svg>
       </span>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to decorative icons (both SVGs and text characters like '✕') inside interactive elements, and ensured `aria-label`s are present.

🎯 **Why:** To prevent screen readers from redundantly or confusingly announcing decorative inner characters when focused on an element that already provides its semantic meaning via an `aria-label`.

♿ **Accessibility:**
- Added `aria-hidden="true"` to SVG elements in `ThemeToggle.vue`, `RefreshToolbar.vue`, and `SearchableSelect.vue`.
- Wrapped '✕' character inside `<span aria-hidden="true">` for clear buttons in `SearchPalette.vue`, `UpdateInstructionsModal.vue`, and `WhatsNewModal.vue`.
- Added missing `aria-label` to the clear button inside `SearchableSelect.vue`.

---
*PR created automatically by Jules for task [9943433231683817106](https://jules.google.com/task/9943433231683817106) started by @MattShelton04*