### PR TITLE
🎨 Palette: Improve accessibility labels on modal and drawer close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Component Accessibility
+**Learning:** Drawers and Modals were using generic 'Close' labels for their close buttons.
+**Action:** When improving accessibility for structural components (like Drawers or Modals), avoid generic aria-label attributes like 'Close' on their controls. Append the component type to the label (e.g., 'Close drawer') to provide explicit context for screen reader users.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 What: Changed the generic `aria-label="Close"` on the close buttons in the `ModalDialog` and `Drawer` components to be `aria-label="Close modal"` and `aria-label="Close drawer"` respectively.
🎯 Why: To provide clearer, more explicit context for screen reader users when interacting with these structural overlay components, ensuring they know exactly what they are closing.
📸 Before/After:
Before: `<button aria-label="Close">`
After: `<button aria-label="Close modal">` and `<button aria-label="Close drawer">`
♿ Accessibility: Improved spatial context and specific action feedback for screen readers for close actions within structural overlays. Updated corresponding unit tests.

---
*PR created automatically by Jules for task [5229308881695539276](https://jules.google.com/task/5229308881695539276) started by @MattShelton04*