### PR TITLE
🎨 Palette: Contextual aria-labels for structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Contextual Aria Labels for Structural Components
+**Learning:** Generic 'Close' aria-labels on structural components (like Drawers and Modals) lack context for screen reader users and are insufficient.
+**Action:** Always append the component type to the label (e.g., 'Close drawer' or 'Close modal') to provide explicit context.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 What: Updated the `aria-label` attribute on the close buttons in `Drawer.vue` and `ModalDialog.vue` to be component-specific (`Close drawer` and `Close modal`). Updated the corresponding tests to reflect this change.

🎯 Why: Generic 'Close' aria-labels on structural components lack sufficient context for screen reader users, making it unclear what exactly is being closed if multiple overlays exist or if the user is tabbing through the interface rapidly.

📸 Before/After: Visuals are unchanged.

♿ Accessibility: Significantly improves screen reader navigation by providing explicit context about the interactive element's purpose.

---
*PR created automatically by Jules for task [11219764209322360182](https://jules.google.com/task/11219764209322360182) started by @MattShelton04*