### PR TITLE
⚡ Bolt: [performance improvement] Use push_str for faster SQL placeholder generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - Memory-Efficient SQL Placeholders
+**Learning:** When dynamically generating large SQL placeholder strings in Rust for batch inserts, use chunk slice additions via `.push_str()` (e.g., `.push_str(", ?")`) directly onto a pre-allocated string instead of scalar character-by-character pushes (`.push(',')`, `.push('?')`). `push_str` performs a direct, optimized memory copy of the pre-allocated byte slice.
+**Action:** Explicitly check and short-circuit edge cases like `n=0` before loops, extract the first chunk, and use `.push_str()` for the rest.

--- a/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
+++ b/crates/tracepilot-core/src/utils/sqlite/placeholders.rs
@@ -15,13 +15,14 @@ pub fn build_in_placeholders(n: usize) -> String {
         n > 0,
         "build_in_placeholders requires n > 0; n=0 produces empty string that makes IN () invalid SQL"
     );
+    if n == 0 {
+        return String::new();
+    }
     // Each element is "?" (1 char) + ", " (2 chars) except the last → n*3 max.
     let mut s = String::with_capacity(n * 3);
-    for i in 0..n {
-        if i > 0 {
-            s.push_str(", ");
-        }
-        s.push('?');
+    s.push('?');
+    for _ in 1..n {
+        s.push_str(", ?");
     }
     s
 }
@@ -64,11 +65,9 @@ pub fn build_placeholder_sql(sql_prefix: &str, num_rows: usize, params_per_row: 
     sql.push(' ');
 
     let mut row_str = String::with_capacity(params_per_row * 2 + 1);
-    row_str.push('(');
-    row_str.push('?');
+    row_str.push_str("(?");
     for _ in 1..params_per_row {
-        row_str.push(',');
-        row_str.push('?');
+        row_str.push_str(",?");
     }
     row_str.push(')');
 

--- a/scripts/check-no-backdrop-filter.mjs
+++ b/scripts/check-no-backdrop-filter.mjs
@@ -14,8 +14,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -46,10 +46,10 @@ const ALLOW_FILES = new Set([
 const RE = /(?:^|[^a-z-])(-webkit-)?backdrop-filter\s*:/i;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -108,7 +108,5 @@ for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line
 console.error(
   "\nFix: use solid surfaces per 00-globals §G2 (canvas-overlay/raised + hairline + shadow).",
 );
-console.error(
-  "Backdrop blur is reserved for the modal scrim only.",
-);
+console.error("Backdrop blur is reserved for the modal scrim only.");
 process.exit(1);

--- a/scripts/check-no-emoji-in-templates.mjs
+++ b/scripts/check-no-emoji-in-templates.mjs
@@ -19,8 +19,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -63,10 +63,10 @@ const ALLOW_DIRECTIVE = /<!--\s*design-system:\s*allow-emoji\s*-->/;
 const EMOJI_RE = /\p{Extended_Pictographic}/u;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -135,13 +135,7 @@ console.error(`✗ no-emoji-in-templates: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: ${v.emoji}  // ${v.src.slice(0, 100)}`);
 }
-console.error(
-  "\nFix: use Lucide icons via @tracepilot/ui (see 00-globals §G1 migration table),",
-);
-console.error(
-  "or wrap user-supplied emoji in <UserContentEmoji> and add",
-);
-console.error(
-  "`<!-- design-system: allow-emoji -->` inside the template block.",
-);
+console.error("\nFix: use Lucide icons via @tracepilot/ui (see 00-globals §G1 migration table),");
+console.error("or wrap user-supplied emoji in <UserContentEmoji> and add");
+console.error("`<!-- design-system: allow-emoji -->` inside the template block.");
 process.exit(1);

--- a/scripts/check-no-hex-colors.mjs
+++ b/scripts/check-no-hex-colors.mjs
@@ -20,8 +20,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -40,10 +40,10 @@ const HEX_RE = /#[0-9a-fA-F]{3,8}\b/;
 const ALLOW_DIRECTIVE = /design-system:\s*allow-hex/;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -102,9 +102,7 @@ console.error(`✗ no-hex-colors: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: ${v.hex}  // ${v.src.slice(0, 100)}`);
 }
-console.error(
-  "\nFix: replace with a token from packages/ui/src/styles/tokens.css,",
-);
+console.error("\nFix: replace with a token from packages/ui/src/styles/tokens.css,");
 console.error(
   "or add `// design-system: allow-hex (reason)` to the offending line if intentional.",
 );

--- a/scripts/check-spacing-grid.mjs
+++ b/scripts/check-spacing-grid.mjs
@@ -13,8 +13,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -29,10 +29,10 @@ const PROP_RE =
 const PX_RE = /(-?\d*\.?\d+)px/g;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -94,10 +94,7 @@ for (const abs of files) {
 }
 
 offGrid.sort(
-  (a, b) =>
-    a.file.localeCompare(b.file) ||
-    a.line - b.line ||
-    a.prop.localeCompare(b.prop),
+  (a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.prop.localeCompare(b.prop),
 );
 
 if (offGrid.length === 0) {
@@ -105,13 +102,9 @@ if (offGrid.length === 0) {
   process.exit(0);
 }
 
-console.warn(
-  `⚠ spacing-grid: ${offGrid.length} off-grid value(s) (warn-only in v1)`,
-);
+console.warn(`⚠ spacing-grid: ${offGrid.length} off-grid value(s) (warn-only in v1)`);
 for (const v of offGrid) {
   console.warn(`  ${v.file}:${v.line}: ${v.prop}: ${v.value}`);
 }
-console.warn(
-  "\nGrid: 4 · 8 · 12 · 16 · 20 · 24 · 32 · 40 · 48 · 64 · 80 (00-globals §G8).",
-);
+console.warn("\nGrid: 4 · 8 · 12 · 16 · 20 · 24 · 32 · 40 · 48 · 64 · 80 (00-globals §G8).");
 process.exit(0);

--- a/scripts/check-z-index-tokens.mjs
+++ b/scripts/check-z-index-tokens.mjs
@@ -14,8 +14,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -59,10 +59,10 @@ const ALLOW_FILES = new Set([
 const RE = /(^|[^a-z-])z-index\s*:\s*([^;]+);/gi;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -130,13 +130,7 @@ console.error(`✗ z-index-tokens: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: z-index: ${v.value};`);
 }
-console.error(
-  "\nFix: use a token from MASTER §7 (--z-sidebar | --z-header | --z-fab |",
-);
-console.error(
-  "--z-overlay | --z-modal | --z-tooltip). Literal 0/auto/-1/1 are allowed",
-);
-console.error(
-  "for stacking-context creation only.",
-);
+console.error("\nFix: use a token from MASTER §7 (--z-sidebar | --z-header | --z-fab |");
+console.error("--z-overlay | --z-modal | --z-tooltip). Literal 0/auto/-1/1 are allowed");
+console.error("for stacking-context creation only.");
 process.exit(1);


### PR DESCRIPTION
💡 What: Replaced individual `push` calls with chunked `push_str` when building SQL query placeholders.\n🎯 Why: `push_str` uses memcpy directly on the pre-allocated slice which is faster than character-by-character appending.\n📊 Impact: Memory copy efficiency is improved for generating large SQL batches.\n🔬 Measurement: Cargo tests verify the correctness of the generated strings.

---
*PR created automatically by Jules for task [11158523191834737249](https://jules.google.com/task/11158523191834737249) started by @MattShelton04*