### PR TITLE
Refine additional feature settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ The orchestration pages are for starting and organizing Copilot CLI work from th
 - **Command Centre** shows repository/session status, recent activity, and system dependency health.
 - **Session Launcher** builds Copilot CLI launch commands with repository, branch, model, prompt, environment, and optional worktree settings.
 - **Worktree Manager** discovers registered repositories, creates/removes/prunes worktrees, fetches remotes, opens folders, and launches sessions from worktrees.
-- **Config Injector** edits Copilot CLI agent model assignments and user settings, compares installed CLI versions, and backs up/restores config files.
 
 TracePilot understands the newer Copilot CLI settings layout: user-editable settings belong in `~/.copilot/settings.json`, while CLI-managed internal state can remain in `~/.copilot/config.json`.
 
@@ -99,8 +98,9 @@ TracePilot includes feature-flagged configuration surfaces for:
 - **MCP Server Manager**: add, import, configure, toggle, and health-check MCP servers compatible with Copilot CLI configuration.
 - **Session Replay**: step through session event timelines using indexed session data.
 - **Copilot SDK bridge**: experimental live-session connection and steering support.
+- **Config Injector**: edit Copilot CLI agent model assignments and user settings, compare installed CLI versions, and back up or restore config files.
 
-Skills, MCP servers, export view, and Markdown rendering are enabled by default in current builds. Session Replay and the Copilot SDK bridge remain experimental and disabled by default.
+Skills, Export, and Exact Context Capture are presented as recommended additional features. MCP Servers, Session Replay, the Copilot SDK bridge, and Config Injector are experimental and disabled by default.
 
 ### Export and share sessions
 

--- a/apps/desktop/src/__tests__/components/settings/SettingsFeatures.test.ts
+++ b/apps/desktop/src/__tests__/components/settings/SettingsFeatures.test.ts
@@ -1,0 +1,129 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import SettingsAlerts from "@/components/settings/SettingsAlerts.vue";
+import SettingsExperimental from "@/components/settings/SettingsExperimental.vue";
+import SettingsGeneral from "@/components/settings/SettingsGeneral.vue";
+import SettingsToolVisualization from "@/components/settings/SettingsToolVisualization.vue";
+import { usePreferencesStore } from "@/stores/preferences";
+
+vi.mock("@tracepilot/client", async () => {
+  const { createClientMock } = await import("../../mocks/client");
+  return createClientMock();
+});
+
+vi.mock("@/composables/useAlertDispatcher", () => ({
+  dispatchTestAlert: vi.fn(),
+}));
+
+describe("settings feature groups", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  it("shows recommended and experimental features in the requested order", async () => {
+    const wrapper = mount(SettingsExperimental);
+    await flushPromises();
+
+    const groups = wrapper.findAll(".feature-group");
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.find(".feature-group-title").text()).toBe("Recommended");
+    expect(groups[0]!.findAll(".setting-label").map((label) => label.text())).toEqual([
+      "Skills",
+      "Export",
+      "Exact Context Capture",
+    ]);
+    expect(groups[1]!.find(".feature-group-title").text()).toBe("Experimental");
+    expect(groups[1]!.findAll(".setting-label").map((label) => label.text())).toEqual([
+      "MCP Servers",
+      "Session Replay",
+      "Copilot SDK Bridge",
+      "Config Injector",
+    ]);
+  });
+
+  it("explains the experimental stability risk and defaults MCP and Config Injector off", async () => {
+    const wrapper = mount(SettingsExperimental);
+    await flushPromises();
+
+    const tooltips = wrapper.findAll('[role="tooltip"]').map((tooltip) => tooltip.text());
+    expect(tooltips).toContain("Stable features that extend TracePilot.");
+    expect(tooltips).toContain("Experimental features are likely to be buggy or unstable.");
+    expect(
+      wrapper.get('[role="switch"][aria-label="MCP Servers"]').attributes("aria-checked"),
+    ).toBe("false");
+    expect(
+      wrapper.get('[role="switch"][aria-label="Config Injector"]').attributes("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("gives Alerts & Notifications the same experimental disclaimer", async () => {
+    const wrapper = mount(SettingsAlerts);
+    await flushPromises();
+
+    expect(wrapper.get(".feature-group-title").text()).toBe("Experimental");
+    expect(wrapper.get('[role="tooltip"]').text()).toBe(
+      "Experimental features are likely to be buggy or unstable.",
+    );
+    expect(wrapper.find(".alerts-experimental-panel").exists()).toBe(true);
+  });
+});
+
+describe("recent sessions setting", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  it("shows Reset before the count without a sessions unit label", async () => {
+    const wrapper = mount(SettingsGeneral);
+    await flushPromises();
+
+    const preferences = usePreferencesStore();
+    preferences.sessionCacheSize += 1;
+    await nextTick();
+
+    const controls = wrapper
+      .findAll(".setting-control-group")
+      .find((group) => group.find('input[aria-label="Recent sessions kept ready"]').exists());
+    expect(controls).toBeDefined();
+    expect(controls!.text()).toBe("Reset");
+    expect(controls!.element.children[0]?.textContent?.trim()).toBe("Reset");
+    expect(controls!.element.children[1]?.tagName).toBe("INPUT");
+  });
+});
+
+describe("rich tool rendering settings", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  it("keeps per-tool overrides collapsed until requested", async () => {
+    const wrapper = mount(SettingsToolVisualization);
+    await flushPromises();
+
+    const details = wrapper.get("details.tool-overrides");
+    expect(details.attributes("open")).toBeUndefined();
+    expect(wrapper.find(".tool-viz-grid").exists()).toBe(false);
+    expect(wrapper.get(".tool-overrides-count").text()).toBe("Using defaults");
+
+    (details.element as HTMLDetailsElement).open = true;
+    await details.trigger("toggle");
+
+    expect(wrapper.find(".tool-viz-grid").exists()).toBe(true);
+  });
+
+  it("summarizes customized overrides while collapsed", async () => {
+    const wrapper = mount(SettingsToolVisualization);
+    await flushPromises();
+
+    const preferences = usePreferencesStore();
+    preferences.setToolRenderingOverride("view", false);
+    await nextTick();
+
+    expect(wrapper.get(".tool-overrides-count").text()).toBe("1 customized");
+  });
+});

--- a/apps/desktop/src/__tests__/router/routeRegistry.test.ts
+++ b/apps/desktop/src/__tests__/router/routeRegistry.test.ts
@@ -44,4 +44,13 @@ describe("route registry consistency", () => {
 
     expect(offenders, `Routes with unknown sidebarId: ${offenders.join(", ")}`).toEqual([]);
   });
+
+  it("gates Config Injector and places it in Configuration navigation", () => {
+    const route = router
+      .getRoutes()
+      .find((candidate) => candidate.name === ROUTE_NAMES.configInjector);
+
+    expect(route?.meta.featureFlag).toBe("configInjector");
+    expect(route?.meta.sidebar?.section).toBe("configuration");
+  });
 });

--- a/apps/desktop/src/components/sessionLauncher/SessionLauncherAdvanced.vue
+++ b/apps/desktop/src/components/sessionLauncher/SessionLauncherAdvanced.vue
@@ -21,7 +21,7 @@ const {
   sdkFeatureEnabled,
 } = useSessionLauncherContext();
 
-const sdkDisabledHint = "Enable copilotSdk in Settings → Experimental";
+const sdkDisabledHint = "Enable Copilot SDK Bridge in Settings → Additional Features";
 
 function toggleHeadless() {
   if (!sdkFeatureEnabled.value) return;

--- a/apps/desktop/src/components/sessionLauncher/SessionLauncherPreview.vue
+++ b/apps/desktop/src/components/sessionLauncher/SessionLauncherPreview.vue
@@ -23,7 +23,7 @@ const {
   sdkFeatureEnabled,
 } = useSessionLauncherContext();
 
-const sdkDisabledHint = "Enable copilotSdk in Settings → Experimental";
+const sdkDisabledHint = "Enable Copilot SDK Bridge in Settings → Additional Features";
 </script>
 
 <template>

--- a/apps/desktop/src/components/sessionLauncher/__tests__/SessionLauncherChildren.test.ts
+++ b/apps/desktop/src/components/sessionLauncher/__tests__/SessionLauncherChildren.test.ts
@@ -245,7 +245,9 @@ describe("SessionLauncherAdvanced", () => {
     const toggles = wrapper.findAll(".toggle-switch");
 
     expect(toggles[2].attributes("disabled")).toBeDefined();
-    expect(toggles[2].attributes("title")).toBe("Enable copilotSdk in Settings → Experimental");
+    expect(toggles[2].attributes("title")).toBe(
+      "Enable Copilot SDK Bridge in Settings → Additional Features",
+    );
     await toggles[2].trigger("click");
 
     expect(ctx.headless.value).toBe(false);

--- a/apps/desktop/src/components/settings/SettingsAlerts.vue
+++ b/apps/desktop/src/components/settings/SettingsAlerts.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ActionButton, FormSwitch, SectionPanel } from "@tracepilot/ui";
+import SettingsFeatureGroupHeader from "@/components/settings/SettingsFeatureGroupHeader.vue";
 import { dispatchTestAlert } from "@/composables/useAlertDispatcher";
 import { usePreferencesStore } from "@/stores/preferences";
 
@@ -13,7 +14,12 @@ function handleTestAlert() {
 <template>
   <div class="settings-section">
     <div class="settings-section-title">Alerts &amp; Notifications</div>
-    <SectionPanel>
+    <SettingsFeatureGroupHeader
+      label="Experimental"
+      tone="experimental"
+      tooltip="Experimental features are likely to be buggy or unstable."
+    />
+    <SectionPanel class="alerts-experimental-panel">
       <div class="setting-row">
         <div>
           <div class="setting-label">Enable alerts</div>
@@ -153,6 +159,10 @@ function handleTestAlert() {
 </template>
 
 <style scoped>
+.alerts-experimental-panel {
+  border-color: var(--warning-muted);
+}
+
 .group-divider {
   height: 1px;
   background: var(--border-subtle);

--- a/apps/desktop/src/components/settings/SettingsExperimental.vue
+++ b/apps/desktop/src/components/settings/SettingsExperimental.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { FormSwitch, SectionPanel } from "@tracepilot/ui";
+import SettingsFeatureGroupHeader from "@/components/settings/SettingsFeatureGroupHeader.vue";
 import type { FeatureFlag } from "@/config/featureFlags";
 import { usePreferencesStore } from "@/stores/preferences";
 import { useSdkStore } from "@/stores/sdk";
@@ -7,7 +8,32 @@ import { useSdkStore } from "@/stores/sdk";
 const preferences = usePreferencesStore();
 const sdk = useSdkStore();
 
-const flags: readonly { key: FeatureFlag; label: string; description: string }[] = [
+interface FeatureOption {
+  key: FeatureFlag;
+  label: string;
+  description: string;
+}
+
+const recommendedFlags: readonly FeatureOption[] = [
+  {
+    key: "skills",
+    label: "Skills",
+    description: "Create and manage reusable skill definitions for Copilot CLI sessions.",
+  },
+  {
+    key: "exportView",
+    label: "Export",
+    description: "Enable the Export view to download sessions in various formats.",
+  },
+  {
+    key: "exactContextCapture",
+    label: "Exact Context Capture",
+    description:
+      "Capture the exact model request body from an isolated copy of an inactive session. No provider is contacted.",
+  },
+] as const;
+
+const experimentalFlags: readonly FeatureOption[] = [
   {
     key: "mcpServers",
     label: "MCP Servers",
@@ -15,19 +41,9 @@ const flags: readonly { key: FeatureFlag; label: string; description: string }[]
       "Manage Model Context Protocol servers — add, configure, and monitor MCP integrations.",
   },
   {
-    key: "skills",
-    label: "Skills",
-    description: "Create and manage reusable skill definitions for Copilot CLI sessions.",
-  },
-  {
     key: "sessionReplay",
     label: "Session Replay",
     description: "Enable the Replay view to step through session events interactively.",
-  },
-  {
-    key: "exportView",
-    label: "Export",
-    description: "Enable the Export view to download sessions in various formats.",
   },
   {
     key: "copilotSdk",
@@ -36,10 +52,10 @@ const flags: readonly { key: FeatureFlag; label: string; description: string }[]
       "Enable the SDK bridge for real-time session steering, programmatic events, and direct communication with Copilot CLI.",
   },
   {
-    key: "exactContextCapture",
-    label: "Exact Context Capture",
+    key: "configInjector",
+    label: "Config Injector",
     description:
-      "Experimentally capture the exact model request body from an isolated copy of an inactive session. No provider is contacted.",
+      "Edit Copilot CLI agent model assignments and configuration, with backup and restore support.",
   },
 ] as const;
 
@@ -54,23 +70,66 @@ function handleToggle(key: FeatureFlag) {
 
 <template>
   <div class="settings-section">
-    <div class="settings-section-title">Experimental</div>
-    <SectionPanel>
-      <div
-        v-for="flag in flags"
-        :key="flag.key"
-        class="setting-row"
-      >
-        <div class="setting-info">
-          <div class="setting-label">{{ flag.label }}</div>
-          <div class="setting-description">{{ flag.description }}</div>
+    <div class="settings-section-title">Additional Features</div>
+
+    <div class="feature-group">
+      <SettingsFeatureGroupHeader
+        label="Recommended"
+        tone="recommended"
+        tooltip="Stable features that extend TracePilot."
+      />
+      <SectionPanel>
+        <div
+          v-for="flag in recommendedFlags"
+          :key="flag.key"
+          class="setting-row"
+        >
+          <div class="setting-info">
+            <div class="setting-label">{{ flag.label }}</div>
+            <div class="setting-description">{{ flag.description }}</div>
+          </div>
+          <FormSwitch
+            :model-value="preferences.isFeatureEnabled(flag.key)"
+            @update:model-value="handleToggle(flag.key)"
+            :aria-label="flag.label"
+          />
         </div>
-        <FormSwitch
-          :model-value="preferences.isFeatureEnabled(flag.key)"
-          @update:model-value="handleToggle(flag.key)"
-          :aria-label="flag.label"
-        />
-      </div>
-    </SectionPanel>
+      </SectionPanel>
+    </div>
+
+    <div class="feature-group feature-group--experimental">
+      <SettingsFeatureGroupHeader
+        label="Experimental"
+        tone="experimental"
+        tooltip="Experimental features are likely to be buggy or unstable."
+      />
+      <SectionPanel class="experimental-panel">
+        <div
+          v-for="flag in experimentalFlags"
+          :key="flag.key"
+          class="setting-row"
+        >
+          <div class="setting-info">
+            <div class="setting-label">{{ flag.label }}</div>
+            <div class="setting-description">{{ flag.description }}</div>
+          </div>
+          <FormSwitch
+            :model-value="preferences.isFeatureEnabled(flag.key)"
+            @update:model-value="handleToggle(flag.key)"
+            :aria-label="flag.label"
+          />
+        </div>
+      </SectionPanel>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.feature-group + .feature-group {
+  margin-top: 18px;
+}
+
+.experimental-panel {
+  border-color: var(--warning-muted);
+}
+</style>

--- a/apps/desktop/src/components/settings/SettingsFeatureGroupHeader.vue
+++ b/apps/desktop/src/components/settings/SettingsFeatureGroupHeader.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { Tooltip } from "@tracepilot/ui";
+import { CircleHelp } from "lucide-vue-next";
+
+defineProps<{
+  label: string;
+  tooltip: string;
+  tone: "recommended" | "experimental";
+}>();
+</script>
+
+<template>
+  <div class="feature-group-heading">
+    <span class="feature-group-title" :class="`feature-group-title--${tone}`">
+      {{ label }}
+    </span>
+    <Tooltip :text="tooltip" position="right">
+      <span
+        class="feature-group-help"
+        :class="`feature-group-help--${tone}`"
+        tabindex="0"
+        :aria-label="`About ${label.toLowerCase()} features`"
+      >
+        <CircleHelp :size="14" :stroke-width="1.75" aria-hidden="true" />
+      </span>
+    </Tooltip>
+  </div>
+</template>
+
+<style scoped>
+.feature-group-heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 4px 8px;
+  min-height: 20px;
+}
+
+.feature-group-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.feature-group-title--recommended {
+  color: var(--success-fg);
+}
+
+.feature-group-title--experimental {
+  color: var(--warning-fg);
+}
+
+.feature-group-help {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-tertiary);
+  cursor: help;
+  border-radius: var(--radius-sm);
+}
+
+.feature-group-help:hover,
+.feature-group-help:focus-visible {
+  outline: none;
+}
+
+.feature-group-help--recommended:hover,
+.feature-group-help--recommended:focus-visible {
+  color: var(--success-fg);
+}
+
+.feature-group-help--experimental:hover,
+.feature-group-help--experimental:focus-visible {
+  color: var(--warning-fg);
+}
+
+.feature-group-help--recommended:focus-visible {
+  box-shadow: 0 0 0 2px var(--success-muted);
+}
+
+.feature-group-help--experimental:focus-visible {
+  box-shadow: 0 0 0 2px var(--warning-muted);
+}
+</style>

--- a/apps/desktop/src/components/settings/SettingsGeneral.vue
+++ b/apps/desktop/src/components/settings/SettingsGeneral.vue
@@ -67,6 +67,13 @@ function updateSessionCacheSize(value: unknown) {
           </div>
         </div>
         <div class="setting-control-group">
+          <ActionButton
+            v-if="preferences.sessionCacheSize !== DEFAULT_SESSION_CACHE_SIZE"
+            size="sm"
+            @click="preferences.sessionCacheSize = DEFAULT_SESSION_CACHE_SIZE"
+          >
+            Reset
+          </ActionButton>
           <FormInput
             :model-value="preferences.sessionCacheSize"
             @update:model-value="updateSessionCacheSize"
@@ -77,15 +84,6 @@ function updateSessionCacheSize(value: unknown) {
             class="input-narrow-center"
             aria-label="Recent sessions kept ready"
           />
-          <span class="setting-unit">sessions</span>
-          <ActionButton
-            v-if="preferences.sessionCacheSize !== DEFAULT_SESSION_CACHE_SIZE"
-            size="sm"
-            variant="ghost"
-            @click="preferences.sessionCacheSize = DEFAULT_SESSION_CACHE_SIZE"
-          >
-            Reset
-          </ActionButton>
         </div>
       </div>
 

--- a/apps/desktop/src/components/settings/SettingsToolVisualization.vue
+++ b/apps/desktop/src/components/settings/SettingsToolVisualization.vue
@@ -1,10 +1,25 @@
 <script setup lang="ts">
 import type { RichRenderableToolName } from "@tracepilot/types";
 import { ActionButton, FormSwitch, getRegisteredRenderers, SectionPanel } from "@tracepilot/ui";
+import { ChevronDown } from "lucide-vue-next";
+import { computed, ref } from "vue";
 import { usePreferencesStore } from "@/stores/preferences";
 
 const preferences = usePreferencesStore();
 const registeredRenderers = getRegisteredRenderers();
+const overridesExpanded = ref(false);
+const customOverrideCount = computed(
+  () => Object.keys(preferences.toolRendering.toolOverrides).length,
+);
+
+function setRichRenderingEnabled(enabled: boolean) {
+  preferences.toolRendering.enabled = enabled;
+  if (!enabled) overridesExpanded.value = false;
+}
+
+function handleOverridesToggle(event: Event) {
+  overridesExpanded.value = (event.currentTarget as HTMLDetailsElement).open;
+}
 </script>
 
 <template>
@@ -22,21 +37,45 @@ const registeredRenderers = getRegisteredRenderers();
         </div>
         <FormSwitch
           :model-value="preferences.toolRendering.enabled"
-          @update:model-value="preferences.toolRendering.enabled = $event"
+          @update:model-value="setRichRenderingEnabled"
           label="Rich Tool Rendering"
         />
       </div>
 
       <!-- Per-tool overrides -->
-      <template v-if="preferences.toolRendering.enabled">
-        <div class="tool-viz-divider" />
-        <div class="setting-row setting-row-stacked">
-          <div class="setting-label setting-label-spaced">Per-Tool Overrides</div>
-          <div class="setting-description setting-description-spaced">
-            Disable rich rendering for specific tool types. Disabled tools fall back to plain text.
+      <details
+        v-if="preferences.toolRendering.enabled"
+        class="tool-overrides"
+        :open="overridesExpanded"
+        @toggle="handleOverridesToggle"
+      >
+        <summary class="tool-overrides-summary">
+          <div class="tool-overrides-summary-copy">
+            <span class="setting-label">Per-tool overrides</span>
+            <span class="setting-description">
+              Choose which tool types fall back to plain text.
+            </span>
           </div>
+          <div class="tool-overrides-summary-meta">
+            <span class="tool-overrides-count">
+              {{ customOverrideCount === 0 ? 'Using defaults' : `${customOverrideCount} customized` }}
+            </span>
+            <ChevronDown
+              class="tool-overrides-chevron"
+              :size="16"
+              :stroke-width="1.75"
+              aria-hidden="true"
+            />
+          </div>
+        </summary>
+
+        <div v-if="overridesExpanded" class="tool-overrides-content">
           <div class="tool-viz-grid">
-            <div v-for="renderer in registeredRenderers" :key="renderer.toolName" class="tool-viz-item">
+            <div
+              v-for="renderer in registeredRenderers"
+              :key="renderer.toolName"
+              class="tool-viz-item"
+            >
               <FormSwitch
                 :model-value="preferences.isRichRenderingEnabled(renderer.toolName)"
                 @update:model-value="preferences.setToolRenderingOverride(renderer.toolName as RichRenderableToolName, $event)"
@@ -44,21 +83,76 @@ const registeredRenderers = getRegisteredRenderers();
               />
             </div>
           </div>
-        </div>
 
-        <div class="tool-viz-divider" />
-        <div class="setting-row setting-row-end">
-          <ActionButton size="sm" @click="preferences.resetToolRendering()">Reset to Defaults</ActionButton>
+          <div v-if="customOverrideCount > 0" class="tool-overrides-actions">
+            <ActionButton size="sm" @click="preferences.resetToolRendering()">
+              Reset to Defaults
+            </ActionButton>
+          </div>
         </div>
-      </template>
+      </details>
     </SectionPanel>
   </div>
 </template>
 
 <style scoped>
-.tool-viz-divider {
+.tool-overrides {
   border-top: 1px solid var(--border-subtle);
-  margin: 0;
+}
+
+.tool-overrides-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 16px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.tool-overrides-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-overrides-summary:hover {
+  background: var(--canvas-default);
+}
+
+.tool-overrides-summary:focus-visible {
+  outline: 2px solid var(--accent-fg);
+  outline-offset: -2px;
+}
+
+.tool-overrides-summary-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.tool-overrides-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.tool-overrides-count {
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+}
+
+.tool-overrides-chevron {
+  color: var(--text-tertiary);
+  transition: transform var(--transition-fast);
+}
+
+.tool-overrides[open] .tool-overrides-chevron {
+  transform: rotate(180deg);
+}
+
+.tool-overrides-content {
+  padding: 4px 16px 12px;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .tool-viz-grid {
@@ -70,5 +164,13 @@ const registeredRenderers = getRegisteredRenderers();
 
 .tool-viz-item {
   padding: 4px 0;
+}
+
+.tool-overrides-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 10px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border-subtle);
 }
 </style>

--- a/apps/desktop/src/router/index.ts
+++ b/apps/desktop/src/router/index.ts
@@ -229,7 +229,8 @@ const routes: RouteRecordRaw[] = [
     meta: {
       title: "Config Injector",
       sidebarId: "config-injector",
-      sidebar: { section: "orchestration", label: "Config Injector", icon: "config", order: 3 },
+      featureFlag: "configInjector",
+      sidebar: { section: "configuration", label: "Config Injector", icon: "config", order: 3 },
     },
   },
   // === MCP Server Management ===

--- a/apps/desktop/src/views/SettingsView.vue
+++ b/apps/desktop/src/views/SettingsView.vue
@@ -37,8 +37,8 @@ const databaseSize = computed(() => dataStorageRef.value?.databaseSize ?? "—")
       <SettingsPricing />
       <SettingsToolVisualization />
       <SettingsUpdates />
-      <SettingsAlerts />
       <SettingsExperimental />
+      <SettingsAlerts />
       <SettingsSdk />
       <SettingsAbout :session-count="sessionCount" :database-size="databaseSize" />
     </div>

--- a/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
+++ b/apps/desktop/src/views/orchestration/ConfigInjectorView.vue
@@ -61,7 +61,7 @@ const tabNavItems = computed(() =>
       />
 
       <nav class="breadcrumb">
-        <span class="breadcrumb-link">Orchestration</span>
+        <span class="breadcrumb-link">Configuration</span>
         <span class="breadcrumb-sep">›</span>
         <span class="breadcrumb-current">Config Injector</span>
       </nav>
@@ -102,4 +102,3 @@ const tabNavItems = computed(() =>
     </div>
   </div>
 </template>
-

--- a/apps/desktop/src/views/orchestration/home/OrchestrationQuickActions.vue
+++ b/apps/desktop/src/views/orchestration/home/OrchestrationQuickActions.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import { Bot, GitBranch, LayoutDashboard, type LucideIcon, Rocket } from "lucide-vue-next";
+import { computed } from "vue";
 import { useRouter } from "vue-router";
+import type { FeatureFlag } from "@/config/featureFlags";
 import { ROUTE_NAMES, type RouteName } from "@/config/routes";
 import { pushRoute } from "@/router/navigation";
+import { usePreferencesStore } from "@/stores/preferences";
 
 const router = useRouter();
+const preferences = usePreferencesStore();
 
 interface QuickAction {
   icon: LucideIcon;
@@ -12,9 +16,10 @@ interface QuickAction {
   desc: string;
   to: RouteName | null;
   disabled: boolean;
+  featureFlag?: FeatureFlag;
 }
 
-const quickActions: QuickAction[] = [
+const allQuickActions: QuickAction[] = [
   {
     icon: Rocket,
     title: "Launch Session",
@@ -35,6 +40,7 @@ const quickActions: QuickAction[] = [
     desc: "Edit agent definitions & configs",
     to: ROUTE_NAMES.configInjector,
     disabled: false,
+    featureFlag: "configInjector",
   },
   {
     icon: GitBranch,
@@ -44,6 +50,12 @@ const quickActions: QuickAction[] = [
     disabled: false,
   },
 ];
+
+const quickActions = computed(() =>
+  allQuickActions.filter(
+    (action) => !action.featureFlag || preferences.isFeatureEnabled(action.featureFlag),
+  ),
+);
 
 function navigateAction(action: QuickAction) {
   if (!action.disabled && action.to) {

--- a/crates/tracepilot-tauri-bindings/src/config/features.rs
+++ b/crates/tracepilot-tauri-bindings/src/config/features.rs
@@ -13,7 +13,7 @@ pub struct FeaturesConfig {
     pub session_replay: bool,
     #[serde(default = "default_true")]
     pub render_markdown: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub mcp_servers: bool,
     #[serde(default = "default_true")]
     pub skills: bool,
@@ -21,6 +21,8 @@ pub struct FeaturesConfig {
     pub copilot_sdk: bool,
     #[serde(default)]
     pub exact_context_capture: bool,
+    #[serde(default)]
+    pub config_injector: bool,
 }
 
 impl Default for FeaturesConfig {
@@ -29,10 +31,28 @@ impl Default for FeaturesConfig {
             export_view: false,
             session_replay: false,
             render_markdown: true,
-            mcp_servers: true,
+            mcp_servers: false,
             skills: true,
             copilot_sdk: false,
             exact_context_capture: false,
+            config_injector: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FeaturesConfig;
+
+    #[test]
+    fn experimental_configuration_features_default_off() {
+        let defaults = FeaturesConfig::default();
+        assert!(!defaults.mcp_servers);
+        assert!(!defaults.config_injector);
+
+        let missing_fields: FeaturesConfig =
+            toml::from_str("").expect("an empty features table should use field defaults");
+        assert!(!missing_fields.mcp_servers);
+        assert!(!missing_fields.config_injector);
     }
 }

--- a/docs/copilot-sdk-usage.md
+++ b/docs/copilot-sdk-usage.md
@@ -2,7 +2,7 @@
 
 TracePilot integrates the community [Copilot SDK for Rust](https://github.com/copilot-community-sdk/copilot-sdk-rust) to enable **real-time session steering**, programmatic event streaming, and direct communication with the Copilot CLI — all from the desktop UI.
 
-> **Status:** Experimental. Enable via Settings → Experimental → Copilot SDK Bridge.
+> **Status:** Experimental. Enable via Settings → Additional Features → Copilot SDK Bridge.
 
 ---
 
@@ -175,7 +175,7 @@ Click "Detect UI Server" in Settings or use "Detect & Connect" for one-click dis
 ### Building
 
 The SDK is compiled into every build — there is no opt-out flag (ADR-0007).
-To disable at runtime, toggle **Settings → Experimental → Copilot SDK** off.
+To disable at runtime, toggle **Settings → Additional Features → Copilot SDK Bridge** off.
 
 ```bash
 cargo build
@@ -405,7 +405,7 @@ cd apps/desktop && npx vue-tsc --noEmit
 
 ### Manual Testing
 
-1. Enable the feature flag: Settings → Experimental → **Copilot SDK Bridge**
+1. Enable the feature flag: Settings → Additional Features → **Copilot SDK Bridge**
 2. In Settings → Copilot SDK Bridge, click **Connect** (leave CLI URL empty to spawn a subprocess)
 3. Open a session in the Conversation tab
 4. The steering panel should appear at the bottom of the Chat view
@@ -430,9 +430,9 @@ pnpm tauri dev
 | Issue | Solution |
 |---|---|
 | "SDK not available" error | Should not occur — the SDK is always compiled in (ADR-0007). If you see this from older logs, rebuild on `main`. |
-| "Copilot SDK bridge is disabled by user preference" | Enable **Settings → Experimental → Copilot SDK**. Existing sessions remain steerable even while the toggle is off. |
+| "Copilot SDK bridge is disabled by user preference" | Enable **Settings → Additional Features → Copilot SDK Bridge**. Existing sessions remain steerable even while the toggle is off. |
 | Can't connect | Ensure Copilot CLI is installed and on PATH (`copilot --version`) |
-| No steering panel | Enable `copilotSdk` feature flag in Settings → Experimental |
+| No steering panel | Enable `copilotSdk` feature flag in Settings → Additional Features |
 | Auth errors | Run `gh auth login` to authenticate |
 | Connection drops | Check CLI subprocess is still running; try reconnecting |
 | Models list empty | Ensure connected and authenticated |

--- a/docs/exact-context-capture.md
+++ b/docs/exact-context-capture.md
@@ -1,6 +1,6 @@
 # Exact Context Capture
 
-Exact Context Capture is an experimental TracePilot feature for inspecting the model API request body that the installed GitHub Copilot CLI builds. It supports isolated captures of an inactive session and fresh CLI context benchmarks.
+Exact Context Capture is an optional TracePilot feature for inspecting the model API request body that the installed GitHub Copilot CLI builds. It supports isolated captures of an inactive session and fresh CLI context benchmarks.
 
 The capture is local. TracePilot directs one request to a temporary listener on `127.0.0.1`, saves the request if you ask it to, returns an intentional error to stop inference, and never forwards the payload to a model provider.
 
@@ -51,7 +51,7 @@ The initial implementation is tested against the capture capabilities exposed by
 ## Enable the feature
 
 1. Open **Settings**.
-2. Open **Experimental**.
+2. Find **Recommended** under **Additional Features**.
 3. Enable **Exact Context Capture**.
 4. Open a session and select its **Context** tab.
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -80,6 +80,7 @@ export interface TracePilotConfig {
     skills: boolean;
     copilotSdk: boolean;
     exactContextCapture: boolean;
+    configInjector: boolean;
   };
   logging: {
     level: string;

--- a/packages/types/src/defaults.ts
+++ b/packages/types/src/defaults.ts
@@ -48,10 +48,11 @@ export const DEFAULT_FEATURES: TracePilotConfig["features"] = {
   exportView: true,
   sessionReplay: false,
   renderMarkdown: true,
-  mcpServers: true,
+  mcpServers: false,
   skills: true,
   copilotSdk: false,
   exactContextCapture: false,
+  configInjector: false,
 };
 
 /**

--- a/packages/types/tests/defaults.test.ts
+++ b/packages/types/tests/defaults.test.ts
@@ -81,6 +81,11 @@ describe("createDefaultConfig", () => {
     expect(createDefaultConfig({})).toEqual(expectedDefaults);
   });
 
+  it("keeps experimental configuration features disabled by default", () => {
+    expect(DEFAULT_FEATURES.mcpServers).toBe(false);
+    expect(DEFAULT_FEATURES.configInjector).toBe(false);
+  });
+
   it("should return a new object each call (mutation isolation)", () => {
     const a = createDefaultConfig();
     const b = createDefaultConfig();


### PR DESCRIPTION
## Summary

- reorganize Settings into visually separated Recommended and Experimental additional-feature groups with consistent accessible tooltips
- make MCP Servers and Config Injector disabled by default, feature-gate Config Injector, and place it under Configuration when enabled
- give Alerts & Notifications the same experimental warning treatment
- collapse Rich Tool Rendering per-tool overrides behind progressive disclosure with a customization count
- refine the recent-session cache control so Reset no longer shifts the count or shows a redundant unit label
- update affected SDK hints, documentation, route coverage, and settings component tests

## Why

The previous settings layout mixed stable and experimental capabilities, exposed experimental configuration surfaces by default, and devoted substantial vertical space to advanced tool-rendering controls. This makes feature maturity clearer, reduces accidental exposure to unstable functionality, and keeps advanced controls available without overwhelming the main settings flow.

## User impact

New or missing configurations default MCP Servers and Config Injector to off. Existing explicitly saved preferences remain intact. Config Injector appears in Configuration only when enabled, while rich-rendering overrides remain available in a collapsed, keyboard-accessible disclosure.

## Validation

- `pnpm --filter @tracepilot/desktop typecheck`
- targeted desktop suites: 32 tests passed across settings, feature flags, routes, and session launcher coverage
- `pnpm --filter @tracepilot/types test`
- `cargo test -p tracepilot-tauri-bindings config --lib`
- targeted Biome checks and `cargo fmt --all -- --check`
- `git diff --check`
