### PR TITLE
Port worthwhile Palette, Bolt, and Sentinel fixes

### DIFF
--- a/apps/desktop/src/ChildApp.vue
+++ b/apps/desktop/src/ChildApp.vue
@@ -100,7 +100,14 @@ async function closeWindow() {
       <!-- Compact title bar -->
       <div class="child-titlebar">
         <span class="child-titlebar-label">{{ sessionLabel }}</span>
-        <button class="child-titlebar-close" title="Close window" @click="closeWindow">×</button>
+        <button
+          class="child-titlebar-close"
+          title="Close window"
+          aria-label="Close window"
+          @click="closeWindow"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
       </div>
 
       <!-- Content -->

--- a/apps/desktop/src/__tests__/components/search/SessionSearchChildren.test.ts
+++ b/apps/desktop/src/__tests__/components/search/SessionSearchChildren.test.ts
@@ -141,7 +141,7 @@ describe("SessionSearchPagination", () => {
       },
     });
     const buttons = wrapper.findAll(".pagination-btn");
-    expect(wrapper.get('nav[aria-label="Search results pagination"]').exists()).toBe(true);
+    expect(wrapper.find('nav[aria-label="Search results pagination"]').exists()).toBe(true);
     expect(wrapper.get('[aria-label="Page 2"]').attributes("aria-current")).toBe("page");
     expect(wrapper.get('[aria-label="Previous page"]').attributes("disabled")).toBeUndefined();
     expect(wrapper.get(".pagination-info").attributes("aria-live")).toBe("polite");

--- a/apps/desktop/src/__tests__/components/search/SessionSearchChildren.test.ts
+++ b/apps/desktop/src/__tests__/components/search/SessionSearchChildren.test.ts
@@ -87,6 +87,10 @@ describe("SessionSearchResultsHeader", () => {
     });
     expect(wrapper.text()).toContain("42");
     const groupedBtn = wrapper.find('[title="Grouped by session"]');
+    expect(groupedBtn.attributes("aria-label")).toBe("Grouped by session");
+    expect(groupedBtn.attributes("aria-pressed")).toBe("false");
+    expect(wrapper.get('[aria-label="Flat list"]').attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get('[aria-label="Clear search"] svg').attributes("aria-hidden")).toBe("true");
     await groupedBtn.trigger("click");
     expect(wrapper.emitted("update:resultViewMode")?.[0]).toEqual(["grouped"]);
   });
@@ -137,6 +141,10 @@ describe("SessionSearchPagination", () => {
       },
     });
     const buttons = wrapper.findAll(".pagination-btn");
+    expect(wrapper.get('nav[aria-label="Search results pagination"]').exists()).toBe(true);
+    expect(wrapper.get('[aria-label="Page 2"]').attributes("aria-current")).toBe("page");
+    expect(wrapper.get('[aria-label="Previous page"]').attributes("disabled")).toBeUndefined();
+    expect(wrapper.get(".pagination-info").attributes("aria-live")).toBe("polite");
     await buttons[0].trigger("click");
     expect(wrapper.emitted("prev")).toBeTruthy();
     await buttons[buttons.length - 1].trigger("click");

--- a/apps/desktop/src/components/UpdateInstructionsModal.vue
+++ b/apps/desktop/src/components/UpdateInstructionsModal.vue
@@ -49,7 +49,9 @@ function handleOpenRelease() {
       <div class="modal-content" role="dialog" aria-labelledby="update-modal-title">
         <div class="modal-header">
           <h2 id="update-modal-title">Update to v{{ version }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close update instructions" @click="emit('close')">
+            <span aria-hidden="true">×</span>
+          </button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/WhatsNewModal.vue
+++ b/apps/desktop/src/components/WhatsNewModal.vue
@@ -48,7 +48,9 @@ const hasRemoteReleaseNotes = computed(() => Boolean(props.releaseNotes?.trim())
       <div class="modal-content" role="dialog" aria-labelledby="whats-new-title">
         <div class="modal-header">
           <h2 id="whats-new-title">🎉 What's New in v{{ currentVersion }}</h2>
-          <button class="modal-close" aria-label="Close" @click="emit('close')">×</button>
+          <button class="modal-close" aria-label="Close what's new" @click="emit('close')">
+            <span aria-hidden="true">×</span>
+          </button>
         </div>
 
         <div class="modal-body">

--- a/apps/desktop/src/components/conversation/SdkSteeringPanel.vue
+++ b/apps/desktop/src/components/conversation/SdkSteeringPanel.vue
@@ -47,11 +47,18 @@ provide(SdkSteeringKey, ctx);
 
     <!-- Inline error banner -->
     <div v-if="ctx.inlineError" class="cb-error-banner" @click="ctx.clearError">
-      <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
+      <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
         <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm-.75 3.75a.75.75 0 011.5 0v3.5a.75.75 0 01-1.5 0v-3.5zM8 11a1 1 0 110 2 1 1 0 010-2z"/>
       </svg>
       <span class="cb-error-text">{{ ctx.inlineError }}</span>
-      <button class="cb-error-dismiss" title="Dismiss">✕</button>
+      <button
+        class="cb-error-dismiss"
+        title="Dismiss"
+        aria-label="Dismiss error"
+        @click.stop="ctx.clearError"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
     </div>
 
     <SdkSteeringLinkPrompt v-if="!ctx.isLinked" />

--- a/apps/desktop/src/components/mcp/McpAddServerModal.vue
+++ b/apps/desktop/src/components/mcp/McpAddServerModal.vue
@@ -35,7 +35,9 @@ const {
               </div>
               <span id="add-server-title">Add MCP Server</span>
             </div>
-            <button class="modal-close" aria-label="Close" @click="emit('close')">✕</button>
+            <button class="modal-close" aria-label="Close add server dialog" @click="emit('close')">
+              <span aria-hidden="true">✕</span>
+            </button>
           </div>
         </div>
 

--- a/apps/desktop/src/components/search/SearchGroupedResults.vue
+++ b/apps/desktop/src/components/search/SearchGroupedResults.vue
@@ -44,9 +44,10 @@ defineEmits<{
           <button
             class="session-group-filter-btn"
             title="Filter search to this session"
+            aria-label="Filter search to this session"
             @click.stop="$emit('filter-by-session', group.sessionId, group.sessionSummary)"
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
               <path d="M2 4h12M4 8h8M6 12h4" />
             </svg>
           </button>
@@ -54,9 +55,10 @@ defineEmits<{
             :to="`/session/${group.sessionId}/conversation`"
             class="session-group-goto-btn"
             title="Go to session"
+            aria-label="Go to session"
             @click.stop
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="12" height="12">
               <path d="M6 3l5 5-5 5" />
             </svg>
           </router-link>
@@ -93,8 +95,9 @@ defineEmits<{
             <router-link
               :to="sessionLink(result.sessionId, result.turnNumber, result.eventIndex)"
               class="session-group-view-btn"
+              aria-label="View result details"
               @click.stop
-            >→</router-link>
+            ><span aria-hidden="true">→</span></router-link>
           </div>
           <!-- Expanded details -->
           <div v-if="expandedResults.has(result.id)" class="session-group-expanded">

--- a/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
+++ b/apps/desktop/src/components/search/SearchSyntaxHelpModal.vue
@@ -10,7 +10,13 @@ defineEmits<{ close: [] }>();
         <div class="syntax-help-modal">
           <div class="syntax-help-header">
             <h3>Search Syntax Guide</h3>
-            <button class="syntax-help-close" @click="$emit('close')">✕</button>
+            <button
+              class="syntax-help-close"
+              aria-label="Close search syntax guide"
+              @click="$emit('close')"
+            >
+              <span aria-hidden="true">✕</span>
+            </button>
           </div>
           <div class="syntax-help-body">
             <section class="syntax-section">

--- a/apps/desktop/src/components/search/SessionSearchPagination.vue
+++ b/apps/desktop/src/components/search/SessionSearchPagination.vue
@@ -19,20 +19,23 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div v-if="totalPages > 1" class="pagination">
+  <nav v-if="totalPages > 1" class="pagination" aria-label="Search results pagination">
     <button
       class="pagination-btn"
       :disabled="page <= 1"
+      aria-label="Previous page"
       @click="emit('prev')"
     >
-      ‹ Prev
+      <span aria-hidden="true">‹</span> Prev
     </button>
     <template v-for="(p, idx) in visiblePages" :key="idx">
-      <span v-if="p === null" class="pagination-ellipsis">…</span>
+      <span v-if="p === null" class="pagination-ellipsis" aria-hidden="true">…</span>
       <button
         v-else
         class="pagination-btn"
         :class="{ active: p === page }"
+        :aria-current="p === page ? 'page' : undefined"
+        :aria-label="`Page ${p}`"
         @click="emit('go', p)"
       >
         {{ p }}
@@ -41,12 +44,13 @@ const emit = defineEmits<{
     <button
       class="pagination-btn"
       :disabled="!hasMore"
+      aria-label="Next page"
       @click="emit('next')"
     >
-      Next ›
+      Next <span aria-hidden="true">›</span>
     </button>
-    <span class="pagination-info">
+    <span class="pagination-info" aria-live="polite">
       {{ pageStart }}–{{ pageEnd }} of {{ formatNumberFull(totalCount) }}
     </span>
-  </div>
+  </nav>
 </template>

--- a/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
+++ b/apps/desktop/src/components/search/SessionSearchResultsHeader.vue
@@ -37,9 +37,10 @@ const emit = defineEmits<{
       <button
         class="view-mode-btn"
         title="Clear search"
+        aria-label="Clear search"
         @click="emit('clear-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="4" y1="4" x2="12" y2="12" /><line x1="12" y1="4" x2="4" y2="12" />
         </svg>
       </button>
@@ -47,9 +48,10 @@ const emit = defineEmits<{
         v-if="hasResults"
         class="view-mode-btn"
         title="Copy all results"
+        aria-label="Copy all results"
         @click="emit('copy-all')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="5" y="5" width="9" height="9" rx="1" /><path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
         </svg>
       </button>
@@ -57,9 +59,11 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'flat' }"
         title="Flat list"
+        aria-label="Flat list"
+        :aria-pressed="resultViewMode === 'flat'"
         @click="emit('update:resultViewMode', 'flat')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <line x1="2" y1="4" x2="14" y2="4" /><line x1="2" y1="8" x2="14" y2="8" /><line x1="2" y1="12" x2="14" y2="12" />
         </svg>
       </button>
@@ -67,9 +71,11 @@ const emit = defineEmits<{
         class="view-mode-btn"
         :class="{ active: resultViewMode === 'grouped' }"
         title="Grouped by session"
+        aria-label="Grouped by session"
+        :aria-pressed="resultViewMode === 'grouped'"
         @click="emit('update:resultViewMode', 'grouped')"
       >
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
           <rect x="2" y="2" width="12" height="4" rx="1" /><rect x="2" y="10" width="12" height="4" rx="1" />
         </svg>
       </button>

--- a/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
+++ b/apps/desktop/src/components/worktree/CreateWorktreeModal.vue
@@ -119,7 +119,7 @@ watch(
         <div class="modal-dialog" role="dialog" aria-labelledby="create-wt-title">
           <div class="modal-header">
             <h2 id="create-wt-title" class="modal-title">Create Worktree</h2>
-            <button class="icon-btn" aria-label="Close" @click="close">
+            <button class="icon-btn" aria-label="Close create worktree dialog" @click="close">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>

--- a/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
+++ b/apps/desktop/src/components/worktree/WorktreeDetailPanel.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
             locked
           </span>
         </div>
-        <button class="icon-btn" aria-label="Close" @click="emit('close')">
+        <button class="icon-btn" aria-label="Close worktree panel" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>

--- a/apps/desktop/src/components/worktree/WorktreeList.vue
+++ b/apps/desktop/src/components/worktree/WorktreeList.vue
@@ -162,19 +162,21 @@ function sortIcon(field: "branch" | "status" | "createdAt" | "diskUsageBytes"): 
         <button
           class="icon-btn"
           :title="wt.isMainWorktree ? 'Cannot lock main worktree' : wt.isLocked ? 'Unlock Worktree' : 'Lock Worktree'"
+          :aria-label="wt.isMainWorktree ? `Cannot lock main worktree ${wt.branch}` : wt.isLocked ? `Unlock worktree ${wt.branch}` : `Lock worktree ${wt.branch}`"
           :disabled="wt.isMainWorktree"
           @click="wt.isLocked ? emit('unlock', wt) : emit('lock', wt)"
         >
-          <svg v-if="wt.isLocked" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 5-5 5 5 0 0 1 5 5" /></svg>
-          <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
+          <svg v-if="wt.isLocked" aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 5-5 5 5 0 0 1 5 5" /></svg>
+          <svg v-else aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg>
         </button>
         <button
           class="icon-btn icon-btn--danger"
           :title="wt.isMainWorktree ? 'Cannot remove main worktree' : wt.isLocked ? 'Unlock to remove' : 'Remove'"
+          :aria-label="wt.isMainWorktree ? `Cannot remove main worktree ${wt.branch}` : wt.isLocked ? `Unlock worktree ${wt.branch} to remove` : `Remove worktree ${wt.branch}`"
           :disabled="wt.isMainWorktree || wt.isLocked"
           @click="emit('delete', wt)"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+          <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
         </button>
       </div>
     </div>

--- a/apps/desktop/src/components/worktree/__tests__/WorktreeChildren.test.ts
+++ b/apps/desktop/src/components/worktree/__tests__/WorktreeChildren.test.ts
@@ -133,6 +133,21 @@ describe("WorktreeList", () => {
     });
     expect(wrapper.text()).toContain("No worktrees found");
   });
+
+  it("names lock and remove actions for their worktree", () => {
+    const wrapper = mount(WorktreeList, {
+      props: {
+        filteredWorktrees: [makeWt()],
+        selectedWorktreePath: null,
+        searchQuery: "",
+      },
+    });
+
+    const lock = wrapper.get('[aria-label="Lock worktree feature/a"]');
+    const remove = wrapper.get('[aria-label="Remove worktree feature/a"]');
+    expect(lock.get("svg").attributes("aria-hidden")).toBe("true");
+    expect(remove.get("svg").attributes("aria-hidden")).toBe("true");
+  });
 });
 
 describe("WorktreeDetailPanel", () => {

--- a/apps/desktop/src/views/skills/SkillsManagerView.vue
+++ b/apps/desktop/src/views/skills/SkillsManagerView.vue
@@ -224,7 +224,13 @@ async function handleDeleteSkill(dir: string) {
         <div class="modal">
           <div class="modal__header">
             <h3 class="modal__title">New Skill</h3>
-            <button class="modal__close" @click="showNewSkillModal = false">✕</button>
+            <button
+              class="modal__close"
+              aria-label="Close new skill dialog"
+              @click="showNewSkillModal = false"
+            >
+              <span aria-hidden="true">✕</span>
+            </button>
           </div>
           <div class="modal__body">
             <label class="modal__label">Name</label>

--- a/crates/tracepilot-export/src/import/validator/safety.rs
+++ b/crates/tracepilot-export/src/import/validator/safety.rs
@@ -8,6 +8,19 @@ use super::validation_err;
 pub(crate) fn contains_path_traversal(s: &str) -> bool {
     let path = Path::new(s);
 
+    // Session IDs and checkpoint names are used as a single path component.
+    // Treat either platform's separator as unsafe regardless of the host OS.
+    if s.contains('/') || s.contains('\\') {
+        return true;
+    }
+
+    // `Path` only recognizes drive prefixes on Windows, so detect them
+    // lexically as well for archives validated on Unix hosts.
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return true;
+    }
+
     // Reject absolute paths (covers `/`, `\`, `C:\`, `\\server`, etc.)
     if path.is_absolute() {
         return true;
@@ -21,8 +34,7 @@ pub(crate) fn contains_path_traversal(s: &str) -> bool {
         }
     }
 
-    // Belt-and-suspenders: also catch `://` and bare `..` in the string
-    s.contains("..") || s.contains(":/")
+    false
 }
 
 /// Check if a string looks like a standard UUID (8-4-4-4-12 hex pattern).

--- a/crates/tracepilot-export/src/import/validator/tests.rs
+++ b/crates/tracepilot-export/src/import/validator/tests.rs
@@ -33,6 +33,23 @@ fn rejects_path_traversal_in_id() {
 }
 
 #[test]
+fn path_checks_are_cross_platform_without_rejecting_double_dot_names() {
+    for unsafe_path in [
+        r"..\\escape",
+        r"folder\\..\\escape",
+        r"C:escape",
+        r"C:\\escape",
+    ] {
+        assert!(
+            contains_path_traversal(unsafe_path),
+            "accepted {unsafe_path:?}"
+        );
+    }
+    assert!(!contains_path_traversal("session..backup"));
+    assert!(!contains_path_traversal("..session"));
+}
+
+#[test]
 fn rejects_absolute_unix_path_in_id() {
     let mut session = minimal_session();
     session.metadata.id = "/etc/evil".to_string();

--- a/crates/tracepilot-indexer/src/index_db/session_writer/prune.rs
+++ b/crates/tracepilot-indexer/src/index_db/session_writer/prune.rs
@@ -21,18 +21,15 @@ impl IndexDb {
 
         self.conn.execute_batch("SAVEPOINT prune_deleted")?;
         let result = (|| -> Result<()> {
-            // Use json_each() to pass all live IDs as a single JSON array parameter,
-            // avoiding the N individual INSERT statements into a temp table.
-            let live_json = serde_json::to_string(&live_ids.iter().collect::<Vec<_>>())
+            // Target only the IDs already known to be stale. In the common case
+            // this keeps the JSON payload and DELETE work proportional to the
+            // number of removed sessions rather than the full live corpus.
+            let stale_json = serde_json::to_string(&stale)
                 .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
 
             self.conn.execute(
-                "DELETE FROM sessions WHERE id NOT IN (SELECT value FROM json_each(?1))",
-                [&live_json],
-            )?;
-            self.conn.execute(
-                "DELETE FROM search_content WHERE session_id NOT IN (SELECT value FROM json_each(?1))",
-                [&live_json],
+                "DELETE FROM sessions WHERE id IN (SELECT value FROM json_each(?1))",
+                [&stale_json],
             )?;
             Ok(())
         })();

--- a/crates/tracepilot-orchestrator/src/launcher/models.rs
+++ b/crates/tracepilot-orchestrator/src/launcher/models.rs
@@ -13,6 +13,22 @@ pub(super) fn validate_model(model: &str) -> Result<()> {
     }
 }
 
+/// Validate the CLI's supported reasoning-effort values before they are
+/// interpolated into a platform-specific command line.
+pub(super) fn validate_reasoning_effort(effort: &str) -> Result<()> {
+    if !effort.is_empty()
+        && effort
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        Ok(())
+    } else {
+        Err(OrchestratorError::Launch(format!(
+            "Invalid reasoning effort: {effort}"
+        )))
+    }
+}
+
 /// List available models.
 ///
 /// Backed by the shared JSON registry at
@@ -45,5 +61,15 @@ mod tests {
         assert!(validate_model("unknown-model").is_err());
         assert!(validate_model("'; rm -rf /").is_err());
         assert!(validate_model("& calc &").is_err());
+    }
+
+    #[test]
+    fn test_validate_reasoning_effort_accepts_safe_current_and_future_values() {
+        for effort in ["low", "medium", "high", "xhigh", "max", "extra-high"] {
+            assert!(validate_reasoning_effort(effort).is_ok());
+        }
+        assert!(validate_reasoning_effort("").is_err());
+        assert!(validate_reasoning_effort("very high").is_err());
+        assert!(validate_reasoning_effort("high; touch /tmp/injected").is_err());
     }
 }

--- a/crates/tracepilot-orchestrator/src/launcher/terminal/mod.rs
+++ b/crates/tracepilot-orchestrator/src/launcher/terminal/mod.rs
@@ -7,7 +7,7 @@ use crate::error::{OrchestratorError, Result};
 use crate::types::{CreateWorktreeRequest, LaunchConfig, LaunchMode, LaunchedSession};
 use crate::worktrees;
 
-use super::models::validate_model;
+use super::models::{validate_model, validate_reasoning_effort};
 use super::paths::canonicalize_user_path;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -98,6 +98,7 @@ pub fn launch_session(config: &LaunchConfig) -> Result<LaunchedSession> {
     }
 
     if let Some(effort) = &config.reasoning_effort {
+        validate_reasoning_effort(effort)?;
         args.push("--reasoning-effort".to_string());
         args.push(effort.clone());
     }

--- a/crates/tracepilot-orchestrator/src/launcher/terminal/unix.rs
+++ b/crates/tracepilot-orchestrator/src/launcher/terminal/unix.rs
@@ -22,8 +22,8 @@ pub(super) fn spawn(plan: &SessionPlan<'_>) -> Result<u32> {
             .branch
             .as_deref()
             .map(|b| {
-                let escaped = b.replace('\'', "''");
-                format!("git checkout '{escaped}' && ")
+                let escaped = crate::process::shell_quote(b);
+                format!("git checkout {escaped} && ")
             })
             .unwrap_or_default()
     } else {
@@ -45,5 +45,5 @@ pub(super) fn spawn(plan: &SessionPlan<'_>) -> Result<u32> {
     let full_cmd = format!("{checkout_prefix}{copilot_cmd}{interactive_suffix}");
     let envs = &config.env_vars;
     let envs_ref = if envs.is_empty() { None } else { Some(envs) };
-    crate::process::spawn_detached_terminal(&full_cmd, &[], work_dir, envs_ref)
+    crate::process::spawn_detached_terminal("sh", &["-c", &full_cmd], work_dir, envs_ref)
 }

--- a/crates/tracepilot-orchestrator/src/skills/import/github.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/github.rs
@@ -151,6 +151,20 @@ pub(crate) fn import_from_github_path(
                     let asset_paths: Vec<String> = collect_skill_blob_paths(&entries, base_path)
                         .into_iter()
                         .filter(|path| path != &skill_md_path)
+                        .filter(|repo_path| {
+                            let relative = if prefix.is_empty() {
+                                repo_path.as_str()
+                            } else {
+                                &repo_path[prefix.len()..]
+                            };
+                            if is_safe_github_relative_path(relative) {
+                                true
+                            } else {
+                                warnings
+                                    .push(format!("Skipped '{}': unsafe path component", relative));
+                                false
+                            }
+                        })
                         .collect();
                     let path_refs: Vec<&str> = asset_paths.iter().map(String::as_str).collect();
                     let contents = crate::github::gh_get_files_batch_with_binary(
@@ -166,16 +180,6 @@ pub(crate) fn import_from_github_path(
                         } else {
                             &repo_path[prefix.len()..]
                         };
-                        // Guard against path traversal from crafted tree entries.
-                        // Use component analysis to correctly detect ParentDir
-                        // segments without false positives on names like "..foo".
-                        let has_traversal = Path::new(relative)
-                            .components()
-                            .any(|c| matches!(c, std::path::Component::ParentDir));
-                        if has_traversal || Path::new(relative).is_absolute() {
-                            warnings.push(format!("Skipped '{}': unsafe path component", relative));
-                            continue;
-                        }
                         match contents.get(&repo_path).and_then(|file| {
                             file.bytes
                                 .as_ref()
@@ -219,6 +223,27 @@ fn skill_path_prefix(base_path: &str) -> String {
     } else {
         format!("{}/", base_path.trim_end_matches('/'))
     }
+}
+
+/// GitHub tree paths use `/` regardless of the host OS. Reject path forms that
+/// could be reinterpreted when the imported skill is written on another host.
+pub(super) fn is_safe_github_relative_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let has_windows_drive_prefix =
+        bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && !has_windows_drive_prefix
+        && !Path::new(path).components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
 }
 
 pub(super) fn collect_skill_blob_paths(entries: &[TreeEntry], base_path: &str) -> Vec<String> {
@@ -280,10 +305,13 @@ fn preview_github_import_path(
             if repo_path == skill_md_path {
                 continue;
             }
-            if prefix.is_empty() {
-                files.push(repo_path);
+            let relative = if prefix.is_empty() {
+                repo_path.as_str()
             } else {
-                files.push(repo_path[prefix.len()..].to_string());
+                &repo_path[prefix.len()..]
+            };
+            if is_safe_github_relative_path(relative) {
+                files.push(relative.to_string());
             }
         }
     }
@@ -351,7 +379,18 @@ pub fn discover_github_skills(
         if let Some(content) = contents.get(*skill_md_path) {
             match parse_skill_md(content) {
                 Ok((fm, _)) => {
-                    let file_count = collect_skill_blob_paths(&entries, &skill_dir).len();
+                    let prefix = skill_path_prefix(&skill_dir);
+                    let file_count = collect_skill_blob_paths(&entries, &skill_dir)
+                        .iter()
+                        .filter(|repo_path| {
+                            let relative = if prefix.is_empty() {
+                                repo_path.as_str()
+                            } else {
+                                &repo_path[prefix.len()..]
+                            };
+                            is_safe_github_relative_path(relative)
+                        })
+                        .count();
 
                     previews.push(GitHubSkillPreview {
                         path: skill_dir,

--- a/crates/tracepilot-orchestrator/src/skills/import/tests.rs
+++ b/crates/tracepilot-orchestrator/src/skills/import/tests.rs
@@ -2,7 +2,7 @@
 
 use super::atomic::atomic_dir_install;
 use super::file::import_from_file;
-use super::github::collect_skill_blob_paths;
+use super::github::{collect_skill_blob_paths, is_safe_github_relative_path};
 use super::local::{
     copy_dir_contents, count_files_recursive, discover_repo_skills, import_from_local,
     skill_preview_from_dir,
@@ -168,6 +168,31 @@ fn collect_skill_blob_paths_for_root_skill_includes_nested_files() {
             "scripts/setup.sh".to_string(),
         ]
     );
+}
+
+#[test]
+fn github_import_paths_reject_cross_platform_traversal() {
+    for path in [
+        "../escape.txt",
+        "nested/../../escape.txt",
+        "/absolute.txt",
+        r"C:\\absolute.txt",
+        r"nested\\..\\escape.txt",
+        r"\\server\\share.txt",
+    ] {
+        assert!(!is_safe_github_relative_path(path), "accepted {path:?}");
+    }
+}
+
+#[test]
+fn github_import_paths_allow_safe_nested_and_double_dot_names() {
+    for path in [
+        "references/guide.md",
+        "scripts/setup.sh",
+        "references/..guide.md",
+    ] {
+        assert!(is_safe_github_relative_path(path), "rejected {path:?}");
+    }
 }
 
 #[test]

--- a/packages/ui/src/__tests__/ModalDialog.test.ts
+++ b/packages/ui/src/__tests__/ModalDialog.test.ts
@@ -49,7 +49,7 @@ describe("ModalDialog", () => {
       props: { visible: true, title: "Test" },
       global: { stubs: { Teleport: true } },
     });
-    await wrapper.find("button[aria-label='Close']").trigger("click");
+    await wrapper.find("button[aria-label='Close Test']").trigger("click");
     expect(wrapper.emitted("update:visible")).toBeTruthy();
     expect(wrapper.emitted("update:visible")?.[0]).toEqual([false]);
   });

--- a/packages/ui/src/__tests__/SearchableSelect.test.ts
+++ b/packages/ui/src/__tests__/SearchableSelect.test.ts
@@ -74,6 +74,16 @@ describe("SearchableSelect", () => {
     expect(emitted[0]).toEqual([""]);
   });
 
+  it("exposes and activates a named clear button", async () => {
+    wrapper = mountComponent({ clearable: true });
+    const clearButton = wrapper.get('button[aria-label="Clear selection"]');
+    expect(clearButton.get("svg").attributes("aria-hidden")).toBe("true");
+
+    await clearButton.trigger("mousedown");
+
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([""]);
+  });
+
   it("does not emit empty string if clearable is false", async () => {
     wrapper = mountComponent({ clearable: false, allowCustom: false });
     const input = wrapper.find("input");

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -104,7 +104,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             <button
               type="button"
               class="drawer-close"
-              aria-label="Close"
+              :aria-label="title ? `Close ${title}` : 'Close drawer'"
               @click="close"
             >
               <X :size="14" :stroke-width="1.5" aria-hidden="true" />

--- a/packages/ui/src/components/ModalDialog.vue
+++ b/packages/ui/src/components/ModalDialog.vue
@@ -56,7 +56,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
             class="btn btn-ghost btn-sm modal-close"
             type="button"
             @click="close"
-            aria-label="Close"
+            :aria-label="title ? `Close ${title}` : 'Close dialog'"
           >
             <X :size="14" :stroke-width="1.5" aria-hidden="true" />
           </button>

--- a/packages/ui/src/components/SearchableSelect.vue
+++ b/packages/ui/src/components/SearchableSelect.vue
@@ -203,11 +203,12 @@ watch(filteredOptions, () => {
           v-if="clearable && searchQuery"
           class="clear-btn"
           title="Clear selection"
+          aria-label="Clear selection"
           @mousedown.prevent="clear"
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
         </button>
-        <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
+        <svg aria-hidden="true" class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" @mousedown.prevent="isOpen ? close() : openDropdown()">
           <path d="M6 9l6 6 6-6" />
         </svg>
       </span>


### PR DESCRIPTION
## Summary

Reviewed all 94 open AI-generated PRs whose titles include Palette (39), Bolt (42), or Sentinel (13), against current `main` rather than relying on their descriptions. No source PR is safe to merge wholesale; this branch ports only the useful parts to the current layout and excludes all `.jules`, journal, plan, `.orig`, scratch binary/script, and unrelated formatter artifacts.

### Changes included

- Improve accessible names/state for search pagination, results controls, grouped-result actions, searchable select clearing, worktree actions, and contextual close/dismiss controls.
- Make stale-session pruning target the already-computed stale IDs instead of comparing against the entire live corpus.
- Harden imported GitHub tree paths and archive identifiers across host path syntaxes while allowing safe embedded double dots such as `session..backup`.
- Restore macOS/Linux terminal launch by executing the assembled command through `sh -c`, correctly quote branch names, and validate reasoning-effort values as forward-compatible safe tokens.

## Review findings

### Palette

- Adopted useful portions: #589, #591, #600, #614, #615, #636, #650, #681, #692.
- Superseded/stale: #583, #585, #619, #621, #638, #641, #643, #645, #661, #665, #666, #669, #671, #682, #683, #688, #695, #699, #701, #704, #705, #708, #711, #712, #714, #717, #720.
- Rejected: #663, #677, #687.
- #589's recent-search removal markup was deliberately not copied because it preserves invalid nested interactive controls.

### Bolt

- Adopted useful portion: #586, adapted to stale-ID JSON plus `json_each` rather than its temp-table/row-insert implementation.
- Superseded/negligible: #590, #599, #601, #616, #618, #620, #628, #629, #634, #637, #642, #646, #647, #672, #678, #684, #685, #690, #691, #693, #694, #698, #700, #702, #707, #713, #719.
- Rejected: #584, #592, #595, #613, #644, #649, #667, #668, #670, #679, #706, #710, #715, #718.
- The other PRs repeat already-landed placeholder preallocation, regress zero-count behavior, lack end-to-end evidence, or contain scratch/generated noise.

### Sentinel

- Adopted useful portions: #630, #689, #716.
- Superseded: #622, #635, #662, #680, #696, #703, #709.
- Rejected: #648, #673, #686.
- The GitHub path claim is low-severity defense-in-depth, not critical: Unix treats backslashes as literal filenames while Windows native parsing already recognizes them. The current Unix launcher regression is the more consequential finding.

## Risk and usability checks

- **UI accessibility — low risk:** screen-reader-test search controls and pagination; confirm current/pressed states, a single page-range announcement, keyboard activation, Escape behavior, and focus restoration. Test two worktrees so lock/remove names identify the correct branch.
- **Stale pruning — medium risk:** an inverted predicate could remove too much rebuildable index data. Index several sessions, delete one source directory, reindex, and confirm only that session disappears from lists/search/analytics; compare with a full rebuild.
- **Import validation — low/medium compatibility risk:** literal-backslash Git filenames and legacy IDs containing separators are now rejected. Preview/import a normal nested skill on Windows and Unix, confirm matching counts, and verify crafted root/drive/parent paths warn or fail.
- **Unix launch — medium platform risk:** smoke macOS and Linux terminals with/without branch, prompt, env vars, multi-word CLI command, apostrophes, and prompt newlines. Windows should also be smoked because reasoning-effort token validation is shared.

## Validation

- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm lint`
- Targeted desktop UI tests: 17 passed
- Targeted shared UI tests: 14 passed
- Focused export/import/launcher/prune Rust tests passed

The exact bulk-close operation for the 94 reviewed PRs is prepared separately and has **not** been run.
