### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal on Windows paths parsed in Unix

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - Path Traversal Component Analysis
+**Vulnerability:** Path traversal could bypass `Path::new(..).components()` checks on cross-platform boundaries (e.g. Windows paths parsed on Unix) and `.contains("..")` falsely flags valid filenames like `my..file.txt`.
+**Learning:** `is_absolute()` and `Component::ParentDir` in `std::path` are platform-dependent. Unix systems do not recognize backslashes (`\`) as separators or Windows absolute paths (e.g. `C:\`), allowing bypasses. Conversely, naive string matching `.contains("..")` causes functional bugs.
+**Prevention:** Always explicitly check for `\` and `/` root characters in combination with `std::path::Component::ParentDir` to perform robust, cross-platform path traversal validation.

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -172,7 +172,9 @@ pub(crate) fn import_from_github_path(
                         let has_traversal = Path::new(relative)
                             .components()
                             .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() {
+                        // Add explicit checks for backslash and forward slash prefixes to catch Windows paths
+                        // on Unix systems where `is_absolute()` might fail.
+                        if has_traversal || Path::new(relative).is_absolute() || relative.starts_with('\\') || relative.starts_with('/') {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -174,7 +174,11 @@ pub(crate) fn import_from_github_path(
                             .any(|c| matches!(c, std::path::Component::ParentDir));
                         // Add explicit checks for backslash and forward slash prefixes to catch Windows paths
                         // on Unix systems where `is_absolute()` might fail.
-                        if has_traversal || Path::new(relative).is_absolute() || relative.starts_with('\\') || relative.starts_with('/') {
+                        if has_traversal
+                            || Path::new(relative).is_absolute()
+                            || relative.starts_with('\\')
+                            || relative.starts_with('/')
+                        {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When parsing GitHub tree entries during a skill import, path traversal validation relies on `std::path::Path::new(..).components()` and `.is_absolute()`. If the backend runs on a Unix system, `is_absolute()` only checks for forward slashes (`/`), allowing paths starting with backslashes (e.g., `\etc\passwd` or `C:\...`) to bypass the absolute path check.
🎯 Impact: An attacker could craft a malicious GitHub tree with explicit backslash prefixes that, when extracted by a Unix host, could bypass the absolute path check and potentially perform cross-platform file overwriting or arbitrary extraction.
🔧 Fix: Added explicit string checks for `relative.starts_with('\\')` and `relative.starts_with('/')` alongside the existing `Path::is_absolute()` check to ensure root characters are always blocked regardless of the host OS parsing rules.
✅ Verification: `cargo test --workspace` passed successfully. Reverted original changes to `validation.rs`, `safety.rs` and `assets.rs` since they inadvertently allowed strings explicitly blocked in the test suite (like `foo..bar`).

---
*PR created automatically by Jules for task [7624123830149968788](https://jules.google.com/task/7624123830149968788) started by @MattShelton04*