### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in GitHub skill imports

### DIFF
--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -172,7 +172,9 @@ pub(crate) fn import_from_github_path(
                         // segments without false positives on names like "..foo".
                         let has_traversal = Path::new(relative)
                             .components()
-                            .any(|c| matches!(c, std::path::Component::ParentDir));
+                            .any(|c| matches!(c, std::path::Component::ParentDir))
+                            || relative.contains('\\')
+                            || relative.starts_with('/');
                         if has_traversal || Path::new(relative).is_absolute() {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal vulnerability in GitHub skill imports. The `import_from_github` function unpacked files based on relative paths extracted from a GitHub tree. While it checked for `..` components using `std::path::Component::ParentDir`, this check on Unix platforms does not detect backslash (`\`) separators. A malicious repository could use backslashes or absolute paths to escape the staging directory when the payload is extracted on a Windows host or if Git processed such entries.
🎯 **Impact:** An attacker could craft a malicious GitHub repository that, when imported as a skill, writes arbitrary files to arbitrary locations on the user's disk (e.g., overwriting configuration files, injecting code, or replacing system executables).
🔧 **Fix:** Enhanced the validation of `relative` paths to explicitly reject any path containing a backslash (`\`) or starting with a forward slash (`/`), in addition to the existing `ParentDir` component check.
✅ **Verification:** Verified by running the workspace test suite (`cargo test --workspace`) and ensuring that `cargo clippy` reports no new warnings. All tests pass successfully.

---
*PR created automatically by Jules for task [3163715072953746811](https://jules.google.com/task/3163715072953746811) started by @MattShelton04*