### PR TITLE
🎨 Palette: Add explicit ARIA labels to generic close controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility: Explicit ARIA labels on generic close controls
+**Learning:** Structural components like Modals and Drawers often share standard accessibility labels (e.g. `aria-label="Close"`). This generic string provides insufficient context for screen reader users when multiple closeable overlays exist on a page simultaneously (e.g., closing the drawer versus closing the active modal).
+**Action:** When updating generic `aria-label`s on core architectural components, ALWAYS append the component type (e.g. "Close modal", "Close drawer") to the label string to provide explicit structural context. Update accompanying query tests concurrently.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
* 💡 What: Added explicit structural context to generic close buttons in Modals and Drawers.
* 🎯 Why: "Close" is insufficient for screen readers when multiple overlays might exist on a page simultaneously; specifying "Close modal" or "Close drawer" improves navigation clarity and structural context.
* 📸 Before/After: Not applicable (DOM attribute change only, no visual change).
* ♿ Accessibility: Significant improvement for screen reader users by removing ambiguous label context on primary UI overlays.

---
*PR created automatically by Jules for task [431797436596233658](https://jules.google.com/task/431797436596233658) started by @MattShelton04*