### PR TITLE
Improve analytics, pricing, and chart usability

### DIFF
--- a/apps/desktop/src/__tests__/stores/preferences.test.ts
+++ b/apps/desktop/src/__tests__/stores/preferences.test.ts
@@ -1,4 +1,5 @@
 import { setupPinia } from "@tracepilot/test-utils";
+import { DEFAULT_COST_PER_PREMIUM_REQUEST } from "@tracepilot/types";
 import { beforeEach, describe, expect, it } from "vitest";
 import { usePreferencesStore } from "../../stores/preferences";
 
@@ -38,6 +39,11 @@ describe("usePreferencesStore", () => {
   it("initializes uiScale with default (1.0)", () => {
     const store = usePreferencesStore();
     expect(store.uiScale).toBe(1.0);
+  });
+
+  it("uses the fixed legacy premium request cost", () => {
+    const store = usePreferencesStore();
+    expect(store.costPerPremiumRequest).toBe(DEFAULT_COST_PER_PREMIUM_REQUEST);
   });
 
   it("can update contentMaxWidth", () => {

--- a/apps/desktop/src/__tests__/styles/chartSharedTheme.test.ts
+++ b/apps/desktop/src/__tests__/styles/chartSharedTheme.test.ts
@@ -5,10 +5,15 @@ import { describe, expect, it } from "vitest";
 describe("chart shared theme styles", () => {
   const cssPath = resolve(__dirname, "../../styles/chart-shared.css");
   const css = readFileSync(cssPath, "utf8");
+  const tooltipPath = resolve(
+    __dirname,
+    "../../../../../packages/ui/src/components/ChartTooltip.vue",
+  );
+  const tooltip = readFileSync(tooltipPath, "utf8");
 
   it("uses explicit chart tooltip theme tokens", () => {
-    expect(css).toContain("var(--chart-tooltip-bg");
-    expect(css).toContain("var(--chart-tooltip-fg");
+    expect(tooltip).toContain("var(--chart-tooltip-bg");
+    expect(tooltip).toContain("var(--chart-tooltip-fg");
   });
 
   it("applies non-opacity-only active bar emphasis", () => {

--- a/apps/desktop/src/__tests__/views/analytics-views.test.ts
+++ b/apps/desktop/src/__tests__/views/analytics-views.test.ts
@@ -387,6 +387,34 @@ describe("CodeImpactView", () => {
     expect(svgs.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("shows timeline details when hovering the code chart", async () => {
+    mockGetCodeImpact.mockResolvedValue(FIXTURE_CODE_IMPACT);
+    const Component = await loadCodeImpact();
+    const wrapper = mount(Component, globalStubs);
+    await flushPromises();
+
+    const svgWrapper = wrapper.find(".code-timeline-chart svg");
+    const svg = svgWrapper.element as SVGSVGElement;
+    Object.defineProperty(svg, "createSVGPoint", {
+      configurable: true,
+      value: () => ({
+        x: 0,
+        y: 0,
+        matrixTransform: () => ({ x: 365, y: 100 }),
+      }),
+    });
+    Object.defineProperty(svg, "getScreenCTM", {
+      configurable: true,
+      value: () => ({ inverse: () => ({}) }),
+    });
+
+    await svgWrapper.trigger("mousemove", { clientX: 100, clientY: 100 });
+    await flushPromises();
+
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toContain("+300 / -80");
+    wrapper.unmount();
+  });
+
   it("strides dense date labels in the changes chart", async () => {
     const changesByDay = Array.from({ length: 30 }, (_, index) => ({
       date: `2025-01-${String(index + 1).padStart(2, "0")}`,

--- a/apps/desktop/src/__tests__/views/analytics-views.test.ts
+++ b/apps/desktop/src/__tests__/views/analytics-views.test.ts
@@ -387,6 +387,25 @@ describe("CodeImpactView", () => {
     expect(svgs.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("strides dense date labels in the changes chart", async () => {
+    const changesByDay = Array.from({ length: 30 }, (_, index) => ({
+      date: `2025-01-${String(index + 1).padStart(2, "0")}`,
+      additions: index + 1,
+      deletions: index,
+    }));
+    mockGetCodeImpact.mockResolvedValue({ ...FIXTURE_CODE_IMPACT, changesByDay });
+    const Component = await loadCodeImpact();
+    const wrapper = mount(Component, globalStubs);
+
+    await flushPromises();
+
+    const xLabels = wrapper
+      .findAll(".code-timeline-chart .chart-label")
+      .filter((label) => label.attributes("text-anchor") === "middle");
+    expect(xLabels.length).toBeGreaterThan(0);
+    expect(xLabels.length).toBeLessThanOrEqual(8);
+  });
+
   it("shows positive net change with correct label", async () => {
     mockGetCodeImpact.mockResolvedValue(FIXTURE_CODE_IMPACT);
     const Component = await loadCodeImpact();

--- a/apps/desktop/src/__tests__/views/analytics-views.test.ts
+++ b/apps/desktop/src/__tests__/views/analytics-views.test.ts
@@ -199,14 +199,14 @@ describe("AnalyticsDashboardView", () => {
     expect(wrapper.text()).not.toContain("API Duration");
   });
 
-  it("renders the AIC-first trend with a legacy compatibility toggle", async () => {
+  it("renders the USD-first cost trend with an AI Credit compatibility toggle", async () => {
     mockGetAnalytics.mockResolvedValue(FIXTURE_ANALYTICS);
     const Component = await loadAnalyticsDashboard();
     const wrapper = mount(Component, globalStubs);
 
     await flushPromises();
 
-    expect(wrapper.text()).toContain("AI Credit Trend");
+    expect(wrapper.text()).toContain("Cost Trend");
 
     const radios = wrapper.findAll('[role="radio"]');
     const aiCreditsBtn = radios.find((b) => b.text().includes("AI Credits"));
@@ -215,11 +215,11 @@ describe("AnalyticsDashboardView", () => {
     expect(legacyBtn).toBeTruthy();
     expect(aiCreditsBtn!.attributes("aria-checked")).toBe("true");
     expect(legacyBtn!.attributes("aria-checked")).toBe("false");
-    expect(wrapper.text()).toContain("Dollar equivalent: 1 AIC = $0.01");
+    expect(wrapper.text()).not.toContain("Dollar equivalent:");
 
     const chartSvg = wrapper
       .findAll("svg")
-      .find((s) => /AI Credit usage/i.test(s.attributes("aria-label") ?? ""));
+      .find((s) => /AI Credit cost in US dollars/i.test(s.attributes("aria-label") ?? ""));
     expect(chartSvg).toBeTruthy();
   });
 
@@ -237,8 +237,7 @@ describe("AnalyticsDashboardView", () => {
     await legacyBtn!.trigger("click");
     await flushPromises();
 
-    expect(wrapper.text()).toContain("Legacy Premium Cost Trend");
-    expect(wrapper.text()).not.toContain("AI Credit Trend");
+    expect(wrapper.text()).toContain("Cost Trend");
     expect(wrapper.text()).not.toContain("Dollar equivalent:");
     expect(legacyBtn!.attributes("aria-checked")).toBe("true");
 

--- a/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
+++ b/apps/desktop/src/components/analytics/AnalyticsDistributionRow.vue
@@ -72,53 +72,52 @@ const costBasis = ref<CostBasis>("aiCredits");
 
 const isAiCredits = computed(() => costBasis.value === "aiCredits");
 
-const costPanelTitle = computed(() =>
-  isAiCredits.value ? "AI Credit Trend" : "Legacy Premium Cost Trend",
-);
-
 const costColor = computed(() => (isAiCredits.value ? CHART_COLORS.success : CHART_COLORS.primary));
 const costColorLight = computed(() =>
   isAiCredits.value ? CHART_COLORS.successLight : CHART_COLORS.primaryLight,
 );
 
-const costPoints = computed(() =>
-  buildAnalyticsCostSeries(
+const costPoints = computed(() => {
+  const points = buildAnalyticsCostSeries(
     props.data,
     costBasis.value,
     prefs.costPerPremiumRequest,
     prefs.computeWholesaleCost,
     prefs.computeUsageBasedCost,
-  ),
-);
+  );
+  return points.map((point) => ({
+    ...point,
+    aiCredits: isAiCredits.value ? point.cost : null,
+    cost: isAiCredits.value ? point.cost * AI_CREDIT_USD : point.cost,
+  }));
+});
 
 const { chartData: costChart } = useLineAreaChartData({
   data: costPoints,
   layout: props.chartLayout,
   accessor: (p) => p.cost,
   yTicks: 4,
-  yFormatter: (value) => (isAiCredits.value ? formatAiCredits(value) : formatCost(value)),
+  yFormatter: formatCost,
   maxFloor: 0.01,
 });
 
 const costAriaLabel = computed(
   () =>
-    `Area chart showing daily ${isAiCredits.value ? "AI Credit usage" : "legacy premium cost"} over ${props.timeRangeLabel}`,
+    `Area chart showing daily ${isAiCredits.value ? "AI Credit cost in US dollars" : "legacy premium cost"} over ${props.timeRangeLabel}`,
 );
 
 const tooltipFormatter = (i: number) => {
   const point = costChart.value?.coords[i];
   return point
-    ? `${formatDateMedium(point.date)} — ${
-        isAiCredits.value
-          ? `${formatAiCredits(point.cost)} (${formatCost(point.cost * AI_CREDIT_USD)})`
-          : formatCost(point.cost)
+    ? `${formatDateMedium(point.date)} — ${formatCost(point.cost)}${
+        point.aiCredits == null ? "" : ` · ${formatAiCredits(point.aiCredits)}`
       }`
     : "";
 };
 </script>
 
 <template>
-  <div class="grid-2 mb-4">
+  <div class="grid-2 mb-4 analytics-distribution-grid">
     <!-- Model Distribution (Donut) -->
     <SectionPanel title="Model Distribution">
       <template #actions>
@@ -159,7 +158,7 @@ const tooltipFormatter = (i: number) => {
             @mouseleave="hoveredDonut = null"
           >
             <span class="donut-legend-dot" :style="{ background: DONUT_COLORS[si % DONUT_COLORS.length] }" />
-            <span>{{ m.model }}</span>
+            <span class="donut-legend-model" :title="m.model">{{ m.model }}</span>
             <span class="donut-legend-pct">{{ m.percentage.toFixed(0) }}%</span>
             <span class="donut-legend-requests" :title="`${formatNumberFull(m.requestCount)} API requests`">{{ formatNumberFull(m.requestCount) }} req</span>
           </div>
@@ -168,7 +167,7 @@ const tooltipFormatter = (i: number) => {
     </SectionPanel>
 
     <!-- Cost Trend -->
-    <SectionPanel :title="costPanelTitle">
+    <SectionPanel title="Cost Trend">
       <template #actions>
         <div
           class="cost-basis-switch"
@@ -213,10 +212,6 @@ const tooltipFormatter = (i: number) => {
         @click="onChartClick($event, costChart.coords, tooltipFormatter, 'cost', '.chart-frame')"
         @dismiss-tooltip="dismissTooltip"
       />
-      <div v-if="isAiCredits" class="cost-equivalence">
-        Dollar equivalent: 1 AIC = {{ formatCost(AI_CREDIT_USD) }}. Daily USD values are shown in
-        chart tooltips.
-      </div>
     </SectionPanel>
   </div>
 </template>
@@ -227,22 +222,46 @@ const tooltipFormatter = (i: number) => {
   align-items: center;
   gap: 24px;
   padding: 18px;
+  min-width: 0;
+}
+
+.analytics-distribution-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.analytics-distribution-grid :deep(.section-panel) {
+  min-width: 0;
 }
 
 .donut-legend {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  flex: 1;
+  min-width: 0;
+  max-height: 160px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-gutter: stable;
 }
 
 .donut-legend-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 8px;
   font-size: 0.8125rem;
   color: var(--text-secondary);
   cursor: default;
   transition: color var(--transition-fast, 0.15s);
+}
+
+.donut-legend-model {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .donut-legend-item--active {
@@ -284,12 +303,6 @@ const tooltipFormatter = (i: number) => {
 .donut-segment {
   cursor: default;
   transition: stroke-width 0.15s ease;
-}
-
-.cost-equivalence {
-  padding: 0 18px 12px;
-  color: var(--text-tertiary);
-  font-size: 0.6875rem;
 }
 
 .more-info-link {

--- a/apps/desktop/src/components/context/ContextWindowChart.vue
+++ b/apps/desktop/src/components/context/ContextWindowChart.vue
@@ -529,7 +529,6 @@ function eventHoverLabel(event: ContextTimelineEvent): string {
         </span>
       </div>
       <div class="context-chart__controls" aria-label="Chart navigation">
-        <span class="context-chart__gesture-hint">Scroll to zoom · drag or middle-drag to pan</span>
         <div class="context-chart__segments" aria-label="Horizontal axis">
           <button type="button" :class="{ active: axisMode === 'turn' }" @click="axisMode = 'turn'">Turn</button>
           <button type="button" :class="{ active: axisMode === 'time' }" @click="axisMode = 'time'">Time</button>
@@ -760,7 +759,6 @@ function eventHoverLabel(event: ContextTimelineEvent): string {
   width: 16px;
   border-top: 2px dotted var(--warning-fg);
 }
-.context-chart__gesture-hint { color: var(--text-tertiary); font-size: 0.6875rem; }
 .context-chart__segments { display: inline-flex; padding: 2px; border: 1px solid var(--border-default); border-radius: var(--radius-sm); }
 .context-chart__segments button { padding: 2px 7px; border: 0; border-radius: 3px; background: transparent; color: var(--text-tertiary); font: inherit; font-size: 0.6875rem; cursor: pointer; }
 .context-chart__segments button.active { background: var(--neutral-subtle); color: var(--text-primary); }

--- a/apps/desktop/src/components/metrics/MetricsSessionActivity.vue
+++ b/apps/desktop/src/components/metrics/MetricsSessionActivity.vue
@@ -220,7 +220,7 @@ function sourceLabel(source: AiCreditUsage["source"]): string {
   scrollbar-width: thin;
   scrollbar-color: var(--border-subtle) transparent;
   margin: 0 -8px;
-  justify-content: center;
+  justify-content: safe center;
 }
 
 .activity-horizontal::-webkit-scrollbar {

--- a/apps/desktop/src/components/settings/SettingsPricing.vue
+++ b/apps/desktop/src/components/settings/SettingsPricing.vue
@@ -1,35 +1,59 @@
 <script setup lang="ts">
-import { ActionButton, FormInput, SectionPanel } from "@tracepilot/ui";
-import { ref } from "vue";
+import type { ModelPriceEntry } from "@tracepilot/types";
+import { ActionButton, FormInput, SearchInput, SectionPanel } from "@tracepilot/ui";
+import { computed, reactive, ref } from "vue";
 import { usePreferencesStore } from "@/stores/preferences";
 
 const preferences = usePreferencesStore();
 
 const newModelName = ref("");
-const newInputPerM = ref(0);
-const newCachedInputPerM = ref(0);
-const newCacheWritePerM = ref(0);
-const newOutputPerM = ref(0);
-const newPremiumRequests = ref(1);
+const newRates = reactive<Record<RateField, number>>({
+  inputPerM: 0,
+  cachedInputPerM: 0,
+  cacheWritePerM: 0,
+  outputPerM: 0,
+});
+const modelSearch = ref("");
 
-function addModelPrice() {
-  if (!newModelName.value.trim()) return;
-  preferences.addWholesalePrice({
-    model: newModelName.value.trim(),
-    inputPerM: newInputPerM.value,
-    cachedInputPerM: newCachedInputPerM.value,
-    cacheWritePerM: newCacheWritePerM.value,
-    outputPerM: newOutputPerM.value,
-    premiumRequests: newPremiumRequests.value,
-    status: "user-override",
-    sourceLabel: "Local settings override",
-  });
-  newModelName.value = "";
-  newInputPerM.value = 0;
-  newCachedInputPerM.value = 0;
-  newCacheWritePerM.value = 0;
-  newOutputPerM.value = 0;
-  newPremiumRequests.value = 1;
+type RateField = "inputPerM" | "cachedInputPerM" | "cacheWritePerM" | "outputPerM";
+
+const RATE_COLUMNS: readonly {
+  field: RateField;
+  label: string;
+  description: string;
+  step: string;
+}[] = [
+  { field: "inputPerM", label: "Input", description: "Input", step: "0.01" },
+  {
+    field: "cachedInputPerM",
+    label: "Cached read",
+    description: "Cached input",
+    step: "0.001",
+  },
+  {
+    field: "cacheWritePerM",
+    label: "Cache write",
+    description: "Cache write",
+    step: "0.001",
+  },
+  { field: "outputPerM", label: "Output", description: "Output", step: "0.01" },
+];
+
+const FAMILY_DEFINITIONS = [
+  { id: "claude", label: "Anthropic Claude" },
+  { id: "openai", label: "OpenAI" },
+  { id: "gemini", label: "Google Gemini" },
+  { id: "other", label: "Other models" },
+] as const;
+
+type FamilyId = (typeof FAMILY_DEFINITIONS)[number]["id"];
+
+function modelFamily(model: string): FamilyId {
+  const normalized = model.toLowerCase();
+  if (normalized.startsWith("claude-")) return "claude";
+  if (normalized.startsWith("gpt-") || /^o[134]-/.test(normalized)) return "openai";
+  if (normalized.startsWith("gemini-")) return "gemini";
+  return "other";
 }
 
 function sourceLabel(model: string): string {
@@ -55,11 +79,51 @@ function sourceTooltip(model: string): string {
   return `${sourceLabel(model)}\nStatus: ${statusLabel(model)}\nEffective: ${effectiveLabel(model)}`;
 }
 
-function contextLabel(price: { pricingTier?: string; minimumInputTokens?: number }): string {
+function contextLabel(price: Pick<ModelPriceEntry, "pricingTier" | "minimumInputTokens">): string {
   if (price.pricingTier === "long-context" && price.minimumInputTokens != null) {
     return `Long context (>${(price.minimumInputTokens - 1).toLocaleString()} tokens)`;
   }
   return "Default context";
+}
+
+const normalizedSearch = computed(() => modelSearch.value.trim().toLowerCase());
+
+const priceGroups = computed(() =>
+  FAMILY_DEFINITIONS.map((family) => ({
+    ...family,
+    rows: preferences.modelWholesalePrices
+      .map((price, index) => ({ price, index }))
+      .filter(({ price }) => modelFamily(price.model) === family.id)
+      .filter(({ price }) => {
+        if (!normalizedSearch.value) return true;
+        return [price.model, contextLabel(price), sourceLabel(price.model)]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch.value);
+      }),
+  })).filter((family) => family.rows.length > 0),
+);
+
+const visibleRateCount = computed(() =>
+  priceGroups.value.reduce((count, family) => count + family.rows.length, 0),
+);
+
+function addModelPrice() {
+  const model = newModelName.value.trim();
+  if (!model) return;
+  preferences.addWholesalePrice({
+    model,
+    ...newRates,
+    premiumRequests: 1,
+    status: "user-override",
+    sourceLabel: "Local settings override",
+  });
+  newModelName.value = "";
+  for (const column of RATE_COLUMNS) newRates[column.field] = 0;
+}
+
+function updateRate(index: number, field: RateField, value: unknown) {
+  preferences.modelWholesalePrices[index][field] = Number(value);
 }
 </script>
 
@@ -67,310 +131,348 @@ function contextLabel(price: { pricingTier?: string; minimumInputTokens?: number
   <div class="settings-section">
     <div class="settings-section-title">AI Credit Tracking</div>
     <p class="pricing-description">
-      Observed AI Credit telemetry is always used when available. These settings only control
-      estimates for historical sessions and models whose AIC telemetry is missing.
+      TracePilot uses the most reliable cost data available for each session. Local fallback rates
+      affect estimates only; they never replace observed AI Credit telemetry.
     </p>
-    <SectionPanel>
-      <div class="setting-row">
-        <div class="setting-info">
-          <div class="setting-label">Legacy cost per premium request</div>
-          <div class="setting-description">
-            Legacy Copilot estimate for premium-request sessions. Usage-based billing uses token rates below and official GitHub Copilot rates where available.
+
+    <div class="fallback-chain" aria-label="AI Credit estimate priority">
+      <div class="fallback-step">
+        <span class="fallback-step-number">1</span>
+        <span><strong>Observed AIC</strong><small>Billing telemetry</small></span>
+      </div>
+      <span class="fallback-chain-arrow" aria-hidden="true">→</span>
+      <div class="fallback-step">
+        <span class="fallback-step-number">2</span>
+        <span><strong>GitHub rate</strong><small>Published token pricing</small></span>
+      </div>
+      <span class="fallback-chain-arrow" aria-hidden="true">→</span>
+      <div class="fallback-step">
+        <span class="fallback-step-number">3</span>
+        <span><strong>Local fallback</strong><small>Rates edited below</small></span>
+      </div>
+    </div>
+
+    <SectionPanel title="AIC Estimate Fallback Rates">
+      <template #actions>
+        <ActionButton size="sm" @click="preferences.resetWholesalePrices()">
+          Reset defaults
+        </ActionButton>
+      </template>
+
+      <p class="pricing-description pricing-description--panel">
+        USD per 1 million tokens. Expand a model family to review or edit its rates.
+      </p>
+
+      <div class="pricing-toolbar">
+        <SearchInput
+          v-model="modelSearch"
+          placeholder="Search models or sources"
+          class="pricing-search"
+        />
+        <span class="pricing-result-count" aria-live="polite">
+          {{ visibleRateCount }} rate{{ visibleRateCount === 1 ? "" : "s" }}
+        </span>
+      </div>
+
+      <div v-if="priceGroups.length" class="pricing-groups">
+        <details
+          v-for="group in priceGroups"
+          :key="group.id"
+          class="pricing-group"
+          :open="Boolean(normalizedSearch)"
+        >
+          <summary class="pricing-group-summary">
+            <span class="pricing-group-chevron" aria-hidden="true" />
+            <span class="pricing-group-name">{{ group.label }}</span>
+            <span class="pricing-group-count">
+              {{ group.rows.length }} rate{{ group.rows.length === 1 ? "" : "s" }}
+            </span>
+          </summary>
+
+          <div class="pricing-table-wrapper">
+            <table class="data-table pricing-table" :aria-label="`${group.label} fallback rates`">
+              <thead>
+                <tr>
+                  <th class="text-left">Model</th>
+                  <th v-for="column in RATE_COLUMNS" :key="column.field">
+                    {{ column.label }}
+                  </th>
+                  <th class="text-left">Source</th>
+                  <th class="pricing-col-action"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="{ price, index } in group.rows"
+                  :key="`${price.model}:${price.pricingTier ?? 'default'}:${price.minimumInputTokens ?? 0}`"
+                >
+                  <td class="pricing-model-cell">
+                    <span class="font-mono text-xs">{{ price.model }}</span>
+                    <span class="pricing-context">{{ contextLabel(price) }}</span>
+                  </td>
+                  <td v-for="column in RATE_COLUMNS" :key="column.field" class="text-center">
+                    <FormInput
+                      type="number"
+                      :model-value="price[column.field] ?? 0"
+                      @update:model-value="updateRate(index, column.field, $event)"
+                      :step="column.step"
+                      min="0"
+                      class="pricing-input"
+                      :aria-label="`${price.model} ${column.description.toLowerCase()} price per 1M tokens`"
+                    />
+                  </td>
+                  <td class="pricing-meta-cell" :title="sourceTooltip(price.model)">
+                    <span class="pricing-source-label">{{ sourceLabel(price.model) }}</span>
+                    <span class="pricing-source-meta">{{ sourceSummary(price.model) }}</span>
+                  </td>
+                  <td class="text-center">
+                    <button
+                      type="button"
+                      class="pricing-remove-btn"
+                      @click="preferences.removeWholesalePrice(price.model)"
+                      :title="`Remove all fallback rates for ${price.model}`"
+                      :aria-label="`Remove all fallback rates for ${price.model}`"
+                    >&times;</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-        </div>
-        <div class="setting-control-group">
-          <span class="setting-unit">$</span>
-          <FormInput
-            type="number"
-            :model-value="preferences.costPerPremiumRequest"
-            @update:model-value="preferences.costPerPremiumRequest = Number($event)"
-            step="0.01"
-            min="0"
-            class="input-cost"
-            aria-label="Cost per premium request in dollars"
-          />
-        </div>
+        </details>
       </div>
-    </SectionPanel>
+      <div v-else class="pricing-empty">
+        No fallback rates match “{{ modelSearch }}”.
+      </div>
 
-    <div class="pricing-subsection-title">AIC Estimate Fallback Rates</div>
-    <p class="pricing-description">
-      Local direct-API/provider prices ($ per 1M tokens) are the final AIC estimate fallback when
-      GitHub's published Copilot token rate is unavailable. Overrides do not replace observed AIC.
-    </p>
-
-    <SectionPanel>
-      <div class="pricing-table-wrapper">
-        <table class="data-table pricing-table" aria-label="Model wholesale pricing">
-          <thead>
-            <tr>
-              <th class="text-left">Model</th>
-              <th>Context tier</th>
-               <th>Input / 1M</th>
-               <th>Cached / 1M</th>
-               <th>Cache Write / 1M</th>
-               <th>Output / 1M</th>
-               <th>Legacy Req.</th>
-               <th>Source</th>
-               <th class="pricing-col-action"></th>
-             </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="(price, idx) in preferences.modelWholesalePrices"
-              :key="`${price.model}:${price.pricingTier ?? 'default'}:${price.minimumInputTokens ?? 0}`"
-            >
-              <td class="font-mono text-xs">{{ price.model }}</td>
-              <td class="text-center text-xs">{{ contextLabel(price) }}</td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  :model-value="price.inputPerM"
-                  @update:model-value="preferences.modelWholesalePrices[idx].inputPerM = Number($event)"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  :aria-label="`${price.model} input price per 1M tokens`"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  :model-value="price.cachedInputPerM"
-                  @update:model-value="preferences.modelWholesalePrices[idx].cachedInputPerM = Number($event)"
-                  step="0.001"
-                  min="0"
-                  class="pricing-input"
-                  :aria-label="`${price.model} cached input price per 1M tokens`"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  :model-value="price.cacheWritePerM ?? 0"
-                  @update:model-value="preferences.modelWholesalePrices[idx].cacheWritePerM = Number($event)"
-                  step="0.001"
-                  min="0"
-                  class="pricing-input"
-                  :aria-label="`${price.model} cache write price per 1M tokens`"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  :model-value="price.outputPerM"
-                  @update:model-value="preferences.modelWholesalePrices[idx].outputPerM = Number($event)"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  :aria-label="`${price.model} output price per 1M tokens`"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  :model-value="price.premiumRequests"
-                  @update:model-value="preferences.modelWholesalePrices[idx].premiumRequests = Number($event)"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  :aria-label="`${price.model} premium requests`"
-                />
-              </td>
-              <td class="pricing-meta-cell" :title="sourceTooltip(price.model)">
-                <span class="pricing-source-label">{{ sourceLabel(price.model) }}</span>
-                <span class="pricing-source-meta">{{ sourceSummary(price.model) }}</span>
-              </td>
-              <td class="text-center">
-                <button class="pricing-remove-btn" @click="preferences.removeWholesalePrice(price.model)" :title="`Remove ${price.model}`" :aria-label="`Remove pricing for ${price.model}`">&times;</button>
-              </td>
-            </tr>
-            <!-- Add new model row -->
-            <tr class="pricing-add-row">
-              <td>
-                <FormInput
-                  v-model="newModelName"
-                  placeholder="model-name"
-                  class="pricing-model-input"
-                  aria-label="New model name"
-                />
-              </td>
-              <td class="text-center text-xs">Default context</td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  v-model="newInputPerM"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  aria-label="New model input price per 1M tokens"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  v-model="newCachedInputPerM"
-                  step="0.001"
-                  min="0"
-                  class="pricing-input"
-                  aria-label="New model cached input price per 1M tokens"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  v-model="newCacheWritePerM"
-                  step="0.001"
-                  min="0"
-                  class="pricing-input"
-                  aria-label="New model cache write price per 1M tokens"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  v-model="newOutputPerM"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  aria-label="New model output price per 1M tokens"
-                />
-              </td>
-              <td class="text-center">
-                <FormInput
-                  type="number"
-                  v-model="newPremiumRequests"
-                  step="0.01"
-                  min="0"
-                  class="pricing-input"
-                  aria-label="New model premium requests"
-                />
-              </td>
-              <td class="pricing-meta-cell" title="Local settings override&#10;Status: user-override&#10;Effective: always">
-                <span class="pricing-source-label">Local settings override</span>
-                <span class="pricing-source-meta">user-override · always</span>
-              </td>
-              <td class="text-center">
-                <button class="pricing-add-btn" @click="addModelPrice" :disabled="!newModelName.trim()" title="Add model" aria-label="Add model pricing entry">+</button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="pricing-actions">
-        <ActionButton size="sm" @click="preferences.resetWholesalePrices()">Reset to Defaults</ActionButton>
-      </div>
+      <details class="custom-rate">
+        <summary class="custom-rate-summary">Add a custom fallback rate</summary>
+        <div class="custom-rate-form">
+          <label class="custom-rate-field custom-rate-field--model">
+            <span>Model ID</span>
+            <FormInput
+              v-model="newModelName"
+              placeholder="model-name"
+              class="pricing-model-input"
+            />
+          </label>
+          <label v-for="column in RATE_COLUMNS" :key="column.field" class="custom-rate-field">
+            <span>{{ column.label }}</span>
+            <FormInput
+              :model-value="newRates[column.field]"
+              @update:model-value="newRates[column.field] = Number($event)"
+              type="number"
+              :step="column.step"
+              min="0"
+              class="pricing-input"
+            />
+          </label>
+          <ActionButton size="sm" :disabled="!newModelName.trim()" @click="addModelPrice">
+            Add rate
+          </ActionButton>
+        </div>
+      </details>
     </SectionPanel>
   </div>
 </template>
 
 <style scoped>
-.pricing-subsection-title {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin: 12px 0 4px;
+.pricing-description {
+  margin-bottom: 10px;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.5;
 }
 
-.pricing-description {
-  font-size: 0.6875rem;
+.pricing-description--panel {
+  margin: 0 0 12px;
+}
+
+.fallback-chain {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--canvas-subtle);
+}
+
+.fallback-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.fallback-step > span:last-child {
+  display: flex;
+  flex-direction: column;
+}
+
+.fallback-step strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.fallback-step small {
   color: var(--text-tertiary);
+  font-size: 0.625rem;
+}
+
+.fallback-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--accent-muted);
+  color: var(--accent-fg);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.fallback-chain-arrow {
+  color: var(--text-placeholder);
+}
+
+.pricing-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin-bottom: 10px;
-  line-height: 1.5;
+}
+
+.pricing-search {
+  flex: 1;
+  max-width: 360px;
+}
+
+.pricing-result-count {
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.pricing-groups {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.pricing-group + .pricing-group {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pricing-group-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--canvas-subtle);
+  color: var(--text-secondary);
+  cursor: pointer;
+  list-style: none;
+  transition: background var(--transition-fast);
+}
+
+.pricing-group-summary::-webkit-details-marker {
+  display: none;
+}
+
+.pricing-group-summary:hover {
+  background: var(--canvas-raised);
+}
+
+.pricing-group-summary:focus-visible {
+  outline: 2px solid var(--accent-emphasis);
+  outline-offset: -2px;
+}
+
+.pricing-group-chevron {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform var(--transition-fast);
+}
+
+.pricing-group[open] .pricing-group-chevron {
+  transform: rotate(45deg);
+}
+
+.pricing-group-name {
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.pricing-group-count {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .pricing-table-wrapper {
   overflow-x: auto;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.pricing-table {
+  min-width: 780px;
 }
 
 .pricing-table th {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  color: var(--text-tertiary);
   padding: 8px 6px;
+  color: var(--text-tertiary);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .pricing-table td {
-  padding: 4px 6px;
+  padding: 6px;
   vertical-align: middle;
 }
 
-.pricing-remove-btn {
-  background: none;
-  border: none;
-  color: var(--danger-fg);
-  font-size: 1.125rem;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  line-height: 1;
-  opacity: 0.6;
-  transition: opacity 100ms ease;
+.pricing-model-cell {
+  min-width: 170px;
 }
 
-.pricing-remove-btn:hover {
-  opacity: 1;
-  background: var(--danger-subtle);
-}
-
-.pricing-add-btn {
-  background: none;
-  border: 1px solid var(--border-default);
-  color: var(--accent-fg);
-  font-size: 1rem;
-  cursor: pointer;
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  line-height: 1;
-  transition: all 100ms ease;
-}
-
-.pricing-add-btn:hover:not(:disabled) {
-  background: var(--accent-subtle);
-}
-
-.pricing-add-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
-
-.pricing-add-row td {
-  padding-top: 8px;
-  border-top: 1px solid var(--border-subtle);
-}
-
-.pricing-actions {
-  padding: 10px 16px;
-  border-top: 1px solid var(--border-subtle);
-  display: flex;
-  justify-content: flex-end;
-}
-
-.pricing-col-action {
-  width: 40px;
+.pricing-context {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-tertiary);
+  font-size: 0.625rem;
 }
 
 .pricing-input {
-  width: 80px;
-  text-align: center;
+  width: 76px;
   font-size: 0.75rem;
+  text-align: center;
 }
 
 .pricing-model-input {
-  width: 140px;
-  font-family: 'JetBrains Mono', monospace;
+  width: 180px;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
 }
 
 .pricing-meta-cell {
-  max-width: 190px;
+  width: 170px;
+  max-width: 170px;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--text-tertiary);
   font-size: 0.6875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pricing-source-label,
@@ -383,5 +485,79 @@ function contextLabel(price: { pricingTier?: string; minimumInputTokens?: number
 .pricing-source-label {
   color: var(--text-secondary);
   font-weight: 600;
+}
+
+.pricing-col-action {
+  width: 40px;
+}
+
+.pricing-remove-btn {
+  padding: 2px 6px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--danger-fg);
+  cursor: pointer;
+  font-size: 1.125rem;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 100ms ease;
+}
+
+.pricing-remove-btn:hover {
+  background: var(--danger-subtle);
+  opacity: 1;
+}
+
+.pricing-empty {
+  padding: 24px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.custom-rate {
+  margin-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.custom-rate-summary {
+  width: fit-content;
+  padding: 10px 0 4px;
+  color: var(--accent-fg);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.custom-rate-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding-top: 10px;
+  overflow-x: auto;
+}
+
+.custom-rate-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 0.625rem;
+  font-weight: 600;
+}
+
+@media (max-width: 760px) {
+  .fallback-chain {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .fallback-chain-arrow {
+    display: none;
+  }
 }
 </style>

--- a/apps/desktop/src/components/settings/__tests__/SettingsPricing.test.ts
+++ b/apps/desktop/src/components/settings/__tests__/SettingsPricing.test.ts
@@ -1,0 +1,43 @@
+import { setupPinia } from "@tracepilot/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tracepilot/client", async () => {
+  const { createClientMock } = await import("../../../__tests__/mocks/client");
+  return createClientMock();
+});
+
+import SettingsPricing from "../SettingsPricing.vue";
+
+describe("SettingsPricing", () => {
+  beforeEach(() => {
+    setupPinia();
+  });
+
+  it("explains the fallback order and removes legacy cost editing", async () => {
+    const wrapper = mount(SettingsPricing);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Observed AIC");
+    expect(wrapper.text()).toContain("GitHub rate");
+    expect(wrapper.text()).toContain("Local fallback");
+    expect(wrapper.text()).not.toContain("Legacy cost per premium request");
+    expect(wrapper.findAll(".pricing-group")).toHaveLength(4);
+  });
+
+  it("groups search results and opens matching families", async () => {
+    const wrapper = mount(SettingsPricing);
+    await flushPromises();
+
+    await wrapper
+      .find('input[aria-label="Search models or sources"]')
+      .setValue("claude-sonnet-4.6");
+
+    const groups = wrapper.findAll(".pricing-group");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].text()).toContain("Anthropic Claude");
+    expect(groups[0].attributes()).toHaveProperty("open");
+    expect(wrapper.text()).toContain("claude-sonnet-4.6");
+    expect(wrapper.text()).not.toContain("gpt-5.4");
+  });
+});

--- a/apps/desktop/src/components/toolAnalysis/ToolFrequencyList.vue
+++ b/apps/desktop/src/components/toolAnalysis/ToolFrequencyList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ToolUsageEntry } from "@tracepilot/types";
 import { formatNumberFull } from "@tracepilot/types";
-import { useChartTooltip } from "@tracepilot/ui";
+import { ChartTooltip, useChartTooltip } from "@tracepilot/ui";
 
 defineProps<{
   tools: readonly ToolUsageEntry[];
@@ -35,12 +35,7 @@ const { tooltip, dismissTooltip, onBarMouseEnter } = useChartTooltip();
           <span class="tool-frequency__count">{{ formatNumberFull(tool.callCount) }}</span>
         </div>
       </div>
-      <div
-        v-if="tooltip.visible && tooltip.chartId === 'frequency'"
-        class="chart-tooltip"
-        :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-        :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-      >{{ tooltip.content }}</div>
+      <ChartTooltip :tooltip="tooltip" chart-id="frequency" />
     </div>
   </div>
 </template>

--- a/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
+++ b/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
@@ -14,8 +14,8 @@ const { tooltip, positionTooltip, dismissTooltip, findNearestIndex } = useChartT
 
 const CHART_RIGHT = 496;
 const MIN_LABEL_WIDTH = 100;
-const MAX_LABEL_WIDTH = 200;
-const MAX_LABEL_CHARACTERS = 26;
+const MAX_LABEL_WIDTH = 120;
+const MAX_LABEL_CHARACTERS = 16;
 const BAR_HEIGHT = 22;
 const ROW_SPACING = 28;
 

--- a/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
+++ b/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ToolUsageEntry } from "@tracepilot/types";
 import { formatNumberFull, formatRate } from "@tracepilot/types";
-import { useChartTooltip } from "@tracepilot/ui";
+import { ChartTooltip, useChartTooltip } from "@tracepilot/ui";
 import { computed } from "vue";
 import { CHART_COLORS } from "@/utils/chartColors";
 
@@ -146,12 +146,7 @@ function onClick(event: MouseEvent) {
           class="chart-overlay"
         />
       </svg>
-      <div
-        v-if="tooltip.visible && tooltip.chartId === 'success-failure'"
-        class="chart-tooltip"
-        :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-        :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-      >{{ tooltip.content }}</div>
+      <ChartTooltip :tooltip="tooltip" chart-id="success-failure" />
     </div>
   </div>
 </template>

--- a/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
+++ b/apps/desktop/src/components/toolAnalysis/ToolSuccessFailureChart.vue
@@ -12,24 +12,41 @@ const props = defineProps<{
 
 const { tooltip, positionTooltip, dismissTooltip, findNearestIndex } = useChartTooltip();
 
-const CHART_LEFT = 100;
-const CHART_WIDTH = 396;
+const CHART_RIGHT = 496;
+const MIN_LABEL_WIDTH = 100;
+const MAX_LABEL_WIDTH = 200;
+const MAX_LABEL_CHARACTERS = 26;
 const BAR_HEIGHT = 22;
 const ROW_SPACING = 28;
+
+function displayToolName(name: string): string {
+  return name.length > MAX_LABEL_CHARACTERS ? `${name.slice(0, MAX_LABEL_CHARACTERS - 1)}…` : name;
+}
 
 const chart = computed(() => {
   if (!props.tools.length) return null;
   const maxCalls = props.maxInvocations || 1;
+  const longestLabel = Math.max(...props.tools.map((tool) => displayToolName(tool.name).length));
+  const chartLeft = Math.min(Math.max(longestLabel * 7 + 20, MIN_LABEL_WIDTH), MAX_LABEL_WIDTH);
+  const chartWidth = CHART_RIGHT - chartLeft;
   const rows = props.tools.map((tool, i) => {
     const successCount = Math.round(tool.callCount * tool.successRate);
     const failureCount = tool.callCount - successCount;
-    const successWidth = (successCount / maxCalls) * CHART_WIDTH;
-    const failureWidth = (failureCount / maxCalls) * CHART_WIDTH;
+    const successWidth = (successCount / maxCalls) * chartWidth;
+    const failureWidth = (failureCount / maxCalls) * chartWidth;
     const y = 18 + i * ROW_SPACING;
-    return { tool, successCount, failureCount, successWidth, failureWidth, y };
+    return {
+      tool,
+      label: displayToolName(tool.name),
+      successCount,
+      failureCount,
+      successWidth,
+      failureWidth,
+      y,
+    };
   });
   const svgHeight = 18 + rows.length * ROW_SPACING + 10;
-  return { rows, svgHeight };
+  return { rows, svgHeight, chartLeft };
 });
 
 function onMouseMove(event: MouseEvent) {
@@ -101,15 +118,18 @@ function onClick(event: MouseEvent) {
       >
         <template v-for="(row, ri) in chart.rows" :key="`sf-${ri}`">
           <text
-            :x="CHART_LEFT - 12"
+            :x="chart.chartLeft - 12"
             :y="row.y + BAR_HEIGHT / 2 + 4"
             font-family="Inter, sans-serif"
             font-size="12"
             fill="var(--text-placeholder)"
             text-anchor="end"
-          >{{ row.tool.name }}</text>
+          >
+            <title>{{ row.tool.name }}</title>
+            {{ row.label }}
+          </text>
           <rect
-            :x="CHART_LEFT"
+            :x="chart.chartLeft"
             :y="row.y"
             :width="Math.max(row.successWidth, 0)"
             :height="BAR_HEIGHT"
@@ -120,7 +140,7 @@ function onClick(event: MouseEvent) {
           />
           <rect
             v-if="row.failureWidth > 0"
-            :x="CHART_LEFT + row.successWidth"
+            :x="chart.chartLeft + row.successWidth"
             :y="row.y"
             :width="row.failureWidth"
             :height="BAR_HEIGHT"
@@ -130,7 +150,7 @@ function onClick(event: MouseEvent) {
             :class="{ 'chart-bar--active': tooltip.chartId === 'success-failure' && tooltip.highlightIndex === ri }"
           />
           <text
-            :x="CHART_LEFT + row.successWidth + row.failureWidth + 8"
+            :x="chart.chartLeft + row.successWidth + row.failureWidth + 8"
             :y="row.y + BAR_HEIGHT / 2 + 4"
             font-family="Inter, sans-serif"
             font-size="10"
@@ -171,6 +191,7 @@ function onClick(event: MouseEvent) {
 
 .scrollable-section {
   max-height: 400px;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 </style>

--- a/apps/desktop/src/components/toolAnalysis/ToolUsageHeatmap.vue
+++ b/apps/desktop/src/components/toolAnalysis/ToolUsageHeatmap.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useChartTooltip } from "@tracepilot/ui";
+import { ChartTooltip, useChartTooltip } from "@tracepilot/ui";
 import { computed } from "vue";
 import { type HeatmapEntry, localizeHeatmap } from "@/utils/analytics";
 
@@ -80,12 +80,7 @@ function getHeatmapLegendColor(level: number): string {
           <span>More</span>
         </div>
       </div>
-      <div
-        v-if="tooltip.visible && tooltip.chartId === 'heatmap'"
-        class="chart-tooltip"
-        :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-        :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-      >{{ tooltip.content }}</div>
+      <ChartTooltip :tooltip="tooltip" chart-id="heatmap" />
     </div>
   </div>
 </template>

--- a/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
+++ b/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
@@ -16,6 +16,7 @@ vi.mock("@tracepilot/ui", () => {
     LoadingOverlay: passthrough("LoadingOverlay"),
     ErrorState: passthrough("ErrorState"),
     StatCard: passthrough("StatCard"),
+    ChartTooltip: passthrough("ChartTooltip"),
     getChartColors: () => ({
       primary: "#000",
       secondary: "#000",

--- a/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
+++ b/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
@@ -131,6 +131,7 @@ describe("ToolSuccessFailureChart", () => {
 
     const label = wrapper.find("svg text");
     expect(Number(label.attributes("x"))).toBeGreaterThan(100);
+    expect(Number(label.attributes("x"))).toBeLessThanOrEqual(108);
     expect(label.text()).toContain("…");
     expect(label.find("title").text()).toBe(longName);
   });

--- a/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
+++ b/apps/desktop/src/components/toolAnalysis/__tests__/ToolAnalysisChildren.test.ts
@@ -119,6 +119,21 @@ describe("ToolSuccessFailureChart", () => {
     });
     expect(wrapper.find("svg").exists()).toBe(false);
   });
+
+  it("reserves label space and deliberately truncates very long tool names", () => {
+    const longName = "mcp_server_tool_with_a_name_that_would_overflow";
+    const wrapper = mount(ToolSuccessFailureChart, {
+      props: {
+        tools: [{ ...tools[0], name: longName }],
+        maxInvocations: 10,
+      },
+    });
+
+    const label = wrapper.find("svg text");
+    expect(Number(label.attributes("x"))).toBeGreaterThan(100);
+    expect(label.text()).toContain("…");
+    expect(label.find("title").text()).toBe(longName);
+  });
 });
 
 describe("ToolFrequencyList", () => {

--- a/apps/desktop/src/stores/preferences.ts
+++ b/apps/desktop/src/stores/preferences.ts
@@ -19,6 +19,7 @@ import type { TracePilotConfig } from "@tracepilot/types";
 import {
   createDefaultConfig,
   DEFAULT_CONTENT_MAX_WIDTH,
+  DEFAULT_COST_PER_PREMIUM_REQUEST,
   DEFAULT_FEATURES,
   DEFAULT_UI_SCALE,
 } from "@tracepilot/types";
@@ -85,7 +86,6 @@ export const usePreferencesStore = defineStore("preferences", () => {
     ui.uiScale.value = Math.max(0.8, Math.min(1.3, rawScale));
 
     ui.cliCommand.value = config.general.cliCommand;
-    pricing.costPerPremiumRequest.value = config.pricing.costPerPremiumRequest;
     pricing.modelWholesalePrices.value =
       config.pricing.models.length > 0 || (config.pricing.removedModels?.length ?? 0) > 0
         ? mergeWholesalePricesWithDefaults(config.pricing.models, config.pricing.removedModels)
@@ -131,7 +131,7 @@ export const usePreferencesStore = defineStore("preferences", () => {
         uiScale: ui.uiScale.value,
       },
       pricing: {
-        costPerPremiumRequest: pricing.costPerPremiumRequest.value,
+        costPerPremiumRequest: DEFAULT_COST_PER_PREMIUM_REQUEST,
         models: [...pricing.modelWholesalePrices.value],
         removedModels: [...pricing.removedModels.value],
       },
@@ -244,7 +244,6 @@ export const usePreferencesStore = defineStore("preferences", () => {
     [
       ui.theme,
       ui.sessionStateDir,
-      pricing.costPerPremiumRequest,
       pricing.modelWholesalePrices,
       ui.hideEmptySessions,
       ui.cliCommand,

--- a/apps/desktop/src/stores/preferences/pricing.ts
+++ b/apps/desktop/src/stores/preferences/pricing.ts
@@ -26,7 +26,7 @@ import {
   modelPriceEntryToPricingEntry,
   resolvePricingEntry,
 } from "@tracepilot/types";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 // Re-export for backwards compat — consumers that imported ModelWholesalePrice
 // now use the shared ModelPriceEntry type from @tracepilot/types.
@@ -73,7 +73,7 @@ export function mergeWholesalePricesWithDefaults(
 }
 
 export function createPricingSlice() {
-  const costPerPremiumRequest = ref(DEFAULT_COST_PER_PREMIUM_REQUEST);
+  const costPerPremiumRequest = computed(() => DEFAULT_COST_PER_PREMIUM_REQUEST);
   const modelWholesalePrices = ref<ModelPriceEntry[]>([...DEFAULT_WHOLESALE_PRICES]);
   const removedModels = ref<string[]>([]);
   const toolRendering = ref<ToolRenderingPreferences>({

--- a/apps/desktop/src/styles/chart-shared.css
+++ b/apps/desktop/src/styles/chart-shared.css
@@ -65,26 +65,3 @@
   pointer-events: none;
   opacity: 0.6;
 }
-
-/* ── Tooltip ─────────────────────────────────────────────── */
-.chart-tooltip {
-  position: absolute;
-  pointer-events: none;
-  background: var(--chart-tooltip-bg, rgba(24, 24, 27, 0.94));
-  color: var(--chart-tooltip-fg);
-  font-size: 0.6875rem;
-  font-weight: 500;
-  padding: 4px 10px;
-  border-radius: 6px;
-  white-space: nowrap;
-  z-index: 10;
-  transform: translateX(-50%);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
-  border: 1px solid color-mix(in srgb, var(--chart-tooltip-bg) 82%, white 18%);
-}
-
-.chart-tooltip--pinned {
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent-fg) var(--chart-active-emphasis, 28%), transparent),
-    0 3px 12px rgba(0, 0, 0, 0.22);
-}

--- a/apps/desktop/src/views/CodeImpactView.vue
+++ b/apps/desktop/src/views/CodeImpactView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  ChartTooltip,
   computeGridLines,
   createChartLayout,
   ErrorState,
@@ -139,12 +140,7 @@ const timelineChart = computed(() => {
                   </div>
                   <span class="token-bar-value">{{ ft.count }} files</span>
                 </div>
-                <div
-                  v-if="tooltip.visible && tooltip.chartId === 'file-types'"
-                  class="chart-tooltip"
-                  :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-                  :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-                >{{ tooltip.content }}</div>
+                <ChartTooltip :tooltip="tooltip" chart-id="file-types" />
               </div>
             </div>
 
@@ -167,12 +163,7 @@ const timelineChart = computed(() => {
                     <div class="churn-bar-add" style="width: 100%" />
                   </div>
                 </div>
-                <div
-                  v-if="tooltip.visible && tooltip.chartId === 'modified-files'"
-                  class="chart-tooltip"
-                  :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-                  :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-                >{{ tooltip.content }}</div>
+                <ChartTooltip :tooltip="tooltip" chart-id="modified-files" />
               </div>
             </div>
           </div>
@@ -282,13 +273,7 @@ const timelineChart = computed(() => {
                     class="chart-label"
                   >{{ xl.label }}</text>
                 </svg>
-                <!-- Tooltip -->
-                <div
-                  v-if="tooltip.visible && tooltip.chartId === 'timeline'"
-                  class="chart-tooltip"
-                  :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-                  :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-                >{{ tooltip.content }}</div>
+                <ChartTooltip :tooltip="tooltip" chart-id="timeline" />
               </div>
             </div>
           </div>

--- a/apps/desktop/src/views/CodeImpactView.vue
+++ b/apps/desktop/src/views/CodeImpactView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import {
+  ChartFrame,
   ChartTooltip,
   computeGridLines,
   createChartLayout,
   ErrorState,
   formatDateShort,
   formatNumberFull,
+  generateXLabels,
   generateYLabels,
   LoadingOverlay,
   mapToLineCoords,
@@ -55,14 +57,7 @@ function addPct(adds: number, dels: number): number {
 
 // ── Changes Over Time Area Chart ─────────────────────────────
 const chartLayout = createChartLayout(50, 680, 30, 200);
-const {
-  left: CHART_LEFT,
-  right: CHART_RIGHT,
-  top: CHART_TOP,
-  bottom: CHART_BOTTOM,
-  width: CHART_W,
-  height: CHART_H,
-} = chartLayout;
+const { left: CHART_LEFT, right: CHART_RIGHT, bottom: CHART_BOTTOM } = chartLayout;
 
 const GRID_ROWS = 4;
 const gridYPositions = computed(() => computeGridLines(chartLayout, GRID_ROWS + 1, GRID_ROWS));
@@ -83,11 +78,12 @@ const timelineChart = computed(() => {
 
   const yLabels = generateYLabels(maxVal, chartLayout, 5, (v) => formatNumberFull(Math.round(v)));
 
-  // Show all labels (no stride filtering) — this chart has fewer data points
-  const xLabels = addCoords.map((c) => ({
-    label: formatDateShort(c.date),
-    x: c.x,
-  }));
+  const xLabels = generateXLabels(
+    addCoords,
+    (c) => c.x,
+    (c) => formatDateShort(c.date),
+    8,
+  );
 
   return { addLine, delLine, addArea, delArea, yLabels, xLabels, addCoords, delCoords };
 });
@@ -176,37 +172,22 @@ const timelineChart = computed(() => {
                 <span><span class="chart-legend-dot" :style="{ background: CHART_COLORS.success }" />Additions</span>
                 <span><span class="chart-legend-dot" :style="{ background: CHART_COLORS.danger }" />Deletions</span>
               </div>
-              <div class="chart-container tooltip-area" @mouseleave="dismissTooltip">
-                <svg
+              <div class="chart-container">
+                <ChartFrame
                   v-if="timelineChart"
-                  viewBox="0 0 700 220"
-                  role="img"
-                  aria-label="Area chart showing lines added and removed over 14 days"
-                  font-family="Inter"
+                  class="code-timeline-chart"
+                  :chart-layout="chartLayout"
+                  :grid-lines="gridYPositions"
+                  :y-labels="timelineChart.yLabels"
+                  :x-labels="timelineChart.xLabels"
+                  view-box="0 0 700 220"
+                  ariaLabel="Area chart showing lines added and removed over the selected period"
+                  chart-id="timeline"
+                  :tooltip="tooltip"
                   @mousemove="onChartMouseMove($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline')"
                   @click="onChartClick($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline')"
+                  @dismiss-tooltip="dismissTooltip"
                 >
-                  <!-- Grid lines -->
-                  <line
-                    v-for="(gy, gi) in gridYPositions"
-                    :key="`g-${gi}`"
-                    :x1="CHART_LEFT"
-                    :y1="gy"
-                    :x2="CHART_RIGHT"
-                    :y2="gy"
-                    class="chart-grid-line"
-                    stroke-dasharray="4,3"
-                  />
-                  <!-- Y-axis labels -->
-                  <text
-                    v-for="(yl, yi) in timelineChart.yLabels"
-                    :key="`y-${yi}`"
-                    :x="CHART_LEFT - 6"
-                    :y="yl.y + 4"
-                    text-anchor="end"
-                    font-size="9"
-                    class="chart-label"
-                  >{{ yl.value }}</text>
                   <!-- Additions area -->
                   <polygon :points="timelineChart.addArea" :fill="CHART_COLORS.success" fill-opacity="0.15" />
                   <!-- Deletions area -->
@@ -229,9 +210,6 @@ const timelineChart = computed(() => {
                     stroke-linejoin="round"
                     stroke-linecap="round"
                   />
-                  <!-- Axes -->
-                  <line :x1="CHART_LEFT" :y1="CHART_TOP" :x2="CHART_LEFT" :y2="CHART_BOTTOM" class="chart-axis" stroke-width="1" />
-                  <line :x1="CHART_LEFT" :y1="CHART_BOTTOM" :x2="CHART_RIGHT" :y2="CHART_BOTTOM" class="chart-axis" stroke-width="1" />
                   <!-- Highlight rings -->
                   <circle
                     v-if="tooltip.chartId === 'timeline' && tooltip.highlightIndex >= 0 && tooltip.highlightIndex < timelineChart.addCoords.length"
@@ -253,27 +231,7 @@ const timelineChart = computed(() => {
                     stroke-width="2"
                     class="chart-highlight-ring"
                   />
-                  <!-- Invisible overlay for mouse capture -->
-                  <rect
-                    :x="CHART_LEFT"
-                    :y="CHART_TOP"
-                    :width="CHART_W"
-                    :height="CHART_H"
-                    fill="transparent"
-                    class="chart-overlay"
-                  />
-                  <!-- X-axis labels -->
-                  <text
-                    v-for="(xl, xi) in timelineChart.xLabels"
-                    :key="`x-${xi}`"
-                    :x="xl.x"
-                    y="215"
-                    text-anchor="middle"
-                    font-size="8"
-                    class="chart-label"
-                  >{{ xl.label }}</text>
-                </svg>
-                <ChartTooltip :tooltip="tooltip" chart-id="timeline" />
+                </ChartFrame>
               </div>
             </div>
           </div>
@@ -356,5 +314,9 @@ const timelineChart = computed(() => {
   border-radius: 50%;
   margin-right: 4px;
   vertical-align: middle;
+}
+
+.code-timeline-chart {
+  width: 100%;
 }
 </style>

--- a/apps/desktop/src/views/CodeImpactView.vue
+++ b/apps/desktop/src/views/CodeImpactView.vue
@@ -184,8 +184,8 @@ const timelineChart = computed(() => {
                   ariaLabel="Area chart showing lines added and removed over the selected period"
                   chart-id="timeline"
                   :tooltip="tooltip"
-                  @mousemove="onChartMouseMove($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline')"
-                  @click="onChartClick($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline')"
+                  @mousemove="onChartMouseMove($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline', '.chart-frame')"
+                  @click="onChartClick($event, timelineChart.addCoords, (i) => `${formatDateShort(timelineChart!.addCoords[i].date)} — +${formatNumberFull(timelineChart!.addCoords[i].additions)} / -${formatNumberFull(timelineChart!.addCoords[i].deletions)}`, 'timeline', '.chart-frame')"
                   @dismiss-tooltip="dismissTooltip"
                 >
                   <!-- Additions area -->

--- a/packages/ui/src/__tests__/ChartFrame.test.ts
+++ b/packages/ui/src/__tests__/ChartFrame.test.ts
@@ -41,6 +41,9 @@ function mountFrame(overrides: Record<string, unknown> = {}) {
       tooltip: makeTooltip(),
       ...overrides,
     },
+    global: {
+      stubs: { Teleport: true },
+    },
   });
 }
 

--- a/packages/ui/src/__tests__/ChartTooltip.test.ts
+++ b/packages/ui/src/__tests__/ChartTooltip.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it } from "vitest";
 import { nextTick, reactive } from "vue";
 import ChartTooltip from "../components/ChartTooltip.vue";
 import type { ChartTooltipState } from "../composables/useChartTooltip";
+
+const tooltipSource = readFileSync(resolve(__dirname, "../components/ChartTooltip.vue"), "utf8");
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -30,6 +34,11 @@ describe("ChartTooltip", () => {
     const tooltip = document.body.querySelector('[role="tooltip"]');
     expect(tooltip?.textContent).toBe("Chart details");
     expect(tooltip?.classList.contains("chart-tooltip")).toBe(true);
+  });
+
+  it("keeps a stable intrinsic width as it moves across the viewport", () => {
+    expect(tooltipSource).toContain("width: max-content");
+    expect(tooltipSource).toContain("box-sizing: border-box");
   });
 
   it("does not render for another chart", () => {

--- a/packages/ui/src/__tests__/ChartTooltip.test.ts
+++ b/packages/ui/src/__tests__/ChartTooltip.test.ts
@@ -1,0 +1,54 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it } from "vitest";
+import { nextTick, reactive } from "vue";
+import ChartTooltip from "../components/ChartTooltip.vue";
+import type { ChartTooltipState } from "../composables/useChartTooltip";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function tooltipState(overrides: Partial<ChartTooltipState> = {}) {
+  return reactive<ChartTooltipState>({
+    visible: true,
+    pinned: false,
+    x: 300,
+    y: 200,
+    content: "Chart details",
+    chartId: "cost",
+    highlightIndex: 0,
+    ...overrides,
+  });
+}
+
+describe("ChartTooltip", () => {
+  it("teleports the active tooltip to the document body", () => {
+    mount(ChartTooltip, {
+      props: { tooltip: tooltipState(), chartId: "cost" },
+    });
+
+    const tooltip = document.body.querySelector('[role="tooltip"]');
+    expect(tooltip?.textContent).toBe("Chart details");
+    expect(tooltip?.classList.contains("chart-tooltip")).toBe(true);
+  });
+
+  it("does not render for another chart", () => {
+    mount(ChartTooltip, {
+      props: { tooltip: tooltipState(), chartId: "tokens" },
+    });
+
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it("flips below the pointer near the top of the viewport", async () => {
+    const state = tooltipState({ y: 2 });
+    mount(ChartTooltip, {
+      props: { tooltip: state, chartId: "cost" },
+    });
+    await nextTick();
+
+    expect(document.body.querySelector('[role="tooltip"]')?.classList).toContain(
+      "chart-tooltip--below",
+    );
+  });
+});

--- a/packages/ui/src/__tests__/useChartTooltip.test.ts
+++ b/packages/ui/src/__tests__/useChartTooltip.test.ts
@@ -83,65 +83,27 @@ describe("useChartTooltip", () => {
   });
 
   describe("positionTooltip", () => {
-    it("clamps tooltip x to minimum 40", () => {
+    it("stores viewport-relative pointer coordinates", () => {
       const w = createWrapper();
-
       const container = document.createElement("div");
-      Object.defineProperty(container, "getBoundingClientRect", {
-        value: () => ({ left: 100, top: 200, width: 500, height: 300 }),
-      });
-      vi.spyOn(window, "getComputedStyle").mockReturnValue({
-        paddingLeft: "10",
-        paddingTop: "10",
-      } as unknown as CSSStyleDeclaration);
-
       const event = { clientX: 110, clientY: 250 } as MouseEvent;
       w.vm.positionTooltip(event, container);
 
-      // rawX = 110 - 100 - 10 = 0 → clamped to 40
-      expect(w.vm.tooltip.x).toBe(40);
-      // rawY = 250 - 200 - 10 = 40 → max(20, 40) = 40
-      expect(w.vm.tooltip.y).toBe(40);
+      expect(w.vm.tooltip.x).toBe(110);
+      expect(w.vm.tooltip.y).toBe(250);
     });
 
-    it("clamps tooltip x to maximum (width - 2*padLeft - 40)", () => {
+    it("clamps coordinates to the viewport", () => {
       const w = createWrapper();
-
       const container = document.createElement("div");
-      Object.defineProperty(container, "getBoundingClientRect", {
-        value: () => ({ left: 0, top: 0, width: 200, height: 300 }),
-      });
-      vi.spyOn(window, "getComputedStyle").mockReturnValue({
-        paddingLeft: "10",
-        paddingTop: "10",
-      } as unknown as CSSStyleDeclaration);
-
-      const event = { clientX: 190, clientY: 50 } as MouseEvent;
+      const event = {
+        clientX: window.innerWidth + 100,
+        clientY: -20,
+      } as MouseEvent;
       w.vm.positionTooltip(event, container);
 
-      // rawX = 190 - 0 - 10 = 180
-      // max bound = 200 - 20 - 40 = 140
-      // clamped to min(180, 140) = 140, max(40, 140) = 140
-      expect(w.vm.tooltip.x).toBe(140);
-    });
-
-    it("clamps tooltip y to minimum 20", () => {
-      const w = createWrapper();
-
-      const container = document.createElement("div");
-      Object.defineProperty(container, "getBoundingClientRect", {
-        value: () => ({ left: 0, top: 100, width: 500, height: 300 }),
-      });
-      vi.spyOn(window, "getComputedStyle").mockReturnValue({
-        paddingLeft: "0",
-        paddingTop: "0",
-      } as unknown as CSSStyleDeclaration);
-
-      const event = { clientX: 100, clientY: 105 } as MouseEvent;
-      w.vm.positionTooltip(event, container);
-
-      // rawY = 105 - 100 - 0 = 5 → max(20, 5) = 20
-      expect(w.vm.tooltip.y).toBe(20);
+      expect(w.vm.tooltip.x).toBe(window.innerWidth);
+      expect(w.vm.tooltip.y).toBe(0);
     });
   });
 

--- a/packages/ui/src/__tests__/useChartTooltip.test.ts
+++ b/packages/ui/src/__tests__/useChartTooltip.test.ts
@@ -211,9 +211,9 @@ describe("useChartTooltip", () => {
   });
 
   describe("onChartMouseMove", () => {
-    function createSvgMocks(svgX: number) {
+    function createSvgMocks(svgX: number, containerSelector = ".tooltip-area") {
       const container = document.createElement("div");
-      container.classList.add("tooltip-area");
+      container.classList.add(containerSelector.slice(1));
       Object.defineProperty(container, "getBoundingClientRect", {
         value: () => ({ left: 0, top: 0, width: 500, height: 300 }),
       });
@@ -239,7 +239,7 @@ describe("useChartTooltip", () => {
       svgEl.appendChild(target);
       vi.spyOn(target, "closest").mockImplementation((sel: string) => {
         if (sel === "svg") return svgEl;
-        if (sel === ".tooltip-area") return container;
+        if (sel === containerSelector) return container;
         return null;
       });
 
@@ -260,6 +260,62 @@ describe("useChartTooltip", () => {
       expect(w.vm.tooltip.content).toBe("Point 2");
       expect(w.vm.tooltip.chartId).toBe("test-chart");
       expect(w.vm.tooltip.highlightIndex).toBe(2);
+    });
+
+    it("supports a custom chart container selector", () => {
+      const w = createWrapper();
+      const { target } = createSvgMocks(20, ".chart-frame");
+      const event = { target, clientX: 100, clientY: 50 } as unknown as MouseEvent;
+
+      w.vm.onChartMouseMove(
+        event,
+        [{ x: 10 }, { x: 20 }, { x: 30 }],
+        (i) => `Point ${i}`,
+        "test-chart",
+        ".chart-frame",
+      );
+
+      expect(w.vm.tooltip.visible).toBe(true);
+      expect(w.vm.tooltip.highlightIndex).toBe(1);
+    });
+
+    it("dismisses the tooltip outside the horizontal data range", () => {
+      const w = createWrapper();
+      w.vm.tooltip.visible = true;
+      w.vm.tooltip.chartId = "test-chart";
+      const { target } = createSvgMocks(5);
+      const event = { target, clientX: 100, clientY: 50 } as unknown as MouseEvent;
+
+      w.vm.onChartMouseMove(
+        event,
+        [{ x: 10 }, { x: 20 }, { x: 30 }],
+        (i) => `Point ${i}`,
+        "test-chart",
+      );
+
+      expect(w.vm.tooltip.visible).toBe(false);
+      expect(w.vm.tooltip.highlightIndex).toBe(-1);
+    });
+
+    it("uses a narrow hit target for a single-point series", () => {
+      const w = createWrapper();
+      const outside = createSvgMocks(30);
+      const outsideEvent = {
+        target: outside.target,
+        clientX: 100,
+        clientY: 50,
+      } as unknown as MouseEvent;
+      w.vm.onChartMouseMove(outsideEvent, [{ x: 10 }], () => "Point", "single");
+      expect(w.vm.tooltip.visible).toBe(false);
+
+      const inside = createSvgMocks(18);
+      const insideEvent = {
+        target: inside.target,
+        clientX: 100,
+        clientY: 50,
+      } as unknown as MouseEvent;
+      w.vm.onChartMouseMove(insideEvent, [{ x: 10 }], () => "Point", "single");
+      expect(w.vm.tooltip.visible).toBe(true);
     });
 
     it("does nothing when pinned", () => {

--- a/packages/ui/src/components/ChartFrame.vue
+++ b/packages/ui/src/components/ChartFrame.vue
@@ -26,6 +26,7 @@
 
 import type { ChartTooltipState } from "../composables/useChartTooltip";
 import type { ChartLayout, XAxisLabel, YAxisLabel } from "../utils/chartGeometry";
+import ChartTooltip from "./ChartTooltip.vue";
 
 withDefaults(
   defineProps<{
@@ -134,13 +135,7 @@ const emit = defineEmits<{
       >{{ xl.label }}</text>
     </svg>
 
-    <!-- Tooltip (only shown when this chart is the active tooltip target) -->
-    <div
-      v-if="tooltip.visible && tooltip.chartId === chartId"
-      class="chart-tooltip"
-      :class="{ 'chart-tooltip--pinned': tooltip.pinned }"
-      :style="{ left: tooltip.x + 'px', top: (tooltip.y - 36) + 'px' }"
-    >{{ tooltip.content }}</div>
+    <ChartTooltip :tooltip="tooltip" :chart-id="chartId" />
 
     <slot name="footer" />
   </div>

--- a/packages/ui/src/components/ChartTooltip.vue
+++ b/packages/ui/src/components/ChartTooltip.vue
@@ -68,7 +68,9 @@ onBeforeUnmount(() => window.removeEventListener("resize", updatePosition));
 .chart-tooltip {
   position: fixed;
   pointer-events: none;
-  max-width: calc(100vw - 16px);
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(28rem, calc(100vw - 16px));
   padding: 4px 10px;
   border: 1px solid color-mix(in srgb, var(--chart-tooltip-bg) 82%, white 18%);
   border-radius: 6px;

--- a/packages/ui/src/components/ChartTooltip.vue
+++ b/packages/ui/src/components/ChartTooltip.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import type { ChartTooltipState } from "../composables/useChartTooltip";
+
+const props = defineProps<{
+  tooltip: ChartTooltipState;
+  chartId: string;
+}>();
+
+const GAP = 8;
+const VIEWPORT_MARGIN = 8;
+
+const tooltipElement = ref<HTMLElement | null>(null);
+const left = ref(0);
+const top = ref(0);
+const placement = ref<"above" | "below">("above");
+
+const isVisible = computed(() => props.tooltip.visible && props.tooltip.chartId === props.chartId);
+
+function updatePosition() {
+  const element = tooltipElement.value;
+  if (!element || typeof window === "undefined") return;
+
+  const width = element.offsetWidth;
+  const height = element.offsetHeight;
+  const minX = VIEWPORT_MARGIN + width / 2;
+  const maxX = window.innerWidth - VIEWPORT_MARGIN - width / 2;
+
+  left.value =
+    minX <= maxX ? Math.min(Math.max(props.tooltip.x, minX), maxX) : window.innerWidth / 2;
+
+  const fitsAbove = props.tooltip.y - GAP - height >= VIEWPORT_MARGIN;
+  placement.value = fitsAbove ? "above" : "below";
+  top.value = fitsAbove ? props.tooltip.y - GAP : props.tooltip.y + GAP;
+}
+
+watch(
+  () => [isVisible.value, props.tooltip.content, props.tooltip.x, props.tooltip.y],
+  async () => {
+    if (!isVisible.value) return;
+    await nextTick();
+    updatePosition();
+  },
+  { immediate: true },
+);
+
+onMounted(() => window.addEventListener("resize", updatePosition));
+onBeforeUnmount(() => window.removeEventListener("resize", updatePosition));
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isVisible"
+      ref="tooltipElement"
+      role="tooltip"
+      class="chart-tooltip"
+      :class="[
+        `chart-tooltip--${placement}`,
+        { 'chart-tooltip--pinned': tooltip.pinned },
+      ]"
+      :style="{ left: `${left}px`, top: `${top}px` }"
+    >{{ tooltip.content }}</div>
+  </Teleport>
+</template>
+
+<style scoped>
+.chart-tooltip {
+  position: fixed;
+  pointer-events: none;
+  max-width: calc(100vw - 16px);
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--chart-tooltip-bg) 82%, white 18%);
+  border-radius: 6px;
+  background: var(--chart-tooltip-bg, rgba(24, 24, 27, 0.94));
+  color: var(--chart-tooltip-fg);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: normal;
+  z-index: var(--z-tooltip);
+}
+
+.chart-tooltip--above {
+  transform: translate(-50%, -100%);
+}
+
+.chart-tooltip--below {
+  transform: translateX(-50%);
+}
+
+.chart-tooltip--pinned {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent-fg) var(--chart-active-emphasis, 28%), transparent),
+    0 3px 12px rgba(0, 0, 0, 0.22);
+}
+</style>

--- a/packages/ui/src/composables/useChartTooltip.ts
+++ b/packages/ui/src/composables/useChartTooltip.ts
@@ -14,8 +14,8 @@ export interface UseChartTooltipReturn {
   /** Reactive tooltip state — bind to template for rendering. */
   tooltip: ChartTooltipState;
   /**
-   * Compute container-relative position from a mouse event and clamp
-   * so the tooltip stays within the container bounds.
+   * Capture a viewport-relative pointer position. The shared ChartTooltip
+   * measures and clamps its rendered content to the viewport.
    */
   positionTooltip: (event: MouseEvent, container: HTMLElement) => void;
   /** Reset tooltip to hidden/unpinned state. */
@@ -79,15 +79,11 @@ export function useChartTooltip(): UseChartTooltipReturn {
     highlightIndex: -1,
   });
 
-  function positionTooltip(event: MouseEvent, container: HTMLElement): void {
-    const rect = container.getBoundingClientRect();
-    const style = getComputedStyle(container);
-    const padLeft = parseFloat(style.paddingLeft) || 0;
-    const padTop = parseFloat(style.paddingTop) || 0;
-    const rawX = event.clientX - rect.left - padLeft;
-    const rawY = event.clientY - rect.top - padTop;
-    tooltip.x = Math.max(40, Math.min(rawX, rect.width - padLeft * 2 - 40));
-    tooltip.y = Math.max(20, rawY);
+  function positionTooltip(event: MouseEvent, _container: HTMLElement): void {
+    const viewportWidth = typeof window === "undefined" ? event.clientX : window.innerWidth;
+    const viewportHeight = typeof window === "undefined" ? event.clientY : window.innerHeight;
+    tooltip.x = Math.min(Math.max(event.clientX, 0), viewportWidth);
+    tooltip.y = Math.min(Math.max(event.clientY, 0), viewportHeight);
   }
 
   function dismissTooltip(): void {

--- a/packages/ui/src/composables/useChartTooltip.ts
+++ b/packages/ui/src/composables/useChartTooltip.ts
@@ -69,6 +69,8 @@ export interface UseChartTooltipReturn {
  * ```
  */
 export function useChartTooltip(): UseChartTooltipReturn {
+  const SINGLE_POINT_HIT_RADIUS = 12;
+
   const tooltip = reactive<ChartTooltipState>({
     visible: false,
     pinned: false,
@@ -127,10 +129,19 @@ export function useChartTooltip(): UseChartTooltipReturn {
     pt.y = event.clientY;
     const svgPt = pt.matrixTransform(ctm.inverse());
 
-    const bestIdx = findNearestIndex(
-      coords.map((c) => c.x),
-      svgPt.x,
-    );
+    const xValues = coords.map((c) => c.x);
+    const minX = Math.min(...xValues);
+    const maxX = Math.max(...xValues);
+    const isOutsideSeries =
+      coords.length === 1
+        ? Math.abs(svgPt.x - minX) > SINGLE_POINT_HIT_RADIUS
+        : svgPt.x < minX || svgPt.x > maxX;
+    if (isOutsideSeries) {
+      dismissTooltip();
+      return;
+    }
+
+    const bestIdx = findNearestIndex(xValues, svgPt.x);
     if (bestIdx < 0) return;
 
     tooltip.visible = true;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -33,6 +33,7 @@ export { default as BtnGroup } from "./components/BtnGroup.vue";
 export type { ChartCardProps, ChartCardState } from "./components/ChartCard.vue";
 export { default as ChartCard } from "./components/ChartCard.vue";
 export { default as ChartFrame } from "./components/ChartFrame.vue";
+export { default as ChartTooltip } from "./components/ChartTooltip.vue";
 export { default as ConfirmDialog } from "./components/ConfirmDialog.vue";
 export { default as DataTable } from "./components/DataTable.vue";
 export { default as DefList } from "./components/DefList.vue";


### PR DESCRIPTION
## Summary

- keep the full analytics model distribution readable with a bounded, scrollable legend
- rename AI Credit Trend to Cost Trend, make USD primary, and retain AIC in tooltips
- move chart tooltips into a shared viewport-aware component with stable sizing and bounded hit areas
- redesign AIC fallback pricing around the actual observed → GitHub → local fallback chain, with searchable model-family groups
- treat legacy premium-request cost as the fixed `$0.04` compatibility value and remove its setting
- tighten tool success/failure labels and prevent tooltips from expanding chart containers
- reuse the analytics chart approach for Code Changes Over Time date density and restore its hover behavior
- keep overflowing Session Activity tiles left-reachable while preserving centered short rows
- remove the redundant Context Pressure gesture hint

## Why

Several chart and settings views degraded when their data became dense: legends widened cards, axis labels became unreadable, tooltips were clipped or changed container dimensions, and centered overflow made the first Session Activity tile unreachable. The fallback-pricing editor also exposed implementation details without explaining the precedence of the values being edited.

The root causes were addressed in shared chart behavior where possible. Tooltips are now teleported and positioned against the viewport, use a position-independent intrinsic width, and only activate inside the plotted horizontal range. Dense date labels use the existing shared label generator. Session Activity uses safe centering so overflowing rows align to the scroll origin.

## User impact

Analytics, Tools, Code, Metrics, and Context charts remain usable with dense or edge-positioned data. Pricing settings are smaller, searchable, grouped by model family, and describe when each fallback applies.

## Validation

- shared UI test suite: 989 tests passed
- desktop test suite: 1,935 tests passed
- focused tooltip regression suite: 31 tests passed
- focused Context Window chart suite: 11 tests passed
- focused Session Activity suite: 1 test passed
- shared UI and desktop typechecks passed
- production desktop build passed
- changed files pass Biome and `git diff --check`

The repository-wide lint command still reports the existing unrelated baseline violations.
