### PR TITLE
🎨 Palette: Improve screen reader context for modal and drawer close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Modal and Drawer Close Button Accessibility
+**Learning:** Structural components like Modals and Drawers often use generic `aria-label="Close"` on their close controls. This lacks explicit context for screen reader users regarding what is being closed.
+**Action:** When improving accessibility for structural components, avoid generic `aria-label` attributes like "Close". Append the component type to the label (e.g., "Close drawer" or "Close dialog") to provide explicit context for screen reader users.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close dialog']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close dialog"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
### 💡 What
Updated the `aria-label` attributes on the close controls in both `ModalDialog.vue` and `Drawer.vue` to include the specific component type context ("Close dialog" and "Close drawer" instead of just "Close"). 

Also updated the corresponding Vitest tests in `ModalDialog.test.ts` to prevent test failures.
Added a learning entry to `.jules/palette.md` to document the pattern of appending component types to generic aria-labels for structural elements.

### 🎯 Why
Structural components like Modals and Drawers often use generic `aria-label="Close"` on their controls. When a screen reader user navigates through the page elements via quick keys and lands on an icon-only button simply announced as "Close button", they lack explicit context regarding *what* will be closed if they activate it. Appending the component type reduces ambiguity.

### 📸 Before/After
**Before:**
```vue
<button aria-label="Close">
  <X aria-hidden="true" />
</button>
```

**After:**
```vue
<button aria-label="Close dialog">
  <X aria-hidden="true" />
</button>
```

### ♿ Accessibility
- Explicit context provided to screen readers for modal/drawer dismissal controls.
- Ensures screen readers announce exactly what action is being taken ("Close drawer" vs just "Close").
- Follows WCAG 2.1 Success Criterion 2.4.4 Link Purpose (In Context).

---
*PR created automatically by Jules for task [11084166608933171280](https://jules.google.com/task/11084166608933171280) started by @MattShelton04*