### PR TITLE
Fix formatter and import-order violations

### DIFF
--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -13,8 +13,8 @@ import {
   discoverInstalledVersions,
   findEventExamples,
   generateMarkdownReport,
-  scanSessionVersions,
   getCopilotPkgDir,
+  scanSessionVersions,
 } from "../lib/version-analyzer.js";
 import { handleValidationError } from "../utils/errorHandler.js";
 import { printJson } from "./utils.js";

--- a/apps/cli/src/lib/version-analyzer.ts
+++ b/apps/cli/src/lib/version-analyzer.ts
@@ -29,4 +29,7 @@ export type {
   SessionVersionInfo,
   VersionDiff,
 } from "./version-analyzer/types.js";
-export { discoverInstalledVersions, getCopilotPkgDir } from "./version-analyzer/version-discovery.js";
+export {
+  discoverInstalledVersions,
+  getCopilotPkgDir,
+} from "./version-analyzer/version-discovery.js";

--- a/apps/desktop/src/styles/features/mcp-manager.css
+++ b/apps/desktop/src/styles/features/mcp-manager.css
@@ -96,10 +96,18 @@
   flex-shrink: 0;
 }
 
-.mcp-manager-view .stat-dot.installed { background: var(--accent-fg); }
-.mcp-manager-view .stat-dot.active    { background: var(--success-fg); }
-.mcp-manager-view .stat-dot.paused    { background: var(--warning-fg); }
-.mcp-manager-view .stat-dot.error     { background: var(--danger-fg); }
+.mcp-manager-view .stat-dot.installed {
+  background: var(--accent-fg);
+}
+.mcp-manager-view .stat-dot.active {
+  background: var(--success-fg);
+}
+.mcp-manager-view .stat-dot.paused {
+  background: var(--warning-fg);
+}
+.mcp-manager-view .stat-dot.error {
+  background: var(--danger-fg);
+}
 
 .mcp-manager-view .stat-sep {
   color: var(--text-placeholder);
@@ -162,7 +170,9 @@
   border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color var(--transition-fast), border-color var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .mcp-manager-view .btn-icon-sm:hover {
@@ -180,8 +190,12 @@
 }
 
 @keyframes mcp-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ─── Section Heading ─── */

--- a/apps/desktop/src/views/tabs/ExplorerTab.vue
+++ b/apps/desktop/src/views/tabs/ExplorerTab.vue
@@ -50,9 +50,7 @@ const viewerSearchRequest = ref({ id: 0, query: "", line: 0 });
 const isSearchOpen = ref(false);
 const searchInputRef = ref<HTMLInputElement | null>(null);
 
-const showSearchPanel = computed(
-  () => isSearchOpen.value || Boolean(searchQuery.value.trim()),
-);
+const showSearchPanel = computed(() => isSearchOpen.value || Boolean(searchQuery.value.trim()));
 
 function toggleSearch() {
   if (showSearchPanel.value) {

--- a/biome.json
+++ b/biome.json
@@ -63,6 +63,7 @@
       "!**/dist",
       "!**/target",
       "!**/.tauri",
+      "!packages/ui/playwright/.cache",
       "!**/*.d.ts",
       "!docs/design/prototypes",
       "!docs/presentation",

--- a/design-system/previews/accent-and-icons.html
+++ b/design-system/previews/accent-and-icons.html
@@ -226,8 +226,8 @@
       </div>
       <div class="card-body">
         <div style="display:flex; gap:8px; margin-bottom:12px;">
-          <button class="btn btn-primary">Run trace</button>
-          <button class="btn">Filter</button>
+          <button type="button" class="btn btn-primary">Run trace</button>
+          <button type="button" class="btn">Filter</button>
           <span class="pill info"><span class="dot" style="background:#06121C"></span>Live</span>
         </div>
         <div class="codeline">$ copilot run --session 0f3a · model=claude-opus-4.7</div>
@@ -290,8 +290,8 @@
       </div>
       <div class="card-body">
         <div style="display:flex; gap:8px; margin-bottom:12px;">
-          <button class="btn btn-primary">Run trace</button>
-          <button class="btn">Filter</button>
+          <button type="button" class="btn btn-primary">Run trace</button>
+          <button type="button" class="btn">Filter</button>
           <span class="pill info"><span class="dot" style="background:#06121C"></span>Live</span>
         </div>
         <div class="codeline">$ copilot run --session 0f3a · model=claude-opus-4.7</div>
@@ -354,8 +354,8 @@
       </div>
       <div class="card-body">
         <div style="display:flex; gap:8px; margin-bottom:12px;">
-          <button class="btn btn-primary">Run trace</button>
-          <button class="btn">Filter</button>
+          <button type="button" class="btn btn-primary">Run trace</button>
+          <button type="button" class="btn">Filter</button>
           <span class="pill info"><span class="dot" style="background:#06121C"></span>Live</span>
         </div>
         <div class="codeline">$ copilot run --session 0f3a · model=claude-opus-4.7</div>
@@ -485,31 +485,31 @@
 
     <div class="card" style="padding:10px 12px; display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
       <span class="micro" style="color:var(--text-muted); width:84px;">Lucide</span>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/lucide/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/lucide/refresh-ccw.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/lucide/filter.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/lucide/download.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/lucide/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/lucide/refresh-ccw.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/lucide/filter.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/lucide/download.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
     </div>
     <div class="card" style="padding:10px 12px; display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
       <span class="micro" style="color:var(--text-muted); width:84px;">Phosphor</span>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/ph/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/ph/arrows-clockwise.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/ph/funnel.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/ph/download-simple.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/ph/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/ph/arrows-clockwise.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/ph/funnel.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/ph/download-simple.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
     </div>
     <div class="card" style="padding:10px 12px; display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
       <span class="micro" style="color:var(--text-muted); width:84px;">Tabler</span>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/tabler/player-play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/tabler/refresh.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/tabler/filter.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/tabler/download.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/tabler/player-play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/tabler/refresh.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/tabler/filter.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/tabler/download.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
     </div>
     <div class="card" style="padding:10px 12px; display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
       <span class="micro" style="color:var(--text-muted); width:84px;">Heroicons</span>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/arrow-path.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/funnel.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
-      <button class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/arrow-down-tray.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/play.svg?color=%23E6E8EC&width=16&height=16" alt="">Run</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/arrow-path.svg?color=%23E6E8EC&width=16&height=16" alt="">Refresh</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/funnel.svg?color=%23E6E8EC&width=16&height=16" alt="">Filter</button>
+      <button type="button" class="btn btn-ghost"><img src="https://api.iconify.design/heroicons/arrow-down-tray.svg?color=%23E6E8EC&width=16&height=16" alt="">Export</button>
     </div>
   </div>
 

--- a/scripts/check-no-backdrop-filter.mjs
+++ b/scripts/check-no-backdrop-filter.mjs
@@ -14,8 +14,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -46,10 +46,10 @@ const ALLOW_FILES = new Set([
 const RE = /(?:^|[^a-z-])(-webkit-)?backdrop-filter\s*:/i;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -108,7 +108,5 @@ for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line
 console.error(
   "\nFix: use solid surfaces per 00-globals §G2 (canvas-overlay/raised + hairline + shadow).",
 );
-console.error(
-  "Backdrop blur is reserved for the modal scrim only.",
-);
+console.error("Backdrop blur is reserved for the modal scrim only.");
 process.exit(1);

--- a/scripts/check-no-emoji-in-templates.mjs
+++ b/scripts/check-no-emoji-in-templates.mjs
@@ -19,8 +19,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -63,10 +63,10 @@ const ALLOW_DIRECTIVE = /<!--\s*design-system:\s*allow-emoji\s*-->/;
 const EMOJI_RE = /\p{Extended_Pictographic}/u;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -135,13 +135,7 @@ console.error(`✗ no-emoji-in-templates: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: ${v.emoji}  // ${v.src.slice(0, 100)}`);
 }
-console.error(
-  "\nFix: use Lucide icons via @tracepilot/ui (see 00-globals §G1 migration table),",
-);
-console.error(
-  "or wrap user-supplied emoji in <UserContentEmoji> and add",
-);
-console.error(
-  "`<!-- design-system: allow-emoji -->` inside the template block.",
-);
+console.error("\nFix: use Lucide icons via @tracepilot/ui (see 00-globals §G1 migration table),");
+console.error("or wrap user-supplied emoji in <UserContentEmoji> and add");
+console.error("`<!-- design-system: allow-emoji -->` inside the template block.");
 process.exit(1);

--- a/scripts/check-no-hex-colors.mjs
+++ b/scripts/check-no-hex-colors.mjs
@@ -20,8 +20,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -40,10 +40,10 @@ const HEX_RE = /#[0-9a-fA-F]{3,8}\b/;
 const ALLOW_DIRECTIVE = /design-system:\s*allow-hex/;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -102,9 +102,7 @@ console.error(`✗ no-hex-colors: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: ${v.hex}  // ${v.src.slice(0, 100)}`);
 }
-console.error(
-  "\nFix: replace with a token from packages/ui/src/styles/tokens.css,",
-);
+console.error("\nFix: replace with a token from packages/ui/src/styles/tokens.css,");
 console.error(
   "or add `// design-system: allow-hex (reason)` to the offending line if intentional.",
 );

--- a/scripts/check-spacing-grid.mjs
+++ b/scripts/check-spacing-grid.mjs
@@ -13,8 +13,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -29,10 +29,10 @@ const PROP_RE =
 const PX_RE = /(-?\d*\.?\d+)px/g;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -76,14 +76,12 @@ for (const abs of files) {
     continue;
   }
   const re = new RegExp(PROP_RE.source, "gi");
-  let m;
-  while ((m = re.exec(text)) !== null) {
+  for (const m of text.matchAll(re)) {
     const prop = m[2];
     const value = m[3];
     const line = lineNumber(text, m.index);
-    let pm;
     PX_RE.lastIndex = 0;
-    while ((pm = PX_RE.exec(value)) !== null) {
+    for (const pm of value.matchAll(PX_RE)) {
       const n = Number.parseFloat(pm[1]);
       if (!Number.isFinite(n)) continue;
       if (!GRID.has(Math.abs(n))) {
@@ -94,10 +92,7 @@ for (const abs of files) {
 }
 
 offGrid.sort(
-  (a, b) =>
-    a.file.localeCompare(b.file) ||
-    a.line - b.line ||
-    a.prop.localeCompare(b.prop),
+  (a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.prop.localeCompare(b.prop),
 );
 
 if (offGrid.length === 0) {
@@ -105,13 +100,9 @@ if (offGrid.length === 0) {
   process.exit(0);
 }
 
-console.warn(
-  `⚠ spacing-grid: ${offGrid.length} off-grid value(s) (warn-only in v1)`,
-);
+console.warn(`⚠ spacing-grid: ${offGrid.length} off-grid value(s) (warn-only in v1)`);
 for (const v of offGrid) {
   console.warn(`  ${v.file}:${v.line}: ${v.prop}: ${v.value}`);
 }
-console.warn(
-  "\nGrid: 4 · 8 · 12 · 16 · 20 · 24 · 32 · 40 · 48 · 64 · 80 (00-globals §G8).",
-);
+console.warn("\nGrid: 4 · 8 · 12 · 16 · 20 · 24 · 32 · 40 · 48 · 64 · 80 (00-globals §G8).");
 process.exit(0);

--- a/scripts/check-z-index-tokens.mjs
+++ b/scripts/check-z-index-tokens.mjs
@@ -14,8 +14,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
@@ -59,10 +59,10 @@ const ALLOW_FILES = new Set([
 const RE = /(^|[^a-z-])z-index\s*:\s*([^;]+);/gi;
 
 function gitStaged() {
-  const out = execSync(
-    "git diff --cached --name-only --diff-filter=ACMR",
-    { encoding: "utf8", cwd: REPO_ROOT },
-  );
+  const out = execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
   return out.split(/\r?\n/).filter(Boolean);
 }
 
@@ -108,8 +108,7 @@ for (const abs of files) {
     continue;
   }
   const re = new RegExp(RE.source, "gi");
-  let m;
-  while ((m = re.exec(text)) !== null) {
+  for (const m of text.matchAll(re)) {
     const value = m[2].trim();
     if (value.startsWith("var(")) continue;
     if (ALLOWED_LITERALS.has(value)) continue;
@@ -130,13 +129,7 @@ console.error(`✗ z-index-tokens: ${violations.length} violation(s)`);
 for (const v of violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.error(`  ${v.file}:${v.line}: z-index: ${v.value};`);
 }
-console.error(
-  "\nFix: use a token from MASTER §7 (--z-sidebar | --z-header | --z-fab |",
-);
-console.error(
-  "--z-overlay | --z-modal | --z-tooltip). Literal 0/auto/-1/1 are allowed",
-);
-console.error(
-  "for stacking-context creation only.",
-);
+console.error("\nFix: use a token from MASTER §7 (--z-sidebar | --z-header | --z-fab |");
+console.error("--z-overlay | --z-modal | --z-tooltip). Literal 0/auto/-1/1 are allowed");
+console.error("for stacking-context creation only.");
 process.exit(1);


### PR DESCRIPTION
## What changed

- applies Biome formatting and import ordering to tracked source and repository scripts
- excludes the ignored Playwright cache from Biome so generated/minified assets do not produce hundreds of false diagnostics
- adds explicit `type="button"` attributes to design-system preview controls
- replaces assignment-in-condition regex loops with equivalent `matchAll` iteration

## Why

`pnpm lint` reported 596 errors, but most of that volume came from ignored Playwright build artifacts. The remaining tracked findings were formatter/import-order drift, preview button accessibility findings, and three script loop-style violations.

This restores `pnpm lint` to a clean, actionable signal across 1,142 checked files.

## Impact

No application behavior is intentionally changed. The only non-format changes are explicit non-submit button types in a standalone design preview and equivalent regex iteration in two repository validation scripts.

Rust formatting was also checked. `cargo fmt --all` produced no changes, so no empty Rust-only commit was added.

## Validation

The locally reproducible CI requirements pass:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — 3,127 tests passed
- `cargo test --workspace --exclude tracepilot-desktop`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `node scripts/check-file-sizes.mjs`
- `node scripts/check-workflow-actions.mjs --verify-remote`
- package/Cargo version consistency
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Scope

`CODE_HEALTH_AUDIT.md` is intentionally excluded from this PR.
