### PR TITLE
🎨 Palette: Add ARIA label to SearchableSelect clear button

### DIFF
--- a/packages/ui/src/components/SearchableSelect.vue
+++ b/packages/ui/src/components/SearchableSelect.vue
@@ -203,11 +203,12 @@ watch(filteredOptions, () => {
           v-if="clearable && searchQuery"
           class="clear-btn"
           title="Clear selection"
+          aria-label="Clear selection"
           @mousedown.prevent="clear"
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
         </button>
-        <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
+        <svg class="chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
           <path d="M6 9l6 6 6-6" />
         </svg>
       </span>


### PR DESCRIPTION
## 💡 What
Added an `aria-label` attribute to the "clear" icon button inside `SearchableSelect.vue`, and hid the inner SVG icon and the decorative dropdown chevron SVG from screen readers using `aria-hidden="true"`.

## 🎯 Why
Icon-only buttons must provide accessible names for screen reader users to understand their purpose. Without an `aria-label`, a screen reader might either ignore the button or read out a confusing and non-descriptive string (like its tag name or the inner raw SVG contents). Adding the label explicitly provides context. Adding `aria-hidden="true"` to the decorative SVGs prevents screen readers from redundantly attempting to interpret the images themselves.

## 📸 Before/After
*   **Before:** The clear button used an icon and a `title` attribute, but lacked an explicit `aria-label`. The SVGs did not have `aria-hidden="true"`.
*   **After:** The clear button now has `aria-label="Clear selection"`. The SVGs inside the clear button and the chevron both feature `aria-hidden="true"`.

## ♿ Accessibility
*   **Accessible Name:** Screen readers will now announce "Clear selection, button" instead of ignoring the element or reading the SVG.
*   **Reduced Noise:** Screen readers will skip the decorative SVGs (`aria-hidden="true"`), reducing cognitive load.

---
*PR created automatically by Jules for task [8890849331921000682](https://jules.google.com/task/8890849331921000682) started by @MattShelton04*