### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix cross-platform path traversal bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Cross-Platform Path Traversal Bypass
+**Vulnerability:** Path validation for imported GitHub trees relied solely on `std::path::Component::ParentDir` and `is_absolute()`. On Unix systems, this fails to identify Windows-style path traversal attempts (e.g., `..\..\file`) or absolute paths (`C:\file`) because backslashes are treated as regular filename characters, allowing traversal vulnerabilities.
+**Learning:** Rust's `Path` parsing is OS-specific. Validating paths from untrusted, cross-platform sources (like git repositories or archives) using standard `Path` methods on Unix will bypass Windows-specific attack vectors.
+**Prevention:** Always explicitly check for backslashes (`\`) and explicit root characters (`/`) when validating paths from external sources, in addition to using `std::path::Component::ParentDir` to safely handle `..` components without introducing functional regressions like naive `.contains("..")` checks would.

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -174,7 +174,11 @@ pub(crate) fn import_from_github_path(
                         let has_traversal = Path::new(relative)
                             .components()
                             .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() || relative.contains('\\') || relative.starts_with('/') {
+                        if has_traversal
+                            || Path::new(relative).is_absolute()
+                            || relative.contains('\\')
+                            || relative.starts_with('/')
+                        {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -169,10 +169,12 @@ pub(crate) fn import_from_github_path(
                         // Guard against path traversal from crafted tree entries.
                         // Use component analysis to correctly detect ParentDir
                         // segments without false positives on names like "..foo".
+                        // Also explicitly block backslashes and explicit root characters
+                        // to prevent cross-platform path traversal bypasses.
                         let has_traversal = Path::new(relative)
                             .components()
                             .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() {
+                        if has_traversal || Path::new(relative).is_absolute() || relative.contains('\\') || relative.starts_with('/') {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When importing GitHub trees, path validation relied solely on `std::path::Component::ParentDir` and `is_absolute()`. Since Rust's `Path` parsing is OS-specific, validating paths from untrusted sources on Unix fails to identify Windows-style path traversal attempts (e.g., `..\..\file`) or absolute paths (`C:\file`), allowing a bypass.
🎯 Impact: Attackers could craft malicious GitHub trees to overwrite files outside the intended installation directory via path traversal on Windows clients.
🔧 Fix: Explicitly check for backslashes (`\`) and explicit root characters (`/`) when validating paths from external sources, in addition to using `std::path::Component::ParentDir` to safely handle `..` components.
✅ Verification: Ran `cargo test` and `cargo clippy` to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [2503585981209628088](https://jules.google.com/task/2503585981209628088) started by @MattShelton04*