### PR TITLE
🎨 Palette: Improve accessibility of Drawer close button

### DIFF
--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />


### PR DESCRIPTION
💡 **What:** Changed the `aria-label` on the Drawer component's close button from "Close" to "Close drawer".

🎯 **Why:** Generic aria-labels like "Close" can lack context when multiple controls exist on a page or when screen readers list form controls out-of-context. Explicitly appending the component type provides much better clarity.

📸 **Before/After:**
*Before:* `<button class="drawer-close" aria-label="Close">`
*After:* `<button class="drawer-close" aria-label="Close drawer">`

♿ **Accessibility:** This directly improves the screen reader experience by providing explicit context for the close action, avoiding ambiguity with other potential close buttons on the screen.

---
*PR created automatically by Jules for task [7448467424669419916](https://jules.google.com/task/7448467424669419916) started by @MattShelton04*