### PR TITLE
Fix update release notes and download progress

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -52,6 +52,7 @@ const {
   whatsNewCurrentVersion,
   whatsNewEntries,
   whatsNewReleaseUrl,
+  whatsNewReleaseNotes,
   closeWhatsNew,
 } = useWhatsNew();
 
@@ -162,6 +163,7 @@ const { breadcrumbs } = useBreadcrumbs(isTabViewActive);
     :current-version="whatsNewCurrentVersion"
     :entries="whatsNewEntries"
     :release-url="whatsNewReleaseUrl"
+    :release-notes="whatsNewReleaseNotes"
     @close="closeWhatsNew"
     @open-external="openExternal"
   />

--- a/apps/desktop/src/__tests__/components/WhatsNewModal.test.ts
+++ b/apps/desktop/src/__tests__/components/WhatsNewModal.test.ts
@@ -1,0 +1,68 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import WhatsNewModal from "@/components/WhatsNewModal.vue";
+
+const markdownContentStub = {
+  props: ["content"],
+  emits: ["open-external"],
+  template: '<div data-testid="remote-release-notes">{{ content }}</div>',
+};
+
+function mountModal(props: Partial<InstanceType<typeof WhatsNewModal>["$props"]> = {}) {
+  return mount(WhatsNewModal, {
+    props: {
+      previousVersion: "0.7.1",
+      currentVersion: "0.8.0",
+      entries: [],
+      ...props,
+    },
+    global: {
+      stubs: {
+        MarkdownContent: markdownContentStub,
+        Teleport: true,
+      },
+    },
+  });
+}
+
+describe("WhatsNewModal", () => {
+  it("renders remote release notes when the bundled manifest is older", () => {
+    const wrapper = mountModal({
+      releaseNotes: "## Added\n\n- Remote update details",
+    });
+
+    expect(wrapper.get('[data-testid="remote-release-notes"]').text()).toContain(
+      "Remote update details",
+    );
+    expect(wrapper.text()).not.toContain("Release notes could not be loaded");
+  });
+
+  it("prefers structured bundled entries when they cover the requested update", () => {
+    const wrapper = mountModal({
+      entries: [
+        {
+          version: "0.8.0",
+          date: "2026-07-26",
+          notes: {
+            added: ["Bundled update details"],
+            changed: [],
+            fixed: [],
+          },
+        },
+      ],
+      releaseNotes: "Remote update details",
+    });
+
+    expect(wrapper.text()).toContain("Bundled update details");
+    expect(wrapper.find('[data-testid="remote-release-notes"]').exists()).toBe(false);
+  });
+
+  it("keeps the GitHub fallback when neither note source is available", () => {
+    const wrapper = mountModal({
+      releaseUrl: "https://github.com/MattShelton04/TracePilot/releases/tag/v0.8.0",
+    });
+
+    expect(wrapper.text()).toContain("Release notes could not be loaded");
+    expect(wrapper.text()).toContain("View release notes on GitHub");
+  });
+});

--- a/apps/desktop/src/__tests__/composables/useAutoUpdate.test.ts
+++ b/apps/desktop/src/__tests__/composables/useAutoUpdate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { calculateDownloadProgress } from "@/composables/useAutoUpdate";
+
+describe("calculateDownloadProgress", () => {
+  it("maps downloaded bytes to the full 0-100 range", () => {
+    expect(calculateDownloadProgress(0, 1_000)).toBe(0);
+    expect(calculateDownloadProgress(500, 1_000)).toBe(50);
+    expect(calculateDownloadProgress(1_000, 1_000)).toBe(100);
+  });
+
+  it("clamps invalid or oversized progress", () => {
+    expect(calculateDownloadProgress(1_100, 1_000)).toBe(100);
+    expect(calculateDownloadProgress(-100, 1_000)).toBe(0);
+    expect(calculateDownloadProgress(100, 0)).toBe(0);
+  });
+});

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -342,6 +342,14 @@ function handleOpenRelease() {
   margin-top: 12px;
 }
 
+.auto-update-progress :deep(.progress-bar) {
+  width: 100%;
+}
+
+.auto-update-progress :deep(.progress-bar-fill) {
+  transition: none;
+}
+
 .progress-text {
   display: block;
   margin-top: 6px;

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ReleaseManifestEntry } from "@tracepilot/types";
+import { MarkdownContent } from "@tracepilot/ui";
 import { computed } from "vue";
 
 const props = defineProps<{
@@ -7,6 +8,7 @@ const props = defineProps<{
   currentVersion: string;
   entries: ReleaseManifestEntry[];
   releaseUrl?: string;
+  releaseNotes?: string;
 }>();
 
 const emit = defineEmits<{
@@ -37,6 +39,7 @@ const relevantEntries = computed(() => {
 });
 
 const needsReindex = computed(() => relevantEntries.value.some((e) => e.requiresReindex));
+const hasRemoteReleaseNotes = computed(() => Boolean(props.releaseNotes?.trim()));
 </script>
 
 <template>
@@ -89,8 +92,18 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
             </div>
           </div>
 
-          <div v-if="relevantEntries.length === 0" class="no-notes">
-            <p>No detailed release notes available for this update.</p>
+          <div
+            v-if="relevantEntries.length === 0 && hasRemoteReleaseNotes"
+            class="remote-release-notes"
+          >
+            <MarkdownContent
+              :content="releaseNotes ?? ''"
+              @open-external="(url) => emit('open-external', url)"
+            />
+          </div>
+
+          <div v-else-if="relevantEntries.length === 0" class="no-notes">
+            <p>Release notes could not be loaded for this update.</p>
             <p v-if="releaseUrl">
               <a
                 href="#"
@@ -240,6 +253,10 @@ const needsReindex = computed(() => relevantEntries.value.some((e) => e.requires
   padding: 20px;
   color: var(--text-secondary);
   font-size: 14px;
+}
+
+.remote-release-notes {
+  padding-top: 4px;
 }
 
 .release-notes-link {

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -116,6 +116,7 @@ async function handleWhatsNewPreview() {
       appVersion.value,
       latestVersion,
       updateResult.value?.releaseUrl ?? undefined,
+      updateResult.value?.releaseNotes ?? undefined,
     );
   }
 }

--- a/apps/desktop/src/components/settings/SettingsUpdates.vue
+++ b/apps/desktop/src/components/settings/SettingsUpdates.vue
@@ -21,6 +21,7 @@ async function handleViewWhatsNew() {
       appVersion.value,
       updateResult.value.latestVersion,
       updateResult.value.releaseUrl ?? undefined,
+      updateResult.value.releaseNotes ?? undefined,
     );
   } else {
     await openWhatsNew("0.0.0", appVersion.value);

--- a/apps/desktop/src/composables/useAutoUpdate.ts
+++ b/apps/desktop/src/composables/useAutoUpdate.ts
@@ -17,6 +17,11 @@ const progress = ref(0);
 const errorMessage = ref<string | null>(null);
 const installType = ref<InstallType>("unknown");
 
+export function calculateDownloadProgress(downloadedBytes: number, totalBytes: number): number {
+  if (totalBytes <= 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((downloadedBytes / totalBytes) * 100)));
+}
+
 async function detectInstallType(): Promise<InstallType> {
   if (installType.value !== "unknown") return installType.value;
   try {
@@ -68,10 +73,11 @@ async function installUpdate(): Promise<void> {
       switch (event.event) {
         case "Started":
           totalBytes = event.data.contentLength ?? 0;
+          downloadedBytes = 0;
           break;
         case "Progress":
           downloadedBytes += event.data.chunkLength;
-          progress.value = totalBytes > 0 ? Math.round((downloadedBytes / totalBytes) * 100) : 0;
+          progress.value = calculateDownloadProgress(downloadedBytes, totalBytes);
           break;
         case "Finished":
           status.value = "installing";

--- a/apps/desktop/src/composables/useWhatsNew.ts
+++ b/apps/desktop/src/composables/useWhatsNew.ts
@@ -7,6 +7,7 @@ const whatsNewPreviousVersion = ref("");
 const whatsNewCurrentVersion = ref("");
 const whatsNewEntries = ref<ReleaseManifestEntry[]>([]);
 const whatsNewReleaseUrl = ref("");
+const whatsNewReleaseNotes = ref("");
 
 async function fetchManifest(): Promise<ReleaseManifestEntry[]> {
   try {
@@ -26,12 +27,14 @@ export async function openWhatsNew(
   previous: string,
   current: string,
   releaseUrl?: string,
+  releaseNotes?: string,
 ): Promise<void> {
   const entries = await fetchManifest();
   whatsNewEntries.value = entries;
   whatsNewPreviousVersion.value = previous;
   whatsNewCurrentVersion.value = current;
   whatsNewReleaseUrl.value = releaseUrl ?? "";
+  whatsNewReleaseNotes.value = releaseNotes ?? "";
   showWhatsNew.value = true;
 }
 
@@ -46,6 +49,7 @@ export function useWhatsNew() {
     whatsNewCurrentVersion,
     whatsNewEntries,
     whatsNewReleaseUrl,
+    whatsNewReleaseNotes,
     openWhatsNew,
     closeWhatsNew,
   };

--- a/crates/tracepilot-tauri-bindings/src/services/update.rs
+++ b/crates/tracepilot-tauri-bindings/src/services/update.rs
@@ -67,6 +67,7 @@ pub(crate) fn update_result_from_latest_release(
                 has_update: false,
                 release_url: None,
                 published_at: None,
+                release_notes: None,
             });
         }
         429 | 403 => {
@@ -102,6 +103,10 @@ pub(crate) fn update_result_from_latest_release(
         has_update,
         release_url: body["html_url"].as_str().map(String::from),
         published_at: body["published_at"].as_str().map(String::from),
+        release_notes: body["body"]
+            .as_str()
+            .filter(|notes| !notes.trim().is_empty())
+            .map(String::from),
     })
 }
 
@@ -115,6 +120,7 @@ mod tests {
             "tag_name": tag,
             "html_url": "https://example.invalid/release",
             "published_at": "2030-01-01T00:00:00Z",
+            "body": "## Added\n\n- A useful feature",
         })
     }
 
@@ -131,6 +137,10 @@ mod tests {
             Some("https://example.invalid/release")
         );
         assert_eq!(result.published_at.as_deref(), Some("2030-01-01T00:00:00Z"));
+        assert_eq!(
+            result.release_notes.as_deref(),
+            Some("## Added\n\n- A useful feature")
+        );
     }
 
     #[test]

--- a/crates/tracepilot-tauri-bindings/src/types.rs
+++ b/crates/tracepilot-tauri-bindings/src/types.rs
@@ -184,6 +184,7 @@ pub struct UpdateCheckResult {
     pub has_update: bool,
     pub release_url: Option<String>,
     pub published_at: Option<String>,
+    pub release_notes: Option<String>,
 }
 
 #[derive(Debug, Serialize, specta::Type)]

--- a/docs/versioning-updates-release-strategy.md
+++ b/docs/versioning-updates-release-strategy.md
@@ -348,7 +348,9 @@ Do not parse `CHANGELOG.md` at runtime for app metadata — CHANGELOG.md is a hu
 }
 ```
 
-This file lives at `apps/desktop/public/release-manifest.json` — Vite copies it into the bundle verbatim. The app fetches it locally at runtime (no network call needed for "What's New" display).
+This file lives at `apps/desktop/public/release-manifest.json` — Vite copies it into the bundle verbatim. The app fetches it locally at runtime for the installed version and historical "What's New" display.
+
+An installed bundle cannot contain manifest entries for versions released after it was built. When an update is available, the update check therefore also carries the GitHub release description returned by the existing latest-release API request. The preview renders that version-specific Markdown with the shared sanitized Markdown renderer when the bundled manifest does not cover the target version. This avoids a second network request while retaining the bundled manifest as the offline fallback.
 
 > **`requiresReindex` flag**: This should almost always be `false`. The indexer already handles reindex decisions automatically via `CURRENT_ANALYTICS_VERSION` and DB schema migration version tracking. The flag in `release-manifest.json` is an escape hatch for the rare case where a logic change isn't reflected in those version numbers (e.g., a parsing fix that improves data quality without changing the schema). When in doubt, leave it `false` — the automatic detection handles the common case.
 
@@ -727,7 +729,8 @@ async function checkForVersionChange() {
 
 The modal should:
 - Display the new version number prominently
-- Show release notes from the locally bundled `release-manifest.json`
+- Show release notes from the locally bundled `release-manifest.json` when it covers the target version
+- For a newer available version, fall back to the release description already returned by the GitHub update check
 - Handle the case where the user skipped multiple versions (e.g., 0.1.0 → 0.3.0) — show notes for all intermediate versions
 - Show a **"Reindex Recommended"** prompt if `requiresReindex: true` in the manifest, with a "Reindex Now" button wired to the existing reindex flow
 - Be dismissible ("Got it" stores the current version as seen)

--- a/packages/client/src/generated/bindings.ts
+++ b/packages/client/src/generated/bindings.ts
@@ -139,6 +139,7 @@ export type UpdateCheckResult = {
 	hasUpdate: boolean,
 	releaseUrl: string | null,
 	publishedAt: string | null,
+	releaseNotes: string | null,
 };
 
 export type ValidateSessionDirResult = {

--- a/packages/client/src/internal/mockData.ts
+++ b/packages/client/src/internal/mockData.ts
@@ -391,6 +391,7 @@ export async function getMockData<T>(cmd: string, args?: Record<string, unknown>
       hasUpdate: false,
       releaseUrl: null,
       publishedAt: null,
+      releaseNotes: null,
     } as UpdateCheckResult,
     get_git_info: { commitHash: "abc1234", branch: "main" } as GitInfo,
     is_session_running: false,


### PR DESCRIPTION
## Summary

- carry the GitHub release body through the existing update-check response and render it as sanitized Markdown when the installed release manifest cannot cover a newer version
- keep bundled structured notes as the preferred source and retain the GitHub release link as a graceful fallback
- reset and clamp updater byte progress, force the modal track to full width, and remove the fill transition that made rapid progress updates visually lag
- document the dual-source release-note strategy and add focused frontend/Rust coverage

## Root cause

An installed TracePilot bundle only contains the release manifest that existed when that version was built, so it can never contain structured notes for a future update. The update preview nevertheless queried only that local file. Separately, the progress label and fill shared the same percentage, but the shared 280 ms width transition caused the visible fill to trail fast Tauri download events.

## Impact

Users on an older version now see the actual GitHub release notes for the available update without an extra network request. Download progress reaches the full track in sync with the displayed percentage.

## Validation

- `cargo test -p tracepilot-tauri-bindings services::update::tests`
- `cargo clippy -p tracepilot-tauri-bindings --lib --no-deps -- -D warnings`
- `pnpm --filter @tracepilot/desktop test -- src/__tests__/components/WhatsNewModal.test.ts src/__tests__/composables/useAutoUpdate.test.ts`
- `pnpm --filter @tracepilot/ui test -- src/__tests__/ProgressBar.test.ts`
- `pnpm --filter @tracepilot/desktop typecheck`
- `pnpm --filter @tracepilot/client typecheck`
- `pnpm --filter @tracepilot/desktop build`
- targeted Biome checks and `git diff --check`
