### PR TITLE
🎨 Palette: Improve accessibility of structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Contextual ARIA labels on structural controls
+**Learning:** Generic `aria-label="Close"` on structural components like Drawers and Modals lacks context for screen reader users when multiple overlay elements might be present on screen.
+**Action:** Always append the component type to the label (e.g., 'Close drawer', 'Close modal') to provide explicit context.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of structural components

💡 What:
Added specific component types to the aria-label of the close buttons in `Drawer` and `ModalDialog` components (changed "Close" to "Close drawer" and "Close modal"). Also added a journal entry for this UX learning.

🎯 Why:
Generic `aria-label="Close"` on structural components lacks context for screen reader users, especially when multiple overlay elements might be present on the screen.

📸 Before/After:
Before: `<button aria-label="Close">...</button>`
After: `<button aria-label="Close modal">...</button>`

♿ Accessibility:
Provides explicit context to screen reader users about which structural overlay they are closing.

---
*PR created automatically by Jules for task [17201451873595648912](https://jules.google.com/task/17201451873595648912) started by @MattShelton04*