### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in GitHub import

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Fix Cross-Platform Path Traversal in GitHub Import
+**Vulnerability:** Path traversal vulnerability in GitHub tree import where Windows-style paths (with backslashes) or root paths might bypass `std::path::Component` and `is_absolute` checks when evaluated on a Unix system.
+**Learning:** `std::path::Component::ParentDir` and `is_absolute()` parse paths according to the host OS. A crafted archive with backslashes is not seen as a traversal/absolute path on Unix, but could be extracted dangerously.
+**Prevention:** Always combine `Path` parsing for `..` segments with explicit character-based rejection of backslashes (`\`) and root characters (`/`) when validating cross-platform archives.

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -172,7 +172,11 @@ pub(crate) fn import_from_github_path(
                         let has_traversal = Path::new(relative)
                             .components()
                             .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() || relative.contains('\\') || relative.starts_with('/') {
+                        if has_traversal
+                            || Path::new(relative).is_absolute()
+                            || relative.contains('\\')
+                            || relative.starts_with('/')
+                        {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -172,7 +172,7 @@ pub(crate) fn import_from_github_path(
                         let has_traversal = Path::new(relative)
                             .components()
                             .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() {
+                        if has_traversal || Path::new(relative).is_absolute() || relative.contains('\\') || relative.starts_with('/') {
                             warnings.push(format!("Skipped '{}': unsafe path component", relative));
                             continue;
                         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A cross-platform path traversal vulnerability exists in the GitHub tree import where Windows-style paths (with backslashes) or paths acting as roots might bypass `std::path::Component` and `is_absolute` checks when the code is evaluated on a Unix system.
🎯 Impact: A crafted GitHub repository tree could be imported into the local machine, escaping the skill directory and potentially overwriting sensitive files on the user's filesystem.
🔧 Fix: Enhanced the existing path parsing validation in `github.rs` to explicitly block backslashes (`\`) and forward slashes (`/` at the start), ensuring complete cross-platform protection against directory traversal.
✅ Verification: Tested against crafted traversal strings to confirm it safely blocks escape characters. cargo tests continue to pass and code review was approved.

---
*PR created automatically by Jules for task [12265854515414992310](https://jules.google.com/task/12265854515414992310) started by @MattShelton04*