### PR TITLE
🎨 Palette: Hide decorative close icons from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Decorative ✕ character screen reader accessibility
+**Learning:** Purely decorative characters like '✕' inside interactive elements (like buttons) must be wrapped with `<span aria-hidden="true">` to prevent screen readers from announcing them confusingly, even when the parent has an explicit `aria-label`.
+**Action:** Always wrap decorative unicode symbols (e.g. '✕') in `<span aria-hidden="true">` when used inside buttons or spans with click handlers.

--- a/apps/desktop/src/components/search/SearchActiveFilters.vue
+++ b/apps/desktop/src/components/search/SearchActiveFilters.vue
@@ -37,19 +37,19 @@ const emit = defineEmits<{
         />
         <span v-if="chip.mode === 'exclude'" class="filter-chip-prefix">NOT</span>
         {{ contentTypeConfig[chip.type]?.label ?? chip.type }}
-        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="repository" class="filter-chip filter-chip-neutral">
         Repo: {{ repository }}
-        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="toolName" class="filter-chip filter-chip-neutral">
         Tool: {{ toolName }}
-        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="sessionId" class="filter-chip filter-chip-include">
         Session: {{ sessionDisplayName }}
-        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <button v-if="activeFilterCount > 1" class="filter-chip-clear-all" @click="$emit('clear-all')">
         Clear all

--- a/apps/desktop/src/components/search/SearchBrowsePresets.vue
+++ b/apps/desktop/src/components/search/SearchBrowsePresets.vue
@@ -81,7 +81,8 @@ const store = useSearchStore();
             @click.stop="store.removeRecentSearch(recent.query)"
             @keydown.enter.stop="store.removeRecentSearch(recent.query)"
             title="Remove"
-          >✕</span>
+            aria-label="Remove"
+          ><span aria-hidden="true">✕</span></span>
         </button>
       </div>
     </div>

--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,7 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button class="syntax-help-close" @click="$emit('close')" aria-label="Close syntax help"><span aria-hidden="true">✕</span></button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">


### PR DESCRIPTION
### 💡 What
This PR adds `<span aria-hidden="true">` tags around decorative text characters like "✕" and "×" inside close or remove buttons in the search interface components, to hide them from screen readers.

### 🎯 Why
Screen readers will sometimes natively announce these decorative unicode elements ("multiply", "times", etc.). By wrapping them in an aria-hidden span, they are hidden from the accessibility tree, ensuring the screen reader relies entirely on the proper `aria-label` text attached to the parent button instead.

### ♿ Accessibility
- Hid decorative "✕" characters from screen reader announcements in search UI
- Added `aria-label="Remove"` to the search preset history buttons
- Added `aria-label="Close syntax help"` to the syntax help modal close button

### 📸 Before/After
No visual changes.

### 📔 Palette Journal
Documented the learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7030535828373917476](https://jules.google.com/task/7030535828373917476) started by @MattShelton04*