### PR TITLE
🎨 Palette: Improve accessibility of structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Accessibility improvements for structural components
+**Learning:** When improving accessibility for structural components (like Drawers or Modals), avoid generic `aria-label` attributes like 'Close' on their controls. Append the component type to the label (e.g., 'Close drawer' or 'Close modal') to provide explicit context for screen reader users. Also ensure component tests that query elements by these exact string literals are concurrently updated.
+**Action:** Use specific, contextual ARIA labels instead of generic ones for important UI controls, and always update associated unit tests.

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -49,7 +49,7 @@ function handleOpenRelease() {
       <div class="modal-content" role="dialog" aria-labelledby="update-modal-title">
         <div class="modal-header">
           <h2 id="update-modal-title">Update to v{{ version }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')">×</button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -45,7 +45,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
       <div class="modal-content" role="dialog" aria-labelledby="whats-new-title">
         <div class="modal-header">
           <h2 id="whats-new-title">🎉 What's New in v{{ currentVersion }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')">×</button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/mcp/McpAddServerModal.vue
+++ b/apps/desktop/src/components/mcp/McpAddServerModal.vue
@@ -35,7 +35,7 @@ const {
               </div>
               <span id="add-server-title">Add MCP Server</span>
             </div>
-            <button class="modal-close" aria-label="Close" @click="emit('close')">✕</button>
+            <button class="modal-close" aria-label="Close modal" @click="emit('close')">✕</button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
+++ b/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
@@ -119,7 +119,7 @@ watch(
         <div class="modal-dialog" role="dialog" aria-labelledby="create-wt-title">
           <div class="modal-header">
             <h2 id="create-wt-title" class="modal-title">Create Worktree</h2>
-            <button class="icon-btn" aria-label="Close" @click="close">
+            <button class="icon-btn" aria-label="Close modal" @click="close">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
             locked
           </span>
         </div>
-        <button class="icon-btn" aria-label="Close" @click="emit('close')">
+        <button class="icon-btn" aria-label="Close panel" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of structural components

💡 What: Updated the `aria-label` attributes on the close buttons within structural components (`ModalDialog.vue`, `Drawer.vue`, `UpdateInstructionsModal.vue`, `WhatsNewModal.vue`, `McpAddServerModal.vue`, `CreateWorktreeModal.vue`, `WorktreeDetailPanel.vue`) from generic "Close" to specific labels like "Close modal", "Close drawer", and "Close panel". Also updated the associated unit test for `ModalDialog`.
🎯 Why: To provide better, more explicit context for screen reader users when interacting with modals, drawers, and side panels.
📸 Before/After: Visuals remain unchanged, but screen reader announcements are significantly improved.
♿ Accessibility: Ensures that generic close buttons within complex structural components announce their specific function (e.g., "Close drawer button" instead of just "Close button").

---
*PR created automatically by Jules for task [3557771095735063527](https://jules.google.com/task/3557771095735063527) started by @MattShelton04*