### PR TITLE
⚡ Bolt: Optimize SQL placeholder string generation with chunked memory slice writes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Direct chunk slice memory copy optimization
+**Learning:** Scalar character-by-character pushes (`.push(',')`, `.push('?')`) for SQL placeholders cause suboptimal memory writes. Grouping these characters into a single chunk slice and using `.push_str(",?")` is faster because it performs a direct, optimized memory copy of the pre-allocated byte slice. However, must handle empty cases like `n=0` to avoid out-of-bounds or runtime errors (e.g. unconditionally pushing `?`).
+**Action:** When generating dynamic SQL placeholders or repeating strings, replace multiple `.push()` calls with a single `.push_str()` to combine characters into literal slices, but ensure edge cases (n=0) are short-circuited.

--- a/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
+++ b/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
@@ -15,13 +15,14 @@ pub fn build_in_placeholders(n: usize) -> String {
         n > 0,
         "build_in_placeholders requires n > 0; n=0 produces empty string that makes IN () invalid SQL"
     );
+    if n == 0 {
+        return String::new();
+    }
     // Each element is "?" (1 char) + ", " (2 chars) except the last → n*3 max.
     let mut s = String::with_capacity(n * 3);
-    for i in 0..n {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        s.push('?');
+    s.push('?');
+    for _ in 1..n {
+        s.push_str(", ?");
     }
     s
 }
@@ -64,11 +65,9 @@ pub fn build_placeholder_sql(sql_prefix: &str, num_rows: usize, params_per_row: 
     sql.push(' ');
 
     let mut row_str = String::with_capacity(params_per_row * 2 + 1);
-    row_str.push('(');
-    row_str.push('?');
+    row_str.push_str("(?");
     for _ in 1..params_per_row {
-        row_str.push(',');
-        row_str.push('?');
+        row_str.push_str(",?");
     }
     row_str.push(')');
 


### PR DESCRIPTION
### 💡 What
Optimized the dynamic SQL placeholder string generation in `tracepilot-core` (`build_in_placeholders` and `build_placeholder_sql`). The inner loops previously pushed individual characters `','` and `'?'` sequentially. This was refactored to use `.push_str(", ?")` to perform a single byte slice copy per iteration instead of multiple individual pushes. An explicit early return for `n == 0` was also added.

### 🎯 Why
When dealing with large bulk operations (e.g. 50-row × 9-column batches), the string builder executes hundreds to thousands of character appends. Grouping these characters into a string literal slice (`", ?"`) and appending it via `push_str` allows Rust to execute a single optimized memory copy rather than two separate bounds checks and memory writes.

### 📊 Impact
Micro-optimization. Accelerates raw string interpolation and memory write speed during large batch SQL operations. Reduces CPU instruction overhead for bounds checking inside hot loops.

### 🔬 Measurement
Run `cargo bench -p tracepilot-bench` or standard testing suites profiling raw SQL builder performance. Tests for `tracepilot-core` pass cleanly and logic remains functionally identical. Included an explicit bounds check for n=0 empty strings to prevent regressions.

---
*PR created automatically by Jules for task [8972995306001227428](https://jules.google.com/task/8972995306001227428) started by @MattShelton04*