### PR TITLE
🎨 Palette: Add aria-hidden to decorative SVGs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Add aria-hidden to decorative SVGs
+**Learning:** Decorative SVGs inside interactive elements like buttons need `aria-hidden="true"` to prevent screen readers from announcing them confusingly, even if the parent element already has an `aria-label`.
+**Action:** Always include `aria-hidden="true"` on inner decorative elements when writing interactive components.

--- a/apps/desktop/src/components/RefreshToolbar.vue
+++ b/apps/desktop/src/components/RefreshToolbar.vue
@@ -69,7 +69,7 @@ onUnmounted(() => {
       aria-label="Refresh data"
       @click="emit('refresh')"
     >
-      <svg class="refresh-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" class="refresh-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 8a6 6 0 1 1-6-6c1.7 0 3.3.7 4.5 1.8L14 5.5" />
         <path d="M14 1.5v4h-4" />
       </svg>

--- a/apps/desktop/src/components/ThemeToggle.vue
+++ b/apps/desktop/src/components/ThemeToggle.vue
@@ -16,11 +16,11 @@ function toggle() {
     @click="toggle"
   >
     <!-- Sun icon (shown in dark mode) -->
-    <svg v-if="prefs.theme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <svg aria-hidden="true" v-if="prefs.theme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
     </svg>
     <!-- Moon icon (shown in light mode) -->
-    <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <svg aria-hidden="true" v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
     </svg>
   </button>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative `<svg>` elements inside the `ThemeToggle` and `RefreshToolbar` buttons.
🎯 Why: These buttons already have descriptive `aria-label`s. Screen readers might redundantly announce the nested SVG paths, creating a confusing or noisy experience for users relying on assistive technologies. Hiding the SVGs from the accessibility tree ensures only the parent button's label is read.
📸 Before/After: Visuals remain unchanged; the accessibility tree is simplified.
♿ Accessibility: Improves screen reader experience by removing redundant decorative elements from the accessibility tree.

---
*PR created automatically by Jules for task [12039658155717861400](https://jules.google.com/task/12039658155717861400) started by @MattShelton04*