### PR TITLE
🎨 Palette: Improve accessibility of close buttons in structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Specific ARIA labels for structural components
+**Learning:** Generic `aria-label="Close"` on structural components like Modals or Drawers can lack context for screen reader users when multiple closeable elements are present.
+**Action:** Always append the component type to the label (e.g., 'Close drawer' or 'Close modal') to provide explicit context.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
**What:** Updated the `aria-label` attributes on the close buttons within the `ModalDialog` and `Drawer` structural components.
**Why:** Generic "Close" labels lack context when multiple closable components are present on the screen or in the DOM tree, leading to ambiguity for screen reader users.
**Before/After:** Before, the buttons simply had `aria-label="Close"`. Now they specify what they are closing: `aria-label="Close modal"` and `aria-label="Close drawer"`.
**Accessibility:** Provides explicit context to assistive technologies about exactly which structural component the button will close, adhering to WCAG guidelines for clear, unambiguous labeling.

---
*PR created automatically by Jules for task [10218487294774825231](https://jules.google.com/task/10218487294774825231) started by @MattShelton04*