### PR TITLE
🎨 Palette: Improve accessibility for modal and drawer close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility rules for close buttons
+**Learning:** When improving accessibility for structural components (like Drawers or Modals), avoid generic `aria-label` attributes like 'Close' on their controls. Append the component type to the label (e.g., 'Close drawer') to provide explicit context for screen reader users. Also make sure to update related tests to reflect the updated aria label.
+**Action:** When updating a close button in a structural component, use a specific `aria-label` like "Close modal" or "Close drawer".

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 **What:** Changed generic "Close" aria-labels to "Close modal" and "Close drawer" on structural UI components.

🎯 **Why:** To provide explicit context for screen reader users when interacting with structural components. The generic "Close" label does not describe what is being closed, which can be confusing if multiple popups or drawers are open.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Improved screen reader context for modal dialog and drawer close buttons.

---
*PR created automatically by Jules for task [12758015110753814054](https://jules.google.com/task/12758015110753814054) started by @MattShelton04*