### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in osascript terminal launch

### DIFF
--- a/crates/tracepilot-orchestrator/src/launcher.rs
+++ b/crates/tracepilot-orchestrator/src/launcher.rs
@@ -147,9 +147,8 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
     // If a branch was specified but we're NOT creating a worktree, checkout the branch first
     let checkout_cmd = if !config.create_worktree {
         config.branch.as_deref().map(|b| {
-            let escaped = b.replace('\'', "''");
-            // Try checkout; if it fails (branch doesn't exist locally), try creating from remote
-            format!("git checkout '{b}'", b = escaped)
+            // Use shell_quote to prevent command injection via branch name
+            format!("git checkout {}", crate::process::shell_quote(b))
         })
     } else {
         None
@@ -258,7 +257,7 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
             .unwrap_or_default();
         let full_cmd = format!("{}{}{}", checkout_prefix, copilot_cmd, interactive_suffix);
         let envs_ref = if envs.is_empty() { None } else { Some(&envs) };
-        crate::process::spawn_detached_terminal(&full_cmd, &[], &work_dir, envs_ref)?
+        crate::process::spawn_detached_terminal("sh", &["-c", &full_cmd], &work_dir, envs_ref)?
     };
 
     Ok(LaunchedSession {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection in `launcher.rs` during terminal launch on macOS/Linux. The code previously used `b.replace('\'', "''")` to escape git branch names, which is correct for Windows PowerShell, but incorrect for POSIX shells, allowing an attacker to escape quotes and execute arbitrary shell commands if they provided a crafted branch name. Additionally, `spawn_detached_terminal` was incorrectly attempting to launch complex multi-command strings (containing `&&`) directly, leading to execution failures.
🎯 Impact: Arbitrary command execution.
🔧 Fix: Used `crate::process::shell_quote(b)` for robust cross-platform shell escaping of the branch name. Updated `spawn_detached_terminal` invocation on macOS/Linux to correctly use `sh -c` so compound commands are evaluated safely.
✅ Verification: Ran full `cargo test --workspace` and `cargo clippy`.

---
*PR created automatically by Jules for task [3429876792158381984](https://jules.google.com/task/3429876792158381984) started by @MattShelton04*