### PR TITLE
🎨 Palette: [Accessibility] Hide decorative characters from screen readers

### DIFF
--- a/apps/desktop/src/components/search/SearchActiveFilters.vue
+++ b/apps/desktop/src/components/search/SearchActiveFilters.vue
@@ -37,19 +37,19 @@ const emit = defineEmits<{
         />
         <span v-if="chip.mode === 'exclude'" class="filter-chip-prefix">NOT</span>
         {{ contentTypeConfig[chip.type]?.label ?? chip.type }}
-        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('remove-content-type', chip.type)" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="repository" class="filter-chip filter-chip-neutral">
         Repo: {{ repository }}
-        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-repository')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="toolName" class="filter-chip filter-chip-neutral">
         Tool: {{ toolName }}
-        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-tool-name')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <span v-if="sessionId" class="filter-chip filter-chip-include">
         Session: {{ sessionDisplayName }}
-        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter">×</button>
+        <button class="filter-chip-remove" @click="$emit('clear-session-id')" aria-label="Remove filter"><span aria-hidden="true">×</span></button>
       </span>
       <button v-if="activeFilterCount > 1" class="filter-chip-clear-all" @click="$emit('clear-all')">
         Clear all

--- a/apps/desktop/src/components/search/SearchBrowsePresets.vue
+++ b/apps/desktop/src/components/search/SearchBrowsePresets.vue
@@ -81,7 +81,8 @@ const store = useSearchStore();
             @click.stop="store.removeRecentSearch(recent.query)"
             @keydown.enter.stop="store.removeRecentSearch(recent.query)"
             title="Remove"
-          >✕</span>
+            aria-label="Remove recent search"
+          ><span aria-hidden="true">✕</span></span>
         </button>
       </div>
     </div>

--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,7 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button class="syntax-help-close" aria-label="Close" @click="$emit('close')"><span aria-hidden="true">✕</span></button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">

--- a/apps/desktop/src/components/todoDependencyGraph/TodoDepDetailSlideover.vue
+++ b/apps/desktop/src/components/todoDependencyGraph/TodoDepDetailSlideover.vue
@@ -18,7 +18,7 @@ const ctx = useTodoDependencyGraphContext();
           {{ ctx.selectedTodo.value.status.replace("_", " ") }}
         </span>
       </div>
-      <button class="close-detail" @click="ctx.closeDetail" aria-label="Close detail panel">✕</button>
+      <button class="close-detail" @click="ctx.closeDetail" aria-label="Close detail panel"><span aria-hidden="true">✕</span></button>
     </div>
     <div class="detail-panel-body">
       <div class="detail-section">


### PR DESCRIPTION
💡 **What:** Added `<span aria-hidden="true">` around decorative unicode characters (like `✕` and `×`) used as icons, and added missing `aria-label` attributes to their parent interactive elements.
🎯 **Why:** To prevent screen readers from literally reading the unicode characters (e.g., announcing "times" or "multiply") instead of the intended action when focusing on buttons and interactive UI elements.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now correctly announce "Remove filter" or "Close" instead of awkward unicode character names when navigating components like the search filters, syntax help modal, and detail slide-overs.

---
*PR created automatically by Jules for task [3438267270888345469](https://jules.google.com/task/3438267270888345469) started by @MattShelton04*