### PR TITLE
⚡ Bolt: Optimize SQL placeholder generation using push_str chunks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Optimize dynamic SQL placeholder generation
+**Learning:** In Rust, when generating dynamic SQL placeholder strings (e.g. `?, ?, ?`), pushing individual characters `s.push(',')`, `s.push('?')` or doing conditional check inside the loop is slower. We can extract the first `?` outside the loop, short-circuit `n=0`, and use `s.push_str(", ?")` which does a direct optimized memory copy of the pre-allocated byte slice instead of iterative scalar character-by-character pushes.
+**Action:** Apply this optimization to `build_in_placeholders` and `build_placeholder_sql` in `tracepilot-core`. Avoid `saturating_add`, `saturating_mul`, `saturating_sub` in `String::with_capacity` as it introduces a de-optimization by injecting unnecessary bounds-checking instructions.

--- a/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
+++ b/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
@@ -15,13 +15,14 @@ pub fn build_in_placeholders(n: usize) -> String {
         n > 0,
         "build_in_placeholders requires n > 0; n=0 produces empty string that makes IN () invalid SQL"
     );
+    if n == 0 {
+        return String::new();
+    }
     // Each element is "?" (1 char) + ", " (2 chars) except the last → n*3 max.
     let mut s = String::with_capacity(n * 3);
-    for i in 0..n {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        s.push('?');
+    s.push('?');
+    for _ in 1..n {
+        s.push_str(", ?");
     }
     s
 }
@@ -64,11 +65,9 @@ pub fn build_placeholder_sql(sql_prefix: &str, num_rows: usize, params_per_row: 
     sql.push(' ');
 
     let mut row_str = String::with_capacity(params_per_row * 2 + 1);
-    row_str.push('(');
-    row_str.push('?');
+    row_str.push_str("(?");
     for _ in 1..params_per_row {
-        row_str.push(',');
-        row_str.push('?');
+        row_str.push_str(",?");
     }
     row_str.push(')');
 


### PR DESCRIPTION
**💡 What:** 
Optimized dynamic SQL string placeholder generation in `tracepilot-core/src/utils/sqlite/placeholders.rs` by transitioning from iterative scalar character pushes (`.push(',')`, `.push('?')`) and in-loop branch evaluations to chunk-based slice copies via `.push_str(", ?")` and `.push_str(",?")`.

**🎯 Why:**
In Rust, executing `.push_str()` on pre-allocated strings performs a highly optimized, direct memory copy of the static byte slice. This is measurably faster than pushing individual characters and eliminates conditional check overhead within hot loops when generating extremely large parameterized query bindings (like 50-row x 9-column batch insertions).

**📊 Impact:** 
Eliminates overhead for branch evaluation in `build_in_placeholders` and significantly reduces function call overhead across bulk insert operations. Memory allocation metrics are unchanged (as capacities were already fully optimized), but CPU cycles spent on loop iteration and string appending are reduced.

**🔬 Measurement:** 
Run existing SQL tests in `crates/tracepilot-core/src/utils/sqlite/placeholders.rs` and verify the output strings match precisely without regressions, alongside `tracepilot-bench` validation.

---
*PR created automatically by Jules for task [11750357924122559417](https://jules.google.com/task/11750357924122559417) started by @MattShelton04*