### PR TITLE
🎨 Palette: Improve close button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-05-17 - Improve accessibility of modal/drawer close buttons
+
+**Learning:** Generic `aria-label="Close"` on structural components like `ModalDialog` and `Drawer` lack context for screen reader users, especially when multiple overlays might be present. Also, raw unicode characters (like `×` and `✕`) in close buttons are often announced confusingly by screen readers even when an `aria-label` is present, and should be wrapped in `<span aria-hidden="true">`.
+
+**Action:** Update structural components to use contextual `aria-label`s (e.g., `"Close modal"` or `"Close drawer"`). For raw unicode icons in close buttons, wrap them in `<span aria-hidden="true">` to prevent screen reader interference.

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -49,7 +49,7 @@ function handleOpenRelease() {
       <div class="modal-content" role="dialog" aria-labelledby="update-modal-title">
         <div class="modal-header">
           <h2 id="update-modal-title">Update to v{{ version }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')"><span aria-hidden="true">×</span></button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -45,7 +45,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
       <div class="modal-content" role="dialog" aria-labelledby="whats-new-title">
         <div class="modal-header">
           <h2 id="whats-new-title">🎉 What's New in v{{ currentVersion }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')"><span aria-hidden="true">×</span></button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/mcp/McpAddServerModal.vue
+++ b/apps/desktop/src/components/mcp/McpAddServerModal.vue
@@ -35,7 +35,7 @@ const {
               </div>
               <span id="add-server-title">Add MCP Server</span>
             </div>
-            <button class="modal-close" aria-label="Close" @click="emit('close')">✕</button>
+            <button class="modal-close" aria-label="Close modal" @click="emit('close')"><span aria-hidden="true">✕</span></button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
+++ b/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
@@ -119,7 +119,7 @@ watch(
         <div class="modal-dialog" role="dialog" aria-labelledby="create-wt-title">
           <div class="modal-header">
             <h2 id="create-wt-title" class="modal-title">Create Worktree</h2>
-            <button class="icon-btn" aria-label="Close" @click="close">
+            <button class="icon-btn" aria-label="Close modal" @click="close">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
             locked
           </span>
         </div>
-        <button class="icon-btn" aria-label="Close" @click="emit('close')">
+        <button class="icon-btn" aria-label="Close worktree panel" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 **What:** 
Replaced generic "Close" `aria-label`s on structural UI components (like Drawers and Modals) with contextual labels (e.g., "Close modal", "Close drawer", "Close worktree panel"). Additionally, wrapped purely decorative characters like `×` and `✕` in close buttons with `<span aria-hidden="true">`.

🎯 **Why:** 
Generic "Close" buttons lack context for screen reader users, especially if there are multiple overlays or overlapping components on the page. Adding contextual labels makes it instantly clear what action is being performed. Furthermore, screen readers will often announce raw unicode cross icons confusingly (e.g., "times" or "multiplication X"), even when a button has a valid `aria-label`. Hiding the decorative icon explicitly via `aria-hidden` guarantees the screen reader only reads the clean `aria-label`.

📸 **Before/After:** 
Codebase structural accessibility improvements without any visual side effects.

♿ **Accessibility:** 
Significant improvement in screen-reader navigation and context inside modals and drawers, leading to a much more predictable interactive experience for users relying on assistive technologies.

---
*PR created automatically by Jules for task [6047024296466016486](https://jules.google.com/task/6047024296466016486) started by @MattShelton04*