### PR TITLE
⚡ Bolt: Optimize SQL placeholder string allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Optimizing dynamic SQL placeholders
+**Learning:** Using scalar character-by-character pushes (`.push(',')`, `.push('?')`) inside a loop is slower than chunk slice additions (`.push_str(", ?")`) directly onto a pre-allocated string. Extracting the first character push before a loop enables this chunking, but requires explicitly checking and short-circuiting edge cases like `n=0` to prevent runtime panics or underflows on capacity calculations.
+**Action:** Use `.push_str()` for repeating string patterns instead of individual character pushes, combined with a pre-allocation calculation using standard arithmetic operators instead of saturating math which injects bounds-checking instructions.

--- a/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
+++ b/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
@@ -15,13 +15,14 @@ pub fn build_in_placeholders(n: usize) -> String {
         n > 0,
         "build_in_placeholders requires n > 0; n=0 produces empty string that makes IN () invalid SQL"
     );
-    // Each element is "?" (1 char) + ", " (2 chars) except the last → n*3 max.
-    let mut s = String::with_capacity(n * 3);
-    for i in 0..n {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        s.push('?');
+    if n == 0 {
+        return String::new();
+    }
+    // Each element is "?" (1 char) + ", " (2 chars) except the last → n*3 - 2 max.
+    let mut s = String::with_capacity(n * 3 - 2);
+    s.push('?');
+    for _ in 1..n {
+        s.push_str(", ?");
     }
     s
 }
@@ -64,11 +65,9 @@ pub fn build_placeholder_sql(sql_prefix: &str, num_rows: usize, params_per_row: 
     sql.push(' ');
 
     let mut row_str = String::with_capacity(params_per_row * 2 + 1);
-    row_str.push('(');
-    row_str.push('?');
+    row_str.push_str("(?");
     for _ in 1..params_per_row {
-        row_str.push(',');
-        row_str.push('?');
+        row_str.push_str(",?");
     }
     row_str.push(')');
 


### PR DESCRIPTION
💡 **What**: Optimized `build_in_placeholders` and `build_placeholder_sql` functions in the `tracepilot-core` crate by replacing character-by-character pushes inside loops with direct string slice additions (`push_str`) via pre-allocated chunks.
🎯 **Why**: When dynamically generating large SQL placeholder strings in Rust for batch inserts (or `IN` clauses), iterating over character scalar pushes (`.push(',')`, `.push('?')`) incurs slight per-character overhead. Pre-allocating string capacity and chunking the repeating sequences (e.g. `, ?`) allows `push_str` to perform a more direct memory copy, making the operation faster.
📊 **Impact**: Expected small measurable reduction in memory write time for heavy batch ingestion operations relying on these placeholder generators.
🔬 **Measurement**: Workspace unit tests correctly pass asserting functionality remains intact, and Rust clippy confirms the new structure meets standard idioms.

Included a critical journal learning in `.jules/bolt.md` documenting string allocation optimization limits.

---
*PR created automatically by Jules for task [16537817722370893425](https://jules.google.com/task/16537817722370893425) started by @MattShelton04*