### PR TITLE
🎨 Palette: Enhance structural component close button aria-labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - Improving Context for Structural Components
+**Learning:** When improving accessibility for structural components (like Drawers or Modals), using generic aria-label attributes like 'Close' on their controls lacks context for screen reader users.
+**Action:** Append the component type to the label (e.g., 'Close drawer' or 'Close modal') to provide explicit context. Ensure associated tests are also updated.

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -49,7 +49,7 @@ function handleOpenRelease() {
       <div class="modal-content" role="dialog" aria-labelledby="update-modal-title">
         <div class="modal-header">
           <h2 id="update-modal-title">Update to v{{ version }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')">×</button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -45,7 +45,7 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
       <div class="modal-content" role="dialog" aria-labelledby="whats-new-title">
         <div class="modal-header">
           <h2 id="whats-new-title">🎉 What's New in v{{ currentVersion }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close modal" @click="emit('close')">×</button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/mcp/McpAddServerModal.vue
+++ b/apps/desktop/src/components/mcp/McpAddServerModal.vue
@@ -35,7 +35,7 @@ const {
               </div>
               <span id="add-server-title">Add MCP Server</span>
             </div>
-            <button class="modal-close" aria-label="Close" @click="emit('close')">✕</button>
+            <button class="modal-close" aria-label="Close modal" @click="emit('close')">✕</button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
+++ b/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
@@ -119,7 +119,7 @@ watch(
         <div class="modal-dialog" role="dialog" aria-labelledby="create-wt-title">
           <div class="modal-header">
             <h2 id="create-wt-title" class="modal-title">Create Worktree</h2>
-            <button class="icon-btn" aria-label="Close" @click="close">
+            <button class="icon-btn" aria-label="Close modal" @click="close">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
             locked
           </span>
         </div>
-        <button class="icon-btn" aria-label="Close" @click="emit('close')">
+        <button class="icon-btn" aria-label="Close panel" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
### 💡 What
Replaced generic "Close" aria-labels on structural components (Drawers, Modals, Details Panels) with more contextual labels (e.g., "Close modal", "Close drawer", "Close panel").

### 🎯 Why
Generic "Close" labels lack context. When a screen reader user navigates the page, hearing "Close" does not explain *what* they are closing, which is especially problematic if multiple overlays, banners, or dialogs exist simultaneously.

### 📸 Before/After
*Before:* `<button aria-label="Close">`
*After:* `<button aria-label="Close modal">`

### ♿ Accessibility
Significantly improves navigation context for screen reader users when interacting with structural overlay components by explicitly describing the element being closed.

---
*PR created automatically by Jules for task [7999879539420163979](https://jules.google.com/task/7999879539420163979) started by @MattShelton04*