### PR TITLE
🎨 Palette: Improve accessibility labels on Drawer and Modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Contextual Close Labels
+**Learning:** Generic `aria-label="Close"` attributes on structural components like Modals and Drawers lack sufficient context for screen reader users, making navigation confusing when multiple overlays might exist or be recently closed.
+**Action:** Append the component type to the label (e.g., `aria-label="Close modal"` or `aria-label="Close drawer"`) and ensure corresponding unit tests querying by these labels are concurrently updated.

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close modal']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              aria-label="Close drawer"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>


### PR DESCRIPTION
### 💡 What
Updated the generic `aria-label="Close"` on the `Drawer` and `ModalDialog` components to be more specific: `"Close drawer"` and `"Close modal"`. Updated the corresponding unit tests to reflect the new labels. Also tracked the learning in a `.jules/palette.md` journal.

### 🎯 Why
Generic `aria-label="Close"` attributes on structural components like Modals and Drawers lack sufficient context for screen reader users. This makes navigation confusing, especially when multiple overlays might exist or be recently closed. Appending the component type provides explicit context.

### 📸 Before/After
- Before: `aria-label="Close"`
- After: `aria-label="Close drawer"` and `aria-label="Close modal"`

### ♿ Accessibility
Improved context for screen reader users when interacting with close buttons on structural layout components.

---
*PR created automatically by Jules for task [3141734441189181830](https://jules.google.com/task/3141734441189181830) started by @MattShelton04*