### PR TITLE
🎨 Palette: Contextual ARIA labels for structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Avoid Generic ARIA Labels on Structural Components
+**Learning:** Structural UI components like Modals and Drawers often use generic `aria-label="Close"` on their close buttons. This lacks context when navigating by screen reader.
+**Action:** Always append the structural component type to the aria-label (e.g., `aria-label="Close drawer"`, `aria-label="Close dialog"`) to provide clear, contextual cues for assistive technology users.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close dialog']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close dialog"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 What: Improved the `aria-label` for the close buttons on `ModalDialog` and `Drawer` components by making them specific to the component type instead of a generic "Close".
🎯 Why: "Close" lacks context when a screen reader user navigates out of order or encounters multiple dialogs/drawers. Contextual labels provide a much better navigation experience.
📸 Before/After: Visuals are identical; this is an accessibility change.
♿ Accessibility: Assistive technologies will now announce "Close dialog" or "Close drawer" rather than just "Close". Tests were also updated to verify the new labels.

---
*PR created automatically by Jules for task [6991068069645891096](https://jules.google.com/task/6991068069645891096) started by @MattShelton04*