### PR TITLE
chore: release v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project loosely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-05-10
+
+### Added
+- **Inline skill invocation rendering** — conversation views now show skill calls as dedicated session events instead of burying them inside generic tool activity
+
+### Changed
+- **Usage-based Copilot pricing support** — pricing settings, session metrics, analytics, and model comparison now understand the newer AI Credit / usage-based billing model
+- **Better objective and cost visibility** — active session objectives are surfaced more clearly, and analytics cost series/distributions are easier to interpret
+- **UI polish across core surfaces** — sidebar, search palette, session views, and shared tool-renderer chrome now feel more consistent and readable
+
+### Fixed
+- **Copilot CLI 1.0.40 compatibility** — newer permission-related events and payload shapes now parse and render correctly
+
 ## [0.6.5] - 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,7 +5948,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracepilot-bench"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "criterion",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-desktop"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "console-subscriber",
  "log",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-export"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "once_cell",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-indexer"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "rayon",
@@ -6040,7 +6040,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-orchestrator"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "copilot-sdk",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-tauri-bindings"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "tracepilot-test-support"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 authors = ["Matt Shelton (@MattShelton04)"]
 license = "GPL-3.0-or-later"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/cli",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "TracePilot CLI - inspect Copilot sessions from your terminal",
   "author": "Matt Shelton (@MattShelton04)",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/desktop",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "TracePilot desktop application - Tauri + Vue",
   "author": "Matt Shelton (@MattShelton04)",

--- a/apps/desktop/public/release-manifest.json
+++ b/apps/desktop/public/release-manifest.json
@@ -1,6 +1,24 @@
 {
   "versions": [
     {
+      "version": "0.6.6",
+      "date": "2026-05-10",
+      "notes": {
+        "added": [
+          "Inline skill invocation rendering: conversation views now show skill calls as dedicated session events instead of burying them inside generic tool activity"
+        ],
+        "changed": [
+          "Usage-based Copilot pricing support: pricing settings, session metrics, analytics, and model comparison now understand the newer AI Credit / usage-based billing model",
+          "Better objective and cost visibility: active session objectives are surfaced more clearly, and analytics cost series/distributions are easier to interpret",
+          "UI polish across core surfaces: sidebar, search palette, session views, and shared tool-renderer chrome now feel more consistent and readable"
+        ],
+        "fixed": [
+          "Copilot CLI 1.0.40 compatibility: newer permission-related events and payload shapes now parse and render correctly"
+        ]
+      },
+      "requiresReindex": false
+    },
+    {
       "version": "0.6.5",
       "date": "2026-05-03",
       "notes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracepilot",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "author": "Matt Shelton (@MattShelton04)",
   "license": "GPL-3.0-or-later",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/client",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "TypeScript client wrapper for TracePilot backend commands",
   "author": "Matt Shelton (@MattShelton04)",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/config",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "Shared TypeScript configuration presets",
   "author": "Matt Shelton (@MattShelton04)",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/test-utils",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "Shared test utilities for TracePilot packages",
   "author": "Matt Shelton (@MattShelton04)",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/types",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "Shared TypeScript types and API contracts for TracePilot",
   "author": "Matt Shelton (@MattShelton04)",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracepilot/ui",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "Shared Vue UI components for TracePilot",
   "author": "Matt Shelton (@MattShelton04)",


### PR DESCRIPTION
## Summary
- bump workspace and package versions to 0.6.6
- add the 0.6.6 changelog entry
- add the 0.6.6 in-app release manifest entry