### PR TITLE
refactor: centralize session path joins

### DIFF
--- a/crates/tracepilot-core/src/summary/loader.rs
+++ b/crates/tracepilot-core/src/summary/loader.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use crate::error::Result;
 use crate::models::session_summary::SessionSummary;
-use crate::parsing::EVENTS_JSONL;
 use crate::parsing::events::{TypedEvent, parse_typed_events};
 
 use super::artifacts::apply_artifact_flags;
@@ -58,7 +57,7 @@ fn load_session_summary_impl(session_dir: &Path, retain_events: bool) -> Result<
     let mut summary = load_workspace_summary(session_dir)?;
 
     // 2–5. Events processing — parse ONCE, derive count from len()
-    let events_path = session_dir.join(EVENTS_JSONL);
+    let events_path = crate::paths::SessionPaths::from_root(session_dir).events_jsonl();
     let mut typed_events_out = None;
     let mut diagnostics_out = None;
 

--- a/crates/tracepilot-indexer/src/index_db/types.rs
+++ b/crates/tracepilot-indexer/src/index_db/types.rs
@@ -178,7 +178,7 @@ impl SessionFileMeta {
 }
 
 pub(super) fn get_workspace_mtime(session_path: &std::path::Path) -> Option<String> {
-    let ws_path = session_path.join("workspace.yaml");
+    let ws_path = tracepilot_core::paths::SessionPaths::from_root(session_path).workspace_yaml();
     std::fs::metadata(&ws_path)
         .ok()
         .and_then(|m| m.modified().ok())
@@ -189,7 +189,7 @@ pub(super) fn get_workspace_mtime(session_path: &std::path::Path) -> Option<Stri
 }
 
 pub(super) fn get_events_mtime_and_size(session_path: &std::path::Path) -> Option<(String, u64)> {
-    let ev_path = session_path.join("events.jsonl");
+    let ev_path = tracepilot_core::paths::SessionPaths::from_root(session_path).events_jsonl();
     let meta = std::fs::metadata(&ev_path).ok()?;
     let mtime = meta.modified().ok()?;
     let dt: chrono::DateTime<chrono::Utc> = mtime.into();

--- a/crates/tracepilot-tauri-bindings/src/commands/export_import/export.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/export_import/export.rs
@@ -283,10 +283,11 @@ pub async fn get_session_sections(
 ) -> CmdResult<SessionSectionsInfo> {
     let sid = crate::validators::validate_session_id(&session_id)?;
     with_session_path(&state, sid, move |session_path| {
-        let events_path = session_path.join("events.jsonl");
-        let db_path = session_path.join("session.db");
-        let plan_path = session_path.join("plan.md");
-        let checkpoints_path = session_path.join("checkpoints");
+        let sp = tracepilot_core::paths::SessionPaths::from_root(&session_path);
+        let events_path = sp.events_jsonl();
+        let db_path = sp.session_db();
+        let plan_path = sp.plan_md();
+        let checkpoints_path = sp.checkpoints_dir();
 
         let summary = tracepilot_core::summary::load_session_summary(&session_path).ok();
 
@@ -311,7 +312,7 @@ pub async fn get_session_sections(
             has_checkpoints,
             has_metrics,
             has_incidents: has_events && scan_events_for_incidents(&events_path),
-            has_rewind_snapshots: session_path.join("rewind-snapshots").exists(),
+            has_rewind_snapshots: sp.rewind_snapshots_dir().exists(),
             has_custom_tables: check_custom_tables(&db_path),
             event_count: summary.as_ref().and_then(|s| s.event_count),
             turn_count: summary.as_ref().and_then(|s| s.turn_count),

--- a/crates/tracepilot-tauri-bindings/src/commands/session/detail.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/session/detail.rs
@@ -25,7 +25,8 @@ pub async fn get_session_detail(
             &session_id,
             &session_state_dir,
         )?;
-        let events_path = path.join("events.jsonl");
+        let sp = tracepilot_core::paths::SessionPaths::from_root(&path);
+        let events_path = sp.events_jsonl();
 
         // Use cached events — avoids re-parsing events.jsonl on every call.
         // Cache key is (session_id, file_size, mtime) so active sessions
@@ -96,7 +97,7 @@ pub async fn get_shutdown_metrics(
     let cache_session_id = session_id.clone();
 
     with_session_path(&state, sid, move |path| {
-        let events_path = path.join("events.jsonl");
+        let events_path = tracepilot_core::paths::SessionPaths::from_root(path).events_jsonl();
         let (events, _, _) = load_cached_typed_events(&cache, &cache_session_id, &events_path)?;
         Ok(
             tracepilot_core::parsing::events::extract_combined_shutdown_data(events.as_ref())

--- a/crates/tracepilot-tauri-bindings/src/commands/session/turns.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/session/turns.rs
@@ -27,7 +27,7 @@ pub async fn get_session_turns(
             &session_id,
             &session_state_dir,
         )?;
-        let events_path = path.join("events.jsonl");
+        let events_path = tracepilot_core::paths::SessionPaths::from_root(&path).events_jsonl();
 
         // Check LRU cache — return if file size unchanged (append-only).
         // Clone cache data and release lock before running prepare_turns_for_ipc


### PR DESCRIPTION
# Tech Debt Refactoring: Centralize Session Path Joins

This PR replaces manual `path.join("...")` calls with the centralized `tracepilot_core::paths::SessionPaths` helper across multiple crates. This ensures consistency in how session files (events, workspace, DB, etc.) are resolved and reduces duplication of session structure knowledge.

## Fixes

### 1. Indexer Path Refactor
- **What**: Replaced manual path joins for `workspace.yaml` and `events.jsonl` in `crates/tracepilot-indexer/src/index_db/types.rs`.
- **Why**: Ensures the indexer uses the same path resolution logic as the rest of the workspace.
- **Evidence**: 2 sites refactored.

### 2. Tauri Bindings Path Refactor
- **What**: Refactored `detail.rs`, `turns.rs`, and `export.rs` in `crates/tracepilot-tauri-bindings` to use `SessionPaths`.
- **Why**: Centralizes path logic at the IPC bridge, ensuring the frontend and backend agree on session file locations.
- **Evidence**: 6 sites refactored (including `rewind-snapshots` missed in initial pass).

### 3. Core Summary Loader Refactor
- **What**: Replaced manual `EVENTS_JSONL` join in `crates/tracepilot-core/src/summary/loader.rs`.
- **Why**: Removes a dependency on internal constants and uses the idiomatic workspace helper.
- **Evidence**: 1 site refactored, unused import removed.

## Verification

- `cargo clippy -p tracepilot-core -p tracepilot-indexer -p tracepilot-tauri-bindings -- -D warnings` (Exit Code: 0)
- `cargo test -p tracepilot-core -p tracepilot-indexer -p tracepilot-tauri-bindings` (Exit Code: 0)
