### PR TITLE
🎨 Palette: [Pagination a11y]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Pagination Accessibility
+**Learning:** Found pagination components missing structural ARIA properties (`<nav>`, `aria-label="Pagination"`, `aria-current="page"`) and exposing decorative arrows to screen readers.
+**Action:** Wrap pagination components in `<nav aria-label="Pagination">`, use `aria-current="page"` on the active item, and hide decorative arrows with `aria-hidden="true"` inside visually labeled buttons.

--- a/apps/desktop/src/components/search/SessionSearchPagination.vue
+++ b/apps/desktop/src/components/search/SessionSearchPagination.vue
@@ -19,20 +19,22 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div v-if="totalPages > 1" class="pagination">
+  <nav v-if="totalPages > 1" class="pagination" aria-label="Pagination">
     <button
       class="pagination-btn"
       :disabled="page <= 1"
       @click="emit('prev')"
     >
-      ‹ Prev
+      <span aria-hidden="true">‹</span> Prev
     </button>
     <template v-for="(p, idx) in visiblePages" :key="idx">
-      <span v-if="p === null" class="pagination-ellipsis">…</span>
+      <span v-if="p === null" class="pagination-ellipsis" aria-hidden="true">…</span>
       <button
         v-else
         class="pagination-btn"
         :class="{ active: p === page }"
+        :aria-current="p === page ? 'page' : undefined"
+        :aria-label="`Page ${p}`"
         @click="emit('go', p)"
       >
         {{ p }}
@@ -43,10 +45,10 @@ const emit = defineEmits<{
       :disabled="!hasMore"
       @click="emit('next')"
     >
-      Next ›
+      Next <span aria-hidden="true">›</span>
     </button>
-    <span class="pagination-info">
+    <span class="pagination-info" aria-live="polite">
       {{ pageStart }}–{{ pageEnd }} of {{ formatNumberFull(totalCount) }}
     </span>
-  </div>
+  </nav>
 </template>


### PR DESCRIPTION
**💡 What:** 
Improved the accessibility of the `SessionSearchPagination` component. Wrapped the pagination in a `<nav aria-label="Pagination">` element to provide structural context, added `aria-current="page"` to the active page button, hid decorative `‹` and `›` characters from screen readers using `<span aria-hidden="true">`, and added `aria-live="polite"` to the summary text.

**🎯 Why:** 
Screen reader users previously heard decorative arrows read out as characters and lacked semantic context that the group of buttons represented a pagination control or which page was currently active.

**📸 Before/After:** 
_N/A - purely semantic/DOM structural changes, no visual differences._

**♿ Accessibility:** 
- Converted the wrapping `div` to a `<nav>` with `aria-label="Pagination"`.
- Added explicit `aria-current="page"` and `aria-label="Page X"` to buttons.
- Hid decorative ASCII arrows `‹` and `›` from screen readers using `<span aria-hidden="true">`.
- Added `aria-live="polite"` to the pagination summary text.

---
*PR created automatically by Jules for task [8287112988112718931](https://jules.google.com/task/8287112988112718931) started by @MattShelton04*