### PR TITLE
🎨 Palette: Improve accessibility of close buttons in structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Specific ARIA labels for structural components
+**Learning:** Structural components like Modals and Drawers should use specific ARIA labels for their close buttons (e.g., 'Close modal', 'Close drawer') rather than a generic 'Close'. This provides explicit context for screen reader users so they know what they are closing.
+**Action:** Always append the component type to the close button's aria-label in structural UI components, and remember to concurrently update associated component tests that query these elements.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 What: Updated the `aria-label` on close buttons in structural components (ModalDialog and Drawer) from a generic "Close" to a more descriptive "Close modal" and "Close drawer".

🎯 Why: Provides explicit context for screen reader users, helping them understand exactly what UI element they are closing.

📸 Before/After: Visuals remain unchanged. Structural elements were modified for screen readers.

♿ Accessibility: Ensures that generic close buttons within distinct structural areas announce their specific context, adhering to better WCAG guidelines for identifiable controls. Also documented this learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [3616508638416403941](https://jules.google.com/task/3616508638416403941) started by @MattShelton04*