### PR TITLE
🎨 Palette: Contextual ARIA labels for structural components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Specific ARIA labels for structural UI
+**Learning:** When improving accessibility for structural components (like Drawers or Modals), using generic aria-label attributes like 'Close' on controls provides insufficient context for screen reader users.
+**Action:** Always append the component type to the label (e.g., 'Close drawer', 'Close modal') to provide explicit context. Ensure associated component tests are updated concurrently to prevent query failures.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
### 💡 What
Updated the `aria-label` attributes on the close buttons within `Drawer.vue` and `ModalDialog.vue` from the generic `"Close"` to `"Close drawer"` and `"Close modal"`, respectively. Also updated the corresponding `ModalDialog` unit test.

### 🎯 Why
When using screen readers, a generic `"Close"` label on a button does not provide sufficient context about *what* is being closed, especially when multiple overlays or structural elements might be present or when users navigate by form controls/landmarks.

### 📸 Before/After
**Before:**
`<button aria-label="Close" ...>` (Drawer/Modal)
**After:**
`<button aria-label="Close drawer" ...>` (Drawer)
`<button aria-label="Close modal" ...>` (ModalDialog)

### ♿ Accessibility
This change provides explicit, contextual feedback for screen reader users when interacting with structural overlay components, ensuring they know exactly what interaction will occur when the control is activated.

---
*PR created automatically by Jules for task [2195789690072399881](https://jules.google.com/task/2195789690072399881) started by @MattShelton04*