### PR TITLE
🎨 Palette: Improve accessibility of structural close controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-19 - Initial Learnings
+**Learning:** This is the first entry. I need to make sure I add UX improvements like ARIA labels or better loading states to UI elements.
+**Action:** Always verify components have proper accessibility features in mind.
+
+## 2024-05-19 - Improved specific ARIA labels
+**Learning:** Structural components like Modals and Drawers should have specific aria-labels for their close buttons (e.g. 'Close modal' instead of 'Close') to provide better context to screen reader users.
+**Action:** Use specific aria-labels indicating the component type rather than generic ones.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
### 💡 What
Updated `aria-label="Close"` to `aria-label="Close modal"` and `aria-label="Close drawer"` respectively in `ModalDialog.vue` and `Drawer.vue`. Also updated the corresponding query in `ModalDialog.test.ts`.

### 🎯 Why
When interacting via a screen reader, structural close controls that simply say "Close" provide insufficient context about what container or modal is actually being closed. This improves accessibility and provides more explicit context.

### ♿ Accessibility
This explicitly solves an a11y problem by providing clearer context on icon-only buttons via an improved `aria-label`.

---
*PR created automatically by Jules for task [17417213425643438611](https://jules.google.com/task/17417213425643438611) started by @MattShelton04*