### PR TITLE
🎨 Palette: Contextual ARIA labels for modals and drawers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Contextual Aria Labels for Structural Components
+**Learning:** Generic `aria-label="Close"` on structural components like Modals and Drawers lacks context for screen reader users when multiple actionable components may be present.
+**Action:** Always append the component type to the aria-label (e.g., "Close modal", "Close drawer") to provide clear explicit context.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
💡 What
Updated the `aria-label` attributes on the close buttons within structural UI components (`ModalDialog.vue` and `Drawer.vue`) from a generic `"Close"` to a context-specific `"Close modal"` and `"Close drawer"`.

🎯 Why
When multiple actionable or dismissible elements exist on a page (e.g., a modal overlaying a page that also has a banner or a drawer), having generic "Close" buttons creates ambiguity for screen reader users. They may not know *what* component they are closing. Appending the component type provides explicit context.

📸 Before/After
*   **Before:** `<button aria-label="Close">`
*   **After:** `<button aria-label="Close modal">`

♿ Accessibility
This change directly improves the clarity and navigability of the application for users relying on assistive technologies by ensuring control labels are descriptive of their specific function and context. The corresponding tests were updated to reflect these changes.

---
*PR created automatically by Jules for task [1361697052192926526](https://jules.google.com/task/1361697052192926526) started by @MattShelton04*