### PR TITLE
refactor: tech debt sweep (canonicalize deduplication and dead shims)

### DIFF
--- a/crates/tracepilot-core/src/session/discovery.rs
+++ b/crates/tracepilot-core/src/session/discovery.rs
@@ -8,11 +8,6 @@ use crate::error::{Result, TracePilotError};
 /// Maximum age of session activity before a lock file is considered stale.
 const STALE_LOCK_THRESHOLD: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 
-/// Default location for Copilot CLI session state.
-pub fn default_session_state_dir() -> PathBuf {
-    crate::paths::default_session_state_dir()
-}
-
 /// A discovered session directory with its UUID and path.
 #[derive(Debug, Clone)]
 pub struct DiscoveredSession {
@@ -148,7 +143,7 @@ fn is_file_recent(path: &Path, now: SystemTime) -> bool {
 /// Resolve a session ID (full or partial prefix) to its directory path.
 /// Returns TracePilotError::SessionNotFound if no match or multiple matches.
 pub fn resolve_session_path(session_id_prefix: &str) -> Result<PathBuf> {
-    resolve_session_path_in(session_id_prefix, &default_session_state_dir())
+    resolve_session_path_in(session_id_prefix, &crate::paths::default_session_state_dir())
 }
 
 /// Resolve a session path directly from a full session UUID without scanning.

--- a/crates/tracepilot-core/src/session/discovery.rs
+++ b/crates/tracepilot-core/src/session/discovery.rs
@@ -143,7 +143,10 @@ fn is_file_recent(path: &Path, now: SystemTime) -> bool {
 /// Resolve a session ID (full or partial prefix) to its directory path.
 /// Returns TracePilotError::SessionNotFound if no match or multiple matches.
 pub fn resolve_session_path(session_id_prefix: &str) -> Result<PathBuf> {
-    resolve_session_path_in(session_id_prefix, &crate::paths::default_session_state_dir())
+    resolve_session_path_in(
+        session_id_prefix,
+        &crate::paths::default_session_state_dir(),
+    )
 }
 
 /// Resolve a session path directly from a full session UUID without scanning.

--- a/crates/tracepilot-core/src/utils/fs.rs
+++ b/crates/tracepilot-core/src/utils/fs.rs
@@ -27,3 +27,9 @@ pub fn normalize_canonical_path(p: PathBuf) -> PathBuf {
     }
     p
 }
+
+/// Canonicalize a path and normalize it by stripping the `\\?\` verbatim prefix on Windows.
+/// Preserves `\\?\UNC\` prefix for network shares.
+pub fn canonicalize(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    std::fs::canonicalize(path).map(normalize_canonical_path)
+}

--- a/crates/tracepilot-orchestrator/src/launcher.rs
+++ b/crates/tracepilot-orchestrator/src/launcher.rs
@@ -304,7 +304,7 @@ pub(crate) fn canonicalize_user_path(path: &str) -> Result<std::path::PathBuf> {
         return Err(OrchestratorError::Launch("Path contains a NUL byte".into()));
     }
 
-    let canonical = std::fs::canonicalize(path).map_err(|e| {
+    let canonical = tracepilot_core::utils::fs::canonicalize(path).map_err(|e| {
         OrchestratorError::launch_ctx(
             format!("Path does not exist or is not accessible: {path}"),
             e,
@@ -325,9 +325,7 @@ pub(crate) fn canonicalize_user_path(path: &str) -> Result<std::path::PathBuf> {
         }
     }
 
-    Ok(tracepilot_core::utils::fs::normalize_canonical_path(
-        canonical,
-    ))
+    Ok(canonical)
 }
 
 /// Open a path in the system file explorer.

--- a/crates/tracepilot-tauri-bindings/src/cache.rs
+++ b/crates/tracepilot-tauri-bindings/src/cache.rs
@@ -6,8 +6,6 @@ use std::num::NonZeroUsize;
 
 use lru::LruCache;
 
-pub(crate) use tracepilot_core::utils::cache::TtlCache;
-
 /// Build a typed, bounded LRU cache keyed by session ID.
 ///
 /// Centralises the `NonZeroUsize::new(cap).unwrap_or(…)` ceremony that was

--- a/crates/tracepilot-tauri-bindings/src/commands/orchestration.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/orchestration.rs
@@ -1,7 +1,6 @@
 //! Orchestration Tauri commands (22 commands).
 
 use crate::blocking_cmd;
-use tracepilot_core::utils::cache::TtlCache;
 use crate::config::SharedConfig;
 use crate::error::{BindingsError, CmdResult};
 use crate::helpers::{read_config, validate_path_within_any};
@@ -9,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tauri::Manager;
+use tracepilot_core::utils::cache::TtlCache;
 
 // ---------------------------------------------------------------------------
 // check_system_deps TTL cache (P0 perf fix)

--- a/crates/tracepilot-tauri-bindings/src/commands/orchestration.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/orchestration.rs
@@ -1,7 +1,7 @@
 //! Orchestration Tauri commands (22 commands).
 
 use crate::blocking_cmd;
-use crate::cache::TtlCache;
+use tracepilot_core::utils::cache::TtlCache;
 use crate::config::SharedConfig;
 use crate::error::{BindingsError, CmdResult};
 use crate::helpers::{read_config, validate_path_within_any};

--- a/crates/tracepilot-tauri-bindings/src/commands/search/cache.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/search/cache.rs
@@ -1,6 +1,6 @@
 //! Facets TTL cache shared by search content and indexing commands.
 
-use crate::cache::TtlCache;
+use tracepilot_core::utils::cache::TtlCache;
 use crate::types::SearchFacetsResponse;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/crates/tracepilot-tauri-bindings/src/commands/search/cache.rs
+++ b/crates/tracepilot-tauri-bindings/src/commands/search/cache.rs
@@ -1,11 +1,11 @@
 //! Facets TTL cache shared by search content and indexing commands.
 
-use tracepilot_core::utils::cache::TtlCache;
 use crate::types::SearchFacetsResponse;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::LazyLock;
 use std::time::Duration;
+use tracepilot_core::utils::cache::TtlCache;
 
 // ---------------------------------------------------------------------------
 // Facets TTL cache (P1 perf fix)

--- a/crates/tracepilot-tauri-bindings/src/helpers/path.rs
+++ b/crates/tracepilot-tauri-bindings/src/helpers/path.rs
@@ -3,15 +3,6 @@
 use crate::error::{BindingsError, CmdResult};
 use std::path::PathBuf;
 
-/// Strip the `\\?\` extended-length path prefix that `std::fs::canonicalize`
-/// adds on Windows for drive-rooted paths (e.g. `\\?\C:\...` → `C:\...`).
-///
-/// UNC share paths (`\\?\UNC\server\share`) are left untouched because
-/// stripping their prefix would produce an invalid path.
-fn normalize_canonicalized(p: PathBuf) -> PathBuf {
-    tracepilot_core::utils::fs::normalize_canonical_path(p)
-}
-
 /// Validate that an existing path resides within `dir`.
 ///
 /// Returns the canonicalized path on success so callers can use the resolved
@@ -27,10 +18,10 @@ pub(crate) fn validate_path_within(path: &str, dir: &std::path::Path) -> CmdResu
             path
         )));
     }
-    let canonical = normalize_canonicalized(p.canonicalize()?);
-    let canonical_dir = normalize_canonicalized(dir.canonicalize().map_err(|e| {
+    let canonical = tracepilot_core::utils::fs::canonicalize(p)?;
+    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir).map_err(|e| {
         BindingsError::Validation(format!("Cannot resolve allowed directory: {e}"))
-    })?);
+    })?;
     if !canonical.starts_with(&canonical_dir) {
         return Err(BindingsError::Validation(
             "Path is outside the allowed directory".into(),
@@ -67,15 +58,14 @@ pub(crate) fn validate_path_within_any(
             "Path does not exist: {path}"
         )));
     }
-    let canonical = normalize_canonicalized(p.canonicalize()?);
+    let canonical = tracepilot_core::utils::fs::canonicalize(p)?;
 
     let mut any_root_resolved = false;
     for root in allowed_roots {
-        let Ok(canonical_root) = root.canonicalize() else {
+        let Ok(canonical_root) = tracepilot_core::utils::fs::canonicalize(root) else {
             continue;
         };
         any_root_resolved = true;
-        let canonical_root = normalize_canonicalized(canonical_root);
         if canonical.starts_with(&canonical_root) {
             return Ok(canonical);
         }
@@ -117,14 +107,14 @@ pub(crate) fn validate_write_path_within(path: &str, dir: &std::path::Path) -> C
             parent.display()
         )));
     }
-    let canonical_dir = normalize_canonicalized(dir.canonicalize().map_err(|e| {
+    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir).map_err(|e| {
         BindingsError::Validation(format!("Cannot resolve allowed directory: {e}"))
-    })?);
+    })?;
 
     // If the target already exists (overwrite or symlink), canonicalize the full
     // path to ensure symlinks don't escape the allowed directory.
     if p.exists() {
-        let canonical_full = normalize_canonicalized(p.canonicalize()?);
+        let canonical_full = tracepilot_core::utils::fs::canonicalize(p)?;
         if !canonical_full.starts_with(&canonical_dir) {
             return Err(BindingsError::Validation(
                 "Path is outside the allowed directory".into(),
@@ -134,7 +124,7 @@ pub(crate) fn validate_write_path_within(path: &str, dir: &std::path::Path) -> C
     }
 
     // File doesn't exist yet — validate parent only.
-    let canonical_parent = normalize_canonicalized(parent.canonicalize()?);
+    let canonical_parent = tracepilot_core::utils::fs::canonicalize(parent)?;
     if !canonical_parent.starts_with(&canonical_dir) {
         return Err(BindingsError::Validation(
             "Path is outside the allowed directory".into(),

--- a/crates/tracepilot-tauri-bindings/src/helpers/path.rs
+++ b/crates/tracepilot-tauri-bindings/src/helpers/path.rs
@@ -19,9 +19,8 @@ pub(crate) fn validate_path_within(path: &str, dir: &std::path::Path) -> CmdResu
         )));
     }
     let canonical = tracepilot_core::utils::fs::canonicalize(p)?;
-    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir).map_err(|e| {
-        BindingsError::Validation(format!("Cannot resolve allowed directory: {e}"))
-    })?;
+    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir)
+        .map_err(|e| BindingsError::Validation(format!("Cannot resolve allowed directory: {e}")))?;
     if !canonical.starts_with(&canonical_dir) {
         return Err(BindingsError::Validation(
             "Path is outside the allowed directory".into(),
@@ -107,9 +106,8 @@ pub(crate) fn validate_write_path_within(path: &str, dir: &std::path::Path) -> C
             parent.display()
         )));
     }
-    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir).map_err(|e| {
-        BindingsError::Validation(format!("Cannot resolve allowed directory: {e}"))
-    })?;
+    let canonical_dir = tracepilot_core::utils::fs::canonicalize(dir)
+        .map_err(|e| BindingsError::Validation(format!("Cannot resolve allowed directory: {e}")))?;
 
     // If the target already exists (overwrite or symlink), canonicalize the full
     // path to ensure symlinks don't escape the allowed directory.


### PR DESCRIPTION
### Tech Debt Reduction (3 Candidates)

| # | Type | File(s) | What | Evidence |
|---|------|---------|------|----------|
| 1 | refactor | `crates/tracepilot-core/src/session/discovery.rs` | Removed dead `default_session_state_dir` shim re-export and updated internal callers. | 2 call sites updated, 1 shim removed. |
| 2 | refactor | `crates/tracepilot-tauri-bindings/src/cache.rs`<br>`crates/tracepilot-tauri-bindings/src/commands/orchestration.rs`<br>`crates/tracepilot-tauri-bindings/src/commands/search/cache.rs` | Removed `TtlCache` shim re-export and updated consumer imports directly to core. | 2 call sites updated, 1 shim removed. |
| 3 | refactor | `crates/tracepilot-core/src/utils/fs.rs`<br>`crates/tracepilot-tauri-bindings/src/helpers/path.rs`<br>`crates/tracepilot-orchestrator/src/launcher.rs` | Deduplicated path canonicalization and Windows UNC stripping into a shared `core::utils::fs::canonicalize` helper. | 9 inline impls → 1 shared helper. |

### Verification

```text
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.92s

$ cargo test --workspace
    test result: ok. 420 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.61s

$ pnpm --filter @tracepilot/desktop typecheck
    > @tracepilot/desktop@0.6.6 typecheck C:\git\RepoClones\TracePilot\apps\desktop

$ node scripts/check-file-sizes.mjs
    ✓ file-size check passed (0 allow-listed violation(s))
```