### PR TITLE
Fix Markdown copy contents action in Session Explorer

### DIFF
--- a/packages/ui/src/__tests__/FileContentViewer.test.ts
+++ b/packages/ui/src/__tests__/FileContentViewer.test.ts
@@ -130,6 +130,7 @@ describe("FileContentViewer", () => {
     expect(wrapper.find(".fcv__content").exists()).toBe(true);
     // MarkdownContent or CodeBlock should be rendered inside .fcv__content
     expect(wrapper.find(".fcv__content").html()).toBeTruthy();
+    expect(wrapper.find('[aria-label="Copy file contents"]').exists()).toBe(true);
   });
 
   it("renders JSON, JSONL, and CSV with structured viewers", () => {

--- a/packages/ui/src/components/FileContentViewer.vue
+++ b/packages/ui/src/components/FileContentViewer.vue
@@ -23,7 +23,7 @@ import CodeBlock from "./renderers/CodeBlock.vue";
 import SqliteTableView from "./SqliteTableView.vue";
 import "../styles/features/file-content-viewer.css";
 
-const props = defineProps<{
+interface FileContentViewerProps {
   /** Relative path within the session directory (for display + language detection). */
   filePath?: string;
   /** Absolute path on host filesystem. */
@@ -58,7 +58,9 @@ const props = defineProps<{
   error?: string | null;
   /** Show the built-in direct content copy action. Disable when the caller requires confirmation. */
   showCopyContent?: boolean;
-}>();
+}
+
+const props = withDefaults(defineProps<FileContentViewerProps>(), { showCopyContent: true });
 
 const emit = defineEmits<{
   /** Re-emitted from MarkdownContent — parent handles OS open (Tauri). */


### PR DESCRIPTION
## Summary

- restore the Session Explorer's built-in **Copy file contents** action for Markdown files
- explicitly default `FileContentViewer.showCopyContent` to enabled
- add regression coverage for the normal Markdown viewer configuration

## Root cause

`showCopyContent` was introduced as an optional Boolean prop, with `showCopyContent !== false` intended to make omission mean enabled. Vue casts an omitted Boolean prop to `false`, so normal `FileContentViewer` callers were silently treated as opting out and the copy action disappeared. Giving the public prop an explicit `true` default restores the intended contract while preserving the explicit `false` opt-out used by sensitive callers.

## Impact

Markdown files in Session Explorer show the copy-contents action again. Callers that deliberately pass `showCopyContent: false` remain unchanged.

## Validation

- `pnpm --filter @tracepilot/ui test -- src/__tests__/FileContentViewer.test.ts` (21 passed)
- `pnpm --filter @tracepilot/ui typecheck`
- `pnpm --filter @tracepilot/desktop typecheck`
- `pnpm exec biome check packages/ui/src/components/FileContentViewer.vue packages/ui/src/__tests__/FileContentViewer.test.ts`
- full UI suite: 1,018 passed; one unrelated Rust syntax-highlighter timing smoke test exceeded its 200 ms threshold by 2.8 ms under concurrent load, then passed in isolation (43/43)
